### PR TITLE
Reroute documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The framework for teams that move fast — without breaking things.
 
-- Read the [docs](https://isograph.dev/docs/), especially the [quickstart guide](https://isograph.dev/docs/quickstart/).
+- Read the [docs](https://isograph.dev/docs/introduction), especially the [quickstart guide](https://isograph.dev/docs/quickstart/).
 - Watch the [talk at GraphQL Conf](https://www.youtube.com/watch?v=gO65JJRqjuc).
 - Join the [Discord](https://discord.gg/kDCcN3EDR6).
 - [Follow the official Twitter account](https://twitter.com/isographlabs).


### PR DESCRIPTION
Was reading the readme and noticed the `docs` link directed me to a `Page Not Found` link.

Currently:
<img width="1720" alt="Screen Shot 2024-02-20 at 11 35 43 PM" src="https://github.com/isographlabs/isograph/assets/38759997/794d86a4-dfce-4dc8-981d-b2120e40114f">

This PR changes it to go [here](https://isograph.dev/docs/introduction/)

![work](https://github.com/isographlabs/isograph/assets/38759997/bb2e8e0c-11db-48e1-a620-5dcfadac35f1)

