### PR TITLE
Specify pnpm version in `package.json`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
@@ -114,9 +112,9 @@ jobs:
       - name: Build JS files
         run: pnpm -r compile
       - name: Typecheck
-        run: cd ./demos/${{ matrix.target.folder }} && yarn tsc
+        run: cd ./demos/${{ matrix.target.folder }} && pnpm tsc
       - name: Lint
-        run: cd ./demos/${{ matrix.target.folder }} && yarn lint
+        run: cd ./demos/${{ matrix.target.folder }} && pnpm lint
 
   build-js-packages:
     name: Build js packages
@@ -124,8 +122,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
@@ -152,8 +148,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
@@ -162,7 +156,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build website
-        run: yarn build
+        run: pnpm build
       - name: Upload artifact
         id: upload-artifact
         uses: actions/upload-artifact@v4
@@ -180,8 +174,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
@@ -240,8 +232,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
@@ -276,8 +266,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - uses: actions/setup-node@v2
         with:
           node-version: 18
@@ -286,7 +274,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Change package versions to commit
-        run: yarn gulp setMainVersion
+        run: pnpm gulp setMainVersion
         env:
           RELEASE_COMMIT_SHA: ${{ github.sha }}
       # TODO reuse this somehow?
@@ -337,8 +325,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - uses: actions/setup-node@v2
         with:
           node-version: 18
@@ -347,7 +333,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       # - name: Change package versions to commit
-      #   run: yarn gulp setMainVersion
+      #   run: pnpm gulp setMainVersion
       #   # TODO do this less hackily
       - name: Build
         run: pnpm -r compile

--- a/libs/isograph-disposable-types/package.json
+++ b/libs/isograph-disposable-types/package.json
@@ -13,7 +13,7 @@
     "test": "echo this package has no tests",
     "test-watch": "echo this package has no tests",
     "coverage": "echo this package has no coverage",
-    "prepack": "yarn run compile",
+    "prepack": "pnpm run compile",
     "tsc": "tsc"
   },
   "dependencies": {},

--- a/libs/isograph-react-disposable-state/package.json
+++ b/libs/isograph-react-disposable-state/package.json
@@ -14,7 +14,7 @@
     "test-watch": "vitest watch",
     "coverage": "vitest run --coverage",
     "note": "WE SHOULD ALSO TEST HERE",
-    "prepack": "yarn run compile",
+    "prepack": "pnpm run compile",
     "tsc": "tsc"
   },
   "dependencies": {

--- a/libs/isograph-react/package.json
+++ b/libs/isograph-react/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "test-watch": "vitest watch",
     "coverage": "vitest run --coverage",
-    "prepack": "yarn run test && yarn run compile",
+    "prepack": "pnpm run test && pnpm run compile",
     "tsc": "tsc"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "watch-pet-demo": "./target/debug/isograph_cli --config ./demos/pet-demo/isograph.config.json --watch",
     "watch-github-demo": "./target/debug/isograph_cli --config ./demos/github-demo/isograph.config.json --watch",
     "watch-isograph-react-demo": "./target/debug/isograph_cli --config ./libs/isograph-react/src/tests/isograph.config.json --watch",
-    "build-demos": "yarn run build-github-demo && yarn run build-pet-demo && yarn run build-isograph-react-demo",
+    "build-demos": "pnpm run build-github-demo && pnpm run build-pet-demo && pnpm run build-isograph-react-demo",
     "build-github-demo": "./target/debug/isograph_cli --config ./demos/github-demo/isograph.config.json",
     "build-pet-demo": "./target/debug/isograph_cli --config ./demos/pet-demo/isograph.config.json",
     "build-isograph-react-demo": "./target/debug/isograph_cli --config ./libs/isograph-react/isograph.config.json",
     "watch-libs": "cargo watch -s 'pnpm -r compile' -d 0.1 -w ./libs",
-    "format": "yarn run format-prettier && yarn run format-rust",
+    "format": "pnpm run format-prettier && pnpm run format-rust",
     "format-prettier": "prettier --config ./.prettier.config.js --write .",
     "format-rust": "cargo fmt",
     "tsc": "pnpm -r tsc"
@@ -29,5 +29,6 @@
   },
   "dependencies": {
     "react-twitter-embed": "^4.0.4"
-  }
+  },
+  "packageManager": "pnpm@8.15.3"
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -65,11 +65,11 @@
     "prettier-check": "prettier -c .",
     "prettier-write": "prettier --write .",
     "lint": "eslint --max-warnings 0 .",
-    "vscode:prepublish": "rm -f tsconfig.tsbuildinfo && rm -rf out && yarn run esbuild-base -- --minify",
+    "vscode:prepublish": "rm -f tsconfig.tsbuildinfo && rm -rf out && pnpm run esbuild-base -- --minify",
     "build-local": "vsce package",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
-    "esbuild": "yarn run esbuild-base --sourcemap",
-    "esbuild-watch": "yarn run esbuild-base --sourcemap --watch"
+    "esbuild": "pnpm run esbuild-base --sourcemap",
+    "esbuild-watch": "pnpm run esbuild-base --sourcemap --watch"
   },
   "engines": {
     "vscode": "^1.60.0"


### PR DESCRIPTION
> Re: `pnpm@8`. Presumably, that doesn't prevent someone who installs `@isograph/compiler` in their project from running `yarn run iso`, right? It's just for commands that are run when developing? If so, then by all means, that sounds great! Thank you!!

Yes, it doesn't prevent anyone from using different package manager in their project