### PR TITLE
fixed "path too long" error on windows ci workflow target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,11 @@ jobs:
             os: macos-latest
             build-name: isograph_cli
             artifact-name: isograph_cli-macos-arm64
-          # - target: x86_64-pc-windows-msvc
-          #   os: windows-latest
-          #   build-name: isograph_cli.exe
-          #   artifact-name: isograph_cli-bin-win-x64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            longpaths: true
+            build-name: isograph_cli.exe
+            artifact-name: isograph_cli-bin-win-x64
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v2
@@ -44,6 +45,10 @@ jobs:
           toolchain: 1.75.0
           override: true
           target: ${{ matrix.target.target }}
+      # more info here:- https://github.com/rust-lang/cargo/issues/13020
+      - name: Enable longer pathnames for git
+        if: matrix.target.longpaths
+        run: git config --system core.longpaths true
       - name: Install cross
         if: matrix.target.cross
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Resolves issue #10

Checked the [relay's ci workflow config](https://github.com/facebook/relay/blob/main/.github/workflows/ci.yml), didn't find a similar solution, they're probably using some other way to implement the same fix.

Cargo internally uses [libgit2](https://github.com/libgit2/libgit2) for git related workflows, and the library has [open issues](https://github.com/libgit2/libgit2/issues?q=longpaths+) regarding this that haven't been fixed yet. 

More info can be found here:- https://github.com/rust-lang/cargo/issues/13020

**TL;DR**:- Windows sucks, but made it work. 