### PR TITLE
rewrite `areEqualObjectsWithDeepComparison` using the `ReaderAst`

### DIFF
--- a/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
+++ b/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
@@ -20,34 +20,26 @@ export function areEqualWithDeepComparison(
     return areEqualArraysWithDeepComparison(field, oldItem, newItem);
   }
 
-  if (typeof newItem === 'object') {
-    if (typeof oldItem !== 'object') {
-      return false;
-    }
-
-    if (oldItem === null) {
-      return false;
-    }
-
-    switch (field.kind) {
-      case 'Scalar':
-        break;
-      case 'Linked':
-        return areEqualObjectsWithDeepComparison(
-          field.selections,
-          oldItem,
-          newItem,
-        );
-      default: {
-        // Ensure we have covered all variants
-        let _: never = field;
-        _;
-        throw new Error('Unexpected case.');
+  switch (field.kind) {
+    case 'Scalar':
+      return newItem === oldItem;
+    case 'Linked':
+      if (oldItem == null) {
+        return false;
       }
+
+      return areEqualObjectsWithDeepComparison(
+        field.selections,
+        oldItem,
+        newItem,
+      );
+    default: {
+      // Ensure we have covered all variants
+      let _: never = field;
+      _;
+      throw new Error('Unexpected case.');
     }
   }
-
-  return newItem === oldItem;
 }
 
 export function areEqualArraysWithDeepComparison(

--- a/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
+++ b/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
@@ -73,13 +73,6 @@ export function areEqualObjectsWithDeepComparison(
   oldItemObject: object,
   newItemObject: object,
 ): boolean {
-  const oldKeys = Object.keys(oldItemObject);
-  const newKeys = Object.keys(newItemObject);
-
-  if (oldKeys.length !== newKeys.length) {
-    return false;
-  }
-
   for (const field of ast) {
     switch (field.kind) {
       case 'Scalar':

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -264,6 +264,7 @@ function callSubscriptions(
 
             if (
               !areEqualObjectsWithDeepComparison(
+                subscription.readerAst,
                 subscription.encounteredDataAndRecords.item,
                 newEncounteredDataAndRecords.item,
               )


### PR DESCRIPTION
This breaks `useSkipLimitPagination`. It should rerender after [`mostRecentFragmentReference.networkRequest`](https://github.com/isographlabs/isograph/blob/752db91444399d6a823a78d23deaada323a5694f/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts#L176C32-L176C47) resolves, what's the best way to do that? My guess is, I could use `.then()`, or `subscribe`.

Part 2 of #92 