### PR TITLE
chore(cli): structop to clap migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,15 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,21 +137,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
@@ -172,10 +148,10 @@ dependencies = [
  "indexmap 1.9.3",
  "once_cell",
  "regex",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "terminal_size",
- "textwrap 0.16.1",
+ "textwrap",
  "unicase",
 ]
 
@@ -185,7 +161,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -381,7 +357,7 @@ dependencies = [
 name = "fixture-tests"
 version = "0.0.0"
 dependencies = [
- "clap 3.2.25",
+ "clap",
  "colored",
  "diff",
  "lazy_static",
@@ -516,15 +492,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -642,6 +609,7 @@ dependencies = [
 name = "isograph_cli"
 version = "0.0.4"
 dependencies = [
+ "clap",
  "colored",
  "isograph_compiler",
  "isograph_config",
@@ -651,7 +619,6 @@ dependencies = [
  "notify-debouncer-full",
  "pretty-duration",
  "regex",
- "structopt",
  "thiserror",
  "tokio",
 ]
@@ -1317,39 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum"
@@ -1366,7 +1303,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1507,15 +1444,6 @@ dependencies = [
  "lazy_static",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1683,12 +1611,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,12 +1663,6 @@ dependencies = [
  "sval_ref",
  "sval_serde",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,16 +192,38 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
  "regex",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "terminal_size",
  "textwrap",
  "unicase",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.5.18",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.7.2",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -161,11 +232,23 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -176,6 +259,18 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
@@ -357,7 +452,7 @@ dependencies = [
 name = "fixture-tests"
 version = "0.0.0"
 dependencies = [
- "clap",
+ "clap 3.2.25",
  "colored",
  "diff",
  "lazy_static",
@@ -497,6 +592,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,10 +707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "isograph_cli"
 version = "0.0.4"
 dependencies = [
- "clap",
+ "clap 4.5.18",
  "colored",
  "isograph_compiler",
  "isograph_config",
@@ -1289,6 +1396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,7 +1416,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1627,6 +1740,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "value-bag"

--- a/crates/isograph_cli/Cargo.toml
+++ b/crates/isograph_cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-structopt = "0.3.26"
+clap = { version = "3", features = ["derive"] }
 thiserror = "1.0.40"
 isograph_compiler = { path = "../isograph_compiler" }
 isograph_config = { path = "../isograph_config" }

--- a/crates/isograph_cli/Cargo.toml
+++ b/crates/isograph_cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4.5.18", features = ["derive"] }
 thiserror = "1.0.40"
 isograph_compiler = { path = "../isograph_compiler" }
 isograph_config = { path = "../isograph_config" }

--- a/crates/isograph_cli/src/main.rs
+++ b/crates/isograph_cli/src/main.rs
@@ -1,21 +1,21 @@
 mod opt;
 
+use clap::Parser;
 use colored::Colorize;
 use isograph_compiler::{compile_and_print, handle_watch_command};
 use isograph_config::create_config;
 use isograph_lsp::lsp_process_error::LSPProcessError;
-use opt::{Command, CompileCommand, LspCommand, Opt};
-use clap::StructOpt;
+use opt::{Commands, CompileCommand, LspCommand, Opt};
 
 #[tokio::main]
 async fn main() {
-    let opt = Opt::from_args();
-    let command = opt.command.unwrap_or(Command::Compile(opt.compile));
+    let opt = Opt::parse();
+    let command = opt.command.unwrap_or(Commands::Compile(opt.compile));
     match command {
-        Command::Compile(compile_command) => {
+        Commands::Compile(compile_command) => {
             start_compiler(compile_command).await;
         }
-        Command::Lsp(lsp_command) => {
+        Commands::Lsp(lsp_command) => {
             start_language_server(lsp_command).await.unwrap();
         }
     }

--- a/crates/isograph_cli/src/main.rs
+++ b/crates/isograph_cli/src/main.rs
@@ -5,7 +5,7 @@ use isograph_compiler::{compile_and_print, handle_watch_command};
 use isograph_config::create_config;
 use isograph_lsp::lsp_process_error::LSPProcessError;
 use opt::{Command, CompileCommand, LspCommand, Opt};
-use structopt::StructOpt;
+use clap::StructOpt;
 
 #[tokio::main]
 async fn main() {

--- a/crates/isograph_cli/src/opt.rs
+++ b/crates/isograph_cli/src/opt.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
-use structopt::StructOpt;
+use clap::StructOpt;
+
 #[derive(Debug, StructOpt)]
 pub struct Opt {
     #[structopt(subcommand)]

--- a/crates/isograph_cli/src/opt.rs
+++ b/crates/isograph_cli/src/opt.rs
@@ -1,37 +1,38 @@
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
-use clap::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Opt {
-    #[structopt(subcommand)]
-    pub command: Option<Command>,
+    #[command(subcommand)]
+    pub command: Option<Commands>,
 
-    #[structopt(flatten)]
+    #[command(flatten)]
     pub compile: CompileCommand,
 }
 
-#[derive(Debug, StructOpt)]
-pub enum Command {
+#[derive(Debug, Subcommand)]
+pub enum Commands {
     Compile(CompileCommand),
     Lsp(LspCommand),
 }
+
 /// Compile
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub(crate) struct CompileCommand {
-    #[structopt(long)]
+    #[arg(long)]
     pub watch: bool,
 
     /// Compile using this config file. If not provided, searches for a config in
     /// package.json under the `isograph` key.
-    #[structopt(long)]
+    #[arg(long)]
     pub config: Option<PathBuf>,
 }
 
 /// LSP
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub(crate) struct LspCommand {
     /// Compile using this config file. If not provided, searches for a config in
     /// package.json under the `isograph` key.
-    #[structopt(long)]
+    #[arg(long)]
     pub config: Option<PathBuf>,
 }


### PR DESCRIPTION
# `structopt` to `clap` Migration

**Warning: I can't run Isograph locally because I'm on Linux and there are some issues getting that working, so this could use testing to make sure the commands actually still works!**

But the help command outputs very similar stuff, and it compiles, which is a very good sign when working with Rust 😁 

## What
- Migrates CLI from the `stuctopt` crate (which is deprecated) to `clap` in preparation for work in #68
- Renames the `Command` enum to `Commands` to align with `clap` conventions

## How
- Followed migration guides:
  - For `structopt` to `clap` v3: https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#migrate-structopt
  - For `clap` v3 to v4: https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#migrating

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/623c24b1-62e8-430f-840a-ddaf0c89b8ca)

### After
![image](https://github.com/user-attachments/assets/abe75a78-fb42-4338-aad9-54e0349b4a13)

