### PR TITLE
Fixing demos

### DIFF
--- a/demos/github-demo/.babelrc.js
+++ b/demos/github-demo/.babelrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   presets: ["next/babel"],
-  plugins: ["../../libs/isograph-babel/BabelPluginIsograph"],
+  plugins: ["../../libs/isograph-babel-plugin/BabelPluginIsograph"],
 };

--- a/demos/graphql-conf-2023-demo/.babelrc.js
+++ b/demos/graphql-conf-2023-demo/.babelrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   presets: ["next/babel"],
-  plugins: ["../../libs/isograph-babel/BabelPluginIsograph"],
+  plugins: ["../../libs/isograph-babel-plugin/BabelPluginIsograph"],
 };


### PR DESCRIPTION
Without this fix, running the demo blows up with the following stacktrace:

```
- wait compiling /_error (client and server)...
- error ./pages/_app.tsx
Error: Cannot find module '../../libs/isograph-babel/BabelPluginIsograph'
Require stack:
```