### PR TITLE
#116: add parameters field to resolver

### DIFF
--- a/crates/graphql_artifact_generation/src/eager_reader_artifact.rs
+++ b/crates/graphql_artifact_generation/src/eager_reader_artifact.rs
@@ -120,10 +120,12 @@ pub(crate) fn generate_eager_reader_param_type_artifact(
         client_field.selection_set_for_parent_query(),
         parent_type,
         &mut param_type_imports,
-        0,
+        1,
         &mut loadable_field_encountered,
     );
 
+    // TODO import generated variable types
+    let variables_import_statement = "import { type Variables } from '@isograph/react';\n";
     let param_type_import_statement = param_type_imports_to_import_statement(&param_type_imports);
     let reader_param_type = format!("{}__{}__param", parent_type.name, client_field.name);
 
@@ -133,10 +135,15 @@ pub(crate) fn generate_eager_reader_param_type_artifact(
         ""
     };
 
+    let indent = "  ";
     let param_type_content = format!(
         "{param_type_import_statement}\n\
         {loadable_field_import}\
-        export type {reader_param_type} = {client_field_parameter_type};\n",
+        {variables_import_statement}\n\
+        export type {reader_param_type} = {{\n\
+        {indent}data: {client_field_parameter_type},\n\
+        {indent}parameters: Variables,\n\
+        }};\n",
     );
     ArtifactPathAndContent {
         relative_directory: relative_directory.clone(),

--- a/crates/graphql_artifact_generation/src/iso_overload_file.rs
+++ b/crates/graphql_artifact_generation/src/iso_overload_file.rs
@@ -72,16 +72,18 @@ export function iso<T>(
 }
 
 pub(crate) fn build_iso_overload(schema: &ValidatedSchema) -> ArtifactPathAndContent {
-    let mut imports = "import type { IsographEntrypoint } from '@isograph/react';\n".to_string();
+    let mut imports =
+        "import type { IsographEntrypoint, ResolverFirstParameter, Variables } from '@isograph/react';\n"
+            .to_string();
     let mut content = String::from(
         "
 // This is the type given to regular client fields.
 // This means that the type of the exported iso literal is exactly
 // the type of the passed-in function, which takes one parameter
 // of type TParam.
-type IdentityWithParam<TParam> = <TClientFieldReturn>(
+type IdentityWithParam<TParam extends Object> = <TClientFieldReturn, TVariables = Variables>(
   clientField: (param: TParam) => TClientFieldReturn
-) => (param: TParam) => TClientFieldReturn;
+) => (param: ResolverFirstParameter<TParam, TVariables>) => TClientFieldReturn;
 
 // This is the type given it to client fields with @component.
 // This means that the type of the exported iso literal is exactly
@@ -90,9 +92,13 @@ type IdentityWithParam<TParam> = <TClientFieldReturn>(
 //
 // TComponentProps becomes the types of the props you must pass
 // whenever the @component field is rendered.
-type IdentityWithParamComponent<TParam> = <TClientFieldReturn, TComponentProps = Record<string, never>>(
+type IdentityWithParamComponent<TParam extends Object> = <
+  TClientFieldReturn,
+  TComponentProps = Record<string, never>,
+  TVariables = Variables
+>(
   clientComponentField: (data: TParam, componentProps: TComponentProps) => TClientFieldReturn
-) => (data: TParam, componentProps: TComponentProps) => TClientFieldReturn;
+) => (data: ResolverFirstParameter<TParam, TVariables>, componentProps: TComponentProps) => TClientFieldReturn;
 
 type WhitespaceCharacter = ' ' | '\\t' | '\\n';
 type Whitespace<In> = In extends `${WhitespaceCharacter}${infer In}`

--- a/demos/github-demo/src/isograph-components/CommentList.tsx
+++ b/demos/github-demo/src/isograph-components/CommentList.tsx
@@ -8,8 +8,8 @@ export const formattedCommentCreationDate = iso(`
   field IssueComment.formattedCommentCreationDate {
     createdAt
   }
-`)((props) => {
-  const date = new Date(props.createdAt);
+`)(({ data }) => {
+  const date = new Date(data.createdAt);
   return date.toLocaleDateString('en-us', {
     year: 'numeric',
     month: 'numeric',
@@ -32,7 +32,7 @@ export const CommentList = iso(`
       }
     }
   }
-`)(function CommentListComponent(data) {
+`)(function CommentListComponent({ data }) {
   const comments = [...data.comments.edges].reverse();
 
   return comments.map((commentNode) => {

--- a/demos/github-demo/src/isograph-components/HomePageList.tsx
+++ b/demos/github-demo/src/isograph-components/HomePageList.tsx
@@ -13,7 +13,7 @@ export const HomePageList = iso(`
     }
   }
 `)(function HomePageListComponent(
-  data,
+  { data },
   {
     setRoute,
   }: {

--- a/demos/github-demo/src/isograph-components/HomeRoute.tsx
+++ b/demos/github-demo/src/isograph-components/HomeRoute.tsx
@@ -13,7 +13,7 @@ export const HomePage = iso(`
     HomePageList
   }
 `)(function HomePageComponent(
-  data,
+  { data },
   {
     route,
     setRoute,

--- a/demos/github-demo/src/isograph-components/PullRequestDetail.tsx
+++ b/demos/github-demo/src/isograph-components/PullRequestDetail.tsx
@@ -15,7 +15,7 @@ export const PullRequestDetail = iso(`
       }
     }
   }
-`)(function PullRequestDetailComponent(data) {
+`)(function PullRequestDetailComponent({ data }) {
   const repository = data.repository;
   if (repository === null) {
     return <h1>Repository not found</h1>;

--- a/demos/github-demo/src/isograph-components/PullRequestLink.tsx
+++ b/demos/github-demo/src/isograph-components/PullRequestLink.tsx
@@ -15,7 +15,7 @@ export const PullRequestLink = iso(`
     }
   }
 `)(function PullRequestLinkComponent(
-  data,
+  { data },
   {
     setRoute,
     children,

--- a/demos/github-demo/src/isograph-components/PullRequestRoute.tsx
+++ b/demos/github-demo/src/isograph-components/PullRequestRoute.tsx
@@ -15,7 +15,7 @@ export const PullRequest = iso(`
     PullRequestDetail
   }
 `)(function PullRequestComponentComponent(
-  data,
+  { data },
   {
     route,
     setRoute,

--- a/demos/github-demo/src/isograph-components/PullRequestTable.tsx
+++ b/demos/github-demo/src/isograph-components/PullRequestTable.tsx
@@ -13,8 +13,8 @@ export const createdAtFormatted = iso(`
   field PullRequest.createdAtFormatted {
     createdAt
   }
-`)((props) => {
-  const date = new Date(props.createdAt);
+`)(({ data }) => {
+  const date = new Date(data.createdAt);
   return date.toLocaleDateString('en-us', {
     year: 'numeric',
     month: 'numeric',
@@ -41,7 +41,7 @@ export const PullRequestTable = iso(`
     }
   }
 `)(function PullRequestTableComponent(
-  data,
+  { data },
   {
     setRoute,
   }: {

--- a/demos/github-demo/src/isograph-components/RepositoryDetail.tsx
+++ b/demos/github-demo/src/isograph-components/RepositoryDetail.tsx
@@ -7,7 +7,7 @@ export const IsStarred = iso(`
     stargazerCount
     viewerHasStarred
   }
-`)((data) => {
+`)(({ data }) => {
   return (
     <p>
       This item has been starred {data.stargazerCount} times,{' '}
@@ -32,7 +32,7 @@ export const RepositoryDetail = iso(`
     }
   }
 `)(function RepositoryDetailComponent(
-  data,
+  { data },
   { setRoute }: { setRoute: (route: Route) => void },
 ) {
   const parent = data.repository?.parent;

--- a/demos/github-demo/src/isograph-components/RepositoryLink.tsx
+++ b/demos/github-demo/src/isograph-components/RepositoryLink.tsx
@@ -13,7 +13,7 @@ export const RepositoryLink = iso(`
     }
   }
 `)(function RepositoryLinkComponent(
-  data,
+  { data },
   {
     setRoute,
     children,

--- a/demos/github-demo/src/isograph-components/RepositoryRoute.tsx
+++ b/demos/github-demo/src/isograph-components/RepositoryRoute.tsx
@@ -15,7 +15,7 @@ export const RepositoryPage = iso(`
     RepositoryDetail
   }
 `)(function RepositoryRouteComponent(
-  data,
+  { data },
   {
     route,
     setRoute,

--- a/demos/github-demo/src/isograph-components/UserDetail.tsx
+++ b/demos/github-demo/src/isograph-components/UserDetail.tsx
@@ -10,7 +10,7 @@ export const UserDetail = iso(`
     }
   }
 `)(function UserDetailComponent(
-  data,
+  { data },
   {
     setRoute,
   }: {

--- a/demos/github-demo/src/isograph-components/UserLink.tsx
+++ b/demos/github-demo/src/isograph-components/UserLink.tsx
@@ -9,7 +9,7 @@ export const UserLink = iso(`
     login
   }
 `)(function UserLinkComponent(
-  data,
+  { data },
   {
     setRoute,
     children,

--- a/demos/github-demo/src/isograph-components/UserRepositoryList.tsx
+++ b/demos/github-demo/src/isograph-components/UserRepositoryList.tsx
@@ -32,7 +32,7 @@ export const RepositoryList = iso(`
     }
   }
 `)(function UserRepositoryListComponent(
-  data,
+  { data },
   { setRoute }: { setRoute: (route: Route) => void },
 ) {
   const repositories = [...data.repositories.edges].reverse();

--- a/demos/github-demo/src/isograph-components/UserRoute.tsx
+++ b/demos/github-demo/src/isograph-components/UserRoute.tsx
@@ -15,7 +15,7 @@ export const UserPage = iso(`
     UserDetail
   }
 `)(function UserRouteComponentComponent(
-  data,
+  { data },
   {
     route,
     setRoute,

--- a/demos/github-demo/src/isograph-components/__isograph/Actor/UserLink/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Actor/UserLink/param_type.ts
@@ -1,7 +1,12 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Actor__UserLink__param = {
-    /**
+  data: {
+        /**
 The username of the actor.
-  */
+    */
 login: string,
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/IssueComment/formattedCommentCreationDate/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/IssueComment/formattedCommentCreationDate/param_type.ts
@@ -1,7 +1,12 @@
 
+import { type Variables } from '@isograph/react';
+
 export type IssueComment__formattedCommentCreationDate__param = {
-    /**
+  data: {
+        /**
 Identifies the date and time when the object was created.
-  */
+    */
 createdAt: string,
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequest/CommentList/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequest/CommentList/param_type.ts
@@ -1,37 +1,42 @@
 import { type IssueComment__formattedCommentCreationDate__output_type } from '../../IssueComment/formattedCommentCreationDate/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type PullRequest__CommentList__param = {
-  /**
-A list of comments associated with the pull request.
-  */
-  comments: {
+  data: {
     /**
-A list of edges.
+A list of comments associated with the pull request.
     */
-    edges: (({
+    comments: {
       /**
-The item at the end of the edge.
+A list of edges.
       */
-      node: ({
-                /**
-The Node ID of the IssueComment object
-        */
-id: string,
-                /**
-The body rendered to text.
-        */
-bodyText: string,
-        formattedCommentCreationDate: IssueComment__formattedCommentCreationDate__output_type,
+      edges: (({
         /**
-The actor who authored the comment.
+The item at the end of the edge.
         */
-        author: ({
+        node: ({
                     /**
-The username of the actor.
+The Node ID of the IssueComment object
           */
+id: string,
+                    /**
+The body rendered to text.
+          */
+bodyText: string,
+          formattedCommentCreationDate: IssueComment__formattedCommentCreationDate__output_type,
+          /**
+The actor who authored the comment.
+          */
+          author: ({
+                        /**
+The username of the actor.
+            */
 login: string,
+          } | null),
         } | null),
-      } | null),
-    } | null))[],
+      } | null))[],
+    },
   },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequest/PullRequestLink/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequest/PullRequestLink/param_type.ts
@@ -1,25 +1,30 @@
 
+import { type Variables } from '@isograph/react';
+
 export type PullRequest__PullRequestLink__param = {
-    /**
-Identifies the pull request number.
-  */
-number: number,
-  /**
-The repository associated with this node.
-  */
-  repository: {
+  data: {
         /**
-The name of the repository.
+Identifies the pull request number.
     */
-name: string,
+number: number,
     /**
-The User owner of the repository.
+The repository associated with this node.
     */
-    owner: {
+    repository: {
             /**
-The username used to login.
+The name of the repository.
       */
+name: string,
+      /**
+The User owner of the repository.
+      */
+      owner: {
+                /**
+The username used to login.
+        */
 login: string,
+      },
     },
   },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequest/createdAtFormatted/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequest/createdAtFormatted/param_type.ts
@@ -1,7 +1,12 @@
 
+import { type Variables } from '@isograph/react';
+
 export type PullRequest__createdAtFormatted__param = {
-    /**
+  data: {
+        /**
 Identifies the date and time when the object was created.
-  */
+    */
 createdAt: string,
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequestConnection/PullRequestTable/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequestConnection/PullRequestTable/param_type.ts
@@ -2,47 +2,52 @@ import { type Actor__UserLink__output_type } from '../../Actor/UserLink/output_t
 import { type PullRequest__PullRequestLink__output_type } from '../../PullRequest/PullRequestLink/output_type';
 import { type PullRequest__createdAtFormatted__output_type } from '../../PullRequest/createdAtFormatted/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type PullRequestConnection__PullRequestTable__param = {
-  /**
-A list of edges.
-  */
-  edges: (({
+  data: {
     /**
-The item at the end of the edge.
+A list of edges.
     */
-    node: ({
-            /**
-The Node ID of the PullRequest object
-      */
-id: string,
-      PullRequestLink: PullRequest__PullRequestLink__output_type,
-            /**
-Identifies the pull request number.
-      */
-number: number,
-            /**
-Identifies the pull request title.
-      */
-title: string,
+    edges: (({
       /**
-The actor who authored the comment.
+The item at the end of the edge.
       */
-      author: ({
-        UserLink: Actor__UserLink__output_type,
+      node: ({
                 /**
-The username of the actor.
+The Node ID of the PullRequest object
         */
+id: string,
+        PullRequestLink: PullRequest__PullRequestLink__output_type,
+                /**
+Identifies the pull request number.
+        */
+number: number,
+                /**
+Identifies the pull request title.
+        */
+title: string,
+        /**
+The actor who authored the comment.
+        */
+        author: ({
+          UserLink: Actor__UserLink__output_type,
+                    /**
+The username of the actor.
+          */
 login: string,
-      } | null),
-            /**
+        } | null),
+                /**
 `true` if the pull request is closed
-      */
+        */
 closed: boolean,
-            /**
+                /**
 Returns a count of how many comments this pull request has received.
-      */
+        */
 totalCommentsCount: (number | null),
-      createdAtFormatted: PullRequest__createdAtFormatted__output_type,
-    } | null),
-  } | null))[],
+        createdAtFormatted: PullRequest__createdAtFormatted__output_type,
+      } | null),
+    } | null))[],
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/Header/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/Header/param_type.ts
@@ -1,14 +1,19 @@
 import { type User__Avatar__output_type } from '../../User/Avatar/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__Header__param = {
-  /**
+  data: {
+    /**
 The currently authenticated user.
-  */
-  viewer: {
-        /**
-The user's public profile name.
     */
+    viewer: {
+            /**
+The user's public profile name.
+      */
 name: (string | null),
-    Avatar: User__Avatar__output_type,
+      Avatar: User__Avatar__output_type,
+    },
   },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/param_type.ts
@@ -1,7 +1,12 @@
 import { type Query__Header__output_type } from '../../Query/Header/output_type';
 import { type Query__HomePageList__output_type } from '../../Query/HomePageList/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__HomePage__param = {
-  Header: Query__Header__output_type,
-  HomePageList: Query__HomePageList__output_type,
+  data: {
+    Header: Query__Header__output_type,
+    HomePageList: Query__HomePageList__output_type,
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/HomePageList/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/HomePageList/param_type.ts
@@ -1,23 +1,28 @@
 import { type User__RepositoryList__output_type } from '../../User/RepositoryList/output_type';
 import { type User____refetch__output_type } from '../../User/__refetch/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__HomePageList__param = {
-  /**
-The currently authenticated user.
-  */
-  viewer: {
-        /**
-The username used to login.
-    */
-login: string,
-        /**
-The user's public profile name.
-    */
-name: (string | null),
-    RepositoryList: User__RepositoryList__output_type,
+  data: {
     /**
-A refetch field for the User type.
+The currently authenticated user.
     */
-    __refetch: User____refetch__output_type,
+    viewer: {
+            /**
+The username used to login.
+      */
+login: string,
+            /**
+The user's public profile name.
+      */
+name: (string | null),
+      RepositoryList: User__RepositoryList__output_type,
+      /**
+A refetch field for the User type.
+      */
+      __refetch: User____refetch__output_type,
+    },
   },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/param_type.ts
@@ -1,7 +1,12 @@
 import { type Query__Header__output_type } from '../../Query/Header/output_type';
 import { type Query__PullRequestDetail__output_type } from '../../Query/PullRequestDetail/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__PullRequest__param = {
-  Header: Query__Header__output_type,
-  PullRequestDetail: Query__PullRequestDetail__output_type,
+  data: {
+    Header: Query__Header__output_type,
+    PullRequestDetail: Query__PullRequestDetail__output_type,
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/param_type.ts
@@ -1,23 +1,28 @@
 import { type PullRequest__CommentList__output_type } from '../../PullRequest/CommentList/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__PullRequestDetail__param = {
-  /**
-Lookup a given repository by the owner and repository name.
-  */
-  repository: ({
+  data: {
     /**
-Returns a single pull request from the current repository by number.
+Lookup a given repository by the owner and repository name.
     */
-    pullRequest: ({
-            /**
+    repository: ({
+      /**
+Returns a single pull request from the current repository by number.
+      */
+      pullRequest: ({
+                /**
 Identifies the pull request title.
-      */
+        */
 title: string,
-            /**
+                /**
 The body rendered to HTML.
-      */
+        */
 bodyHTML: string,
-      CommentList: PullRequest__CommentList__output_type,
+        CommentList: PullRequest__CommentList__output_type,
+      } | null),
     } | null),
-  } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/param_type.ts
@@ -2,31 +2,36 @@ import { type PullRequestConnection__PullRequestTable__output_type } from '../..
 import { type Repository__RepositoryLink__output_type } from '../../Repository/RepositoryLink/output_type';
 import { type Starrable__IsStarred__output_type } from '../../Starrable/IsStarred/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__RepositoryDetail__param = {
-  /**
-Lookup a given repository by the owner and repository name.
-  */
-  repository: ({
-    IsStarred: Starrable__IsStarred__output_type,
-        /**
-The repository's name with owner.
-    */
-nameWithOwner: string,
+  data: {
     /**
-The repository parent, if this is a fork.
+Lookup a given repository by the owner and repository name.
     */
-    parent: ({
-      RepositoryLink: Repository__RepositoryLink__output_type,
+    repository: ({
+      IsStarred: Starrable__IsStarred__output_type,
             /**
 The repository's name with owner.
       */
 nameWithOwner: string,
-    } | null),
-    /**
+      /**
+The repository parent, if this is a fork.
+      */
+      parent: ({
+        RepositoryLink: Repository__RepositoryLink__output_type,
+                /**
+The repository's name with owner.
+        */
+nameWithOwner: string,
+      } | null),
+      /**
 A list of pull requests that have been opened in the repository.
-    */
-    pullRequests: {
-      PullRequestTable: PullRequestConnection__PullRequestTable__output_type,
-    },
-  } | null),
+      */
+      pullRequests: {
+        PullRequestTable: PullRequestConnection__PullRequestTable__output_type,
+      },
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/param_type.ts
@@ -1,7 +1,12 @@
 import { type Query__Header__output_type } from '../../Query/Header/output_type';
 import { type Query__RepositoryDetail__output_type } from '../../Query/RepositoryDetail/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__RepositoryPage__param = {
-  Header: Query__Header__output_type,
-  RepositoryDetail: Query__RepositoryDetail__output_type,
+  data: {
+    Header: Query__Header__output_type,
+    RepositoryDetail: Query__RepositoryDetail__output_type,
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/param_type.ts
@@ -1,14 +1,19 @@
 import { type User__RepositoryList__output_type } from '../../User/RepositoryList/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__UserDetail__param = {
-  /**
+  data: {
+    /**
 Lookup a user by login.
-  */
-  user: ({
-        /**
-The user's public profile name.
     */
+    user: ({
+            /**
+The user's public profile name.
+      */
 name: (string | null),
-    RepositoryList: User__RepositoryList__output_type,
-  } | null),
+      RepositoryList: User__RepositoryList__output_type,
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/param_type.ts
@@ -1,7 +1,12 @@
 import { type Query__Header__output_type } from '../../Query/Header/output_type';
 import { type Query__UserDetail__output_type } from '../../Query/UserDetail/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__UserPage__param = {
-  Header: Query__Header__output_type,
-  UserDetail: Query__UserDetail__output_type,
+  data: {
+    Header: Query__Header__output_type,
+    UserDetail: Query__UserDetail__output_type,
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Repository/RepositoryLink/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Repository/RepositoryLink/param_type.ts
@@ -1,20 +1,25 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Repository__RepositoryLink__param = {
-    /**
-The Node ID of the Repository object
-  */
-id: string,
-    /**
-The name of the repository.
-  */
-name: string,
-  /**
-The User owner of the repository.
-  */
-  owner: {
+  data: {
         /**
-The username used to login.
+The Node ID of the Repository object
     */
+id: string,
+        /**
+The name of the repository.
+    */
+name: string,
+    /**
+The User owner of the repository.
+    */
+    owner: {
+            /**
+The username used to login.
+      */
 login: string,
+    },
   },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Starrable/IsStarred/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Starrable/IsStarred/param_type.ts
@@ -1,11 +1,16 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Starrable__IsStarred__param = {
-    /**
+  data: {
+        /**
 Returns a count of how many stargazers there are on this object
-  */
+    */
 stargazerCount: number,
-    /**
+        /**
 Returns a boolean indicating whether the viewing user has starred this starrable.
-  */
+    */
 viewerHasStarred: boolean,
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/User/Avatar/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/Avatar/param_type.ts
@@ -1,11 +1,16 @@
 
+import { type Variables } from '@isograph/react';
+
 export type User__Avatar__param = {
-    /**
+  data: {
+        /**
 The user's public profile name.
-  */
+    */
 name: (string | null),
-    /**
+        /**
 A URL pointing to the user's public avatar.
-  */
+    */
 avatarUrl: string,
+  },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/User/RepositoryList/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/RepositoryList/param_type.ts
@@ -1,62 +1,67 @@
 import { type Repository__RepositoryLink__output_type } from '../../Repository/RepositoryLink/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type User__RepositoryList__param = {
-  /**
-A list of repositories that the user owns.
-  */
-  repositories: {
+  data: {
     /**
-A list of edges.
+A list of repositories that the user owns.
     */
-    edges: (({
+    repositories: {
       /**
-The item at the end of the edge.
+A list of edges.
       */
-      node: ({
-                /**
+      edges: (({
+        /**
+The item at the end of the edge.
+        */
+        node: ({
+                    /**
 The Node ID of the Repository object
-        */
+          */
 id: string,
-        RepositoryLink: Repository__RepositoryLink__output_type,
-                /**
+          RepositoryLink: Repository__RepositoryLink__output_type,
+                    /**
 The name of the repository.
-        */
+          */
 name: string,
-                /**
+                    /**
 The repository's name with owner.
-        */
+          */
 nameWithOwner: string,
-                /**
+                    /**
 The description of the repository.
-        */
+          */
 description: (string | null),
-                /**
+                    /**
 Returns how many forks there are of this repository in the whole network.
-        */
+          */
 forkCount: number,
-        /**
+          /**
 A list of pull requests that have been opened in the repository.
-        */
-        pullRequests: {
-                    /**
-Identifies the total count of items in the connection.
           */
+          pullRequests: {
+                        /**
+Identifies the total count of items in the connection.
+            */
 totalCount: number,
-        },
-                /**
+          },
+                    /**
 Returns a count of how many stargazers there are on this object
-        */
-stargazerCount: number,
-        /**
-A list of users watching the repository.
-        */
-        watchers: {
-                    /**
-Identifies the total count of items in the connection.
           */
+stargazerCount: number,
+          /**
+A list of users watching the repository.
+          */
+          watchers: {
+                        /**
+Identifies the total count of items in the connection.
+            */
 totalCount: number,
-        },
-      } | null),
-    } | null))[],
+          },
+        } | null),
+      } | null))[],
+    },
   },
+  parameters: Variables,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/iso.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/iso.ts
@@ -1,4 +1,4 @@
-import type { IsographEntrypoint } from '@isograph/react';
+import type { IsographEntrypoint, ResolverFirstParameter, Variables } from '@isograph/react';
 import { type Actor__UserLink__param } from './Actor/UserLink/param_type';
 import { type IssueComment__formattedCommentCreationDate__param } from './IssueComment/formattedCommentCreationDate/param_type';
 import { type PullRequest__CommentList__param } from './PullRequest/CommentList/param_type';
@@ -27,9 +27,9 @@ import entrypoint_Query__UserPage from '../__isograph/Query/UserPage/entrypoint'
 // This means that the type of the exported iso literal is exactly
 // the type of the passed-in function, which takes one parameter
 // of type TParam.
-type IdentityWithParam<TParam> = <TClientFieldReturn>(
+type IdentityWithParam<TParam extends Object> = <TClientFieldReturn, TVariables = Variables>(
   clientField: (param: TParam) => TClientFieldReturn
-) => (param: TParam) => TClientFieldReturn;
+) => (param: ResolverFirstParameter<TParam, TVariables>) => TClientFieldReturn;
 
 // This is the type given it to client fields with @component.
 // This means that the type of the exported iso literal is exactly
@@ -38,9 +38,13 @@ type IdentityWithParam<TParam> = <TClientFieldReturn>(
 //
 // TComponentProps becomes the types of the props you must pass
 // whenever the @component field is rendered.
-type IdentityWithParamComponent<TParam> = <TClientFieldReturn, TComponentProps = Record<string, never>>(
+type IdentityWithParamComponent<TParam extends Object> = <
+  TClientFieldReturn,
+  TComponentProps = Record<string, never>,
+  TVariables = Variables
+>(
   clientComponentField: (data: TParam, componentProps: TComponentProps) => TClientFieldReturn
-) => (data: TParam, componentProps: TComponentProps) => TClientFieldReturn;
+) => (data: ResolverFirstParameter<TParam, TVariables>, componentProps: TComponentProps) => TClientFieldReturn;
 
 type WhitespaceCharacter = ' ' | '\t' | '\n';
 type Whitespace<In> = In extends `${WhitespaceCharacter}${infer In}`

--- a/demos/github-demo/src/isograph-components/avatar.tsx
+++ b/demos/github-demo/src/isograph-components/avatar.tsx
@@ -6,6 +6,6 @@ export const Avatar = iso(`
     name
     avatarUrl
   }
-`)(function AvatarComponent(data) {
+`)(function AvatarComponent({ data }) {
   return <MuiAvatar alt={data.name ?? ''} src={data.avatarUrl} />;
 });

--- a/demos/github-demo/src/isograph-components/header.tsx
+++ b/demos/github-demo/src/isograph-components/header.tsx
@@ -16,7 +16,7 @@ export const Header = iso(`
     }
   }
 `)(function HeaderComponent(
-  data,
+  { data },
   {
     route,
     setRoute,

--- a/demos/pet-demo/src/components/FavoritePhrase.tsx
+++ b/demos/pet-demo/src/components/FavoritePhrase.tsx
@@ -8,7 +8,7 @@ export const FavoritePhraseLoader = iso(`
   field Pet.FavoritePhraseLoader @component {
     id
   }
-`)((pet) => {
+`)(({ data: pet }) => {
   const { fragmentReference, loadFragmentReference } = useImperativeReference(
     iso(`entrypoint Query.PetFavoritePhrase`),
   );
@@ -37,7 +37,7 @@ export const PetFavoritePhrase = iso(`
       favorite_phrase
     }
   }
-`)((data) => {
+`)(({ data }) => {
   const pet = data.pet;
   if (pet == null) return;
   return (

--- a/demos/pet-demo/src/components/HomeRoute.tsx
+++ b/demos/pet-demo/src/components/HomeRoute.tsx
@@ -12,7 +12,7 @@ export const HomeRoute = iso(`
       PetSummaryCard
     }
   }
-`)(function HomeRouteComponent(data) {
+`)(function HomeRouteComponent({ data }) {
   return (
     <Container maxWidth="md">
       <h1>Robert&apos;s Pet List 3000</h1>

--- a/demos/pet-demo/src/components/Newsfeed/AdItem.tsx
+++ b/demos/pet-demo/src/components/Newsfeed/AdItem.tsx
@@ -12,7 +12,7 @@ export const BlogItem = iso(`
     message
   }
 `)((
-  adItem,
+  { data: adItem },
   { onVisible, index }: { onVisible: (() => void) | null; index: number },
 ) => {
   const isIntersectingRef = useRef(null);

--- a/demos/pet-demo/src/components/Newsfeed/AdItemDisplayWrapper.tsx
+++ b/demos/pet-demo/src/components/Newsfeed/AdItemDisplayWrapper.tsx
@@ -7,7 +7,7 @@ export const AdItemDisplayWrapper = iso(`
     AdItemDisplay @loadable(lazyLoadArtifact: true)
   }
 `)((
-  data,
+  { data },
   { onVisible, index }: { onVisible: (() => void) | null; index: number },
 ) => {
   const { fragmentReference } = useClientSideDefer(data.AdItemDisplay);

--- a/demos/pet-demo/src/components/Newsfeed/BlogItem.tsx
+++ b/demos/pet-demo/src/components/Newsfeed/BlogItem.tsx
@@ -24,7 +24,7 @@ export const BlogItem = iso(`
     }
   }
 `)((
-  blogItem,
+  { data: blogItem },
   { onVisible, index }: { onVisible: (() => void) | null; index: number },
 ) => {
   const isIntersectingRef = useRef(null);
@@ -64,7 +64,7 @@ export const ImageDisplayWrapper = iso(`
   field Image.ImageDisplayWrapper @component {
     ImageDisplay @loadable(lazyLoadArtifact: true)
   }
-`)((image) => {
+`)(({ data: image }) => {
   const { fragmentReference } = useClientSideDefer(image.ImageDisplay);
   return (
     <Suspense fallback={null}>

--- a/demos/pet-demo/src/components/Newsfeed/BlogItemMoreDetail.tsx
+++ b/demos/pet-demo/src/components/Newsfeed/BlogItemMoreDetail.tsx
@@ -5,7 +5,7 @@ export const BlogItemMoreDetail = iso(`
   field BlogItem.BlogItemMoreDetail @component {
     moreContent
   }
-`)((blogItem) => {
+`)(({ data: blogItem }) => {
   return blogItem.moreContent
     .split('\n')
     .map((paragraph, index) => <p key={index}>{paragraph}</p>);

--- a/demos/pet-demo/src/components/Newsfeed/ImageDisplay.tsx
+++ b/demos/pet-demo/src/components/Newsfeed/ImageDisplay.tsx
@@ -6,7 +6,7 @@ export const ImageDisplay = iso(`
   field Image.ImageDisplay @component {
     url
   }
-`)((image) => (
+`)(({ data: image }) => (
   <CardMedia
     component="img"
     image={image.url}

--- a/demos/pet-demo/src/components/Newsfeed/NewsfeedPagination.tsx
+++ b/demos/pet-demo/src/components/Newsfeed/NewsfeedPagination.tsx
@@ -7,6 +7,6 @@ export const NewsfeedPaginationComponent = iso(`
       NewsfeedAdOrBlog
     }
   }
-`)((data) => {
+`)(({ data }) => {
   return data.newsfeed;
 });

--- a/demos/pet-demo/src/components/Newsfeed/NewsfeedRoute.tsx
+++ b/demos/pet-demo/src/components/Newsfeed/NewsfeedRoute.tsx
@@ -18,7 +18,7 @@ export const Newsfeed = iso(`
       NewsfeedPaginationComponent @loadable
     }
   }
-`)(function PetDetailRouteComponent(data) {
+`)(function PetDetailRouteComponent({ data }) {
   const viewer = data.viewer;
 
   const paginationState = useSkipLimitPagination(
@@ -82,7 +82,7 @@ export const NewsfeedAdOrBlog = iso(`
     }
   }
 `)((
-  newsfeedItem,
+  { data: newsfeedItem },
   { onVisible, index }: { onVisible: (() => void) | null; index: number },
 ) => {
   const fallback = (

--- a/demos/pet-demo/src/components/PetBestFriendCard.tsx
+++ b/demos/pet-demo/src/components/PetBestFriendCard.tsx
@@ -16,7 +16,7 @@ export const PetBestFriendCard = iso(`
       }
     }
   }
-`)(function PetBestFriendCardComponent(data) {
+`)(function PetBestFriendCardComponent({ data }) {
   const navigateTo = useNavigateTo();
   const bestFriendRelationship = data.best_friend_relationship;
   if (!bestFriendRelationship) {

--- a/demos/pet-demo/src/components/PetByName.tsx
+++ b/demos/pet-demo/src/components/PetByName.tsx
@@ -9,7 +9,7 @@ export const PetByNameRouteComponent = iso(`
       PetDetailDeferredRouteInnerComponent
     }
   }
-`)(function (data) {
+`)(function ({ data }) {
   const { pet } = data;
   if (pet == null) {
     return <h1>Pet not found.</h1>;

--- a/demos/pet-demo/src/components/PetCheckinListRoute.tsx
+++ b/demos/pet-demo/src/components/PetCheckinListRoute.tsx
@@ -16,7 +16,7 @@ export const PetDetailDeferredRouteComponent = iso(`
       PetCheckinsCardList @loadable(lazyLoadArtifact: true)
     }
   }
-`)(function PetDetailRouteComponent(data) {
+`)(function PetDetailRouteComponent({ data }) {
   const { pet } = data;
   const navigateTo = useNavigateTo();
 

--- a/demos/pet-demo/src/components/PetCheckinsCard.tsx
+++ b/demos/pet-demo/src/components/PetCheckinsCard.tsx
@@ -11,7 +11,7 @@ export const PetCheckinsCard = iso(`
       id
     }
   }
-`)(function PetCheckinsCardComponent(data) {
+`)(function PetCheckinsCardComponent({ data }) {
   return (
     <Card
       variant="outlined"
@@ -37,7 +37,7 @@ export const CheckinDisplay = iso(`
     time
     make_super
   }
-`)((checkin) => {
+`)(({ data: checkin }) => {
   const { loadField } = useImperativeExposedMutationField(checkin.make_super);
   return (
     <b>
@@ -56,6 +56,6 @@ export const PetCheckinsCardList = iso(`
       id
     }
   }
-`)(function PetCheckinsCardComponent(data) {
+`)(function PetCheckinsCardComponent({ data }) {
   return data.checkins;
 });

--- a/demos/pet-demo/src/components/PetDetailDeferredRoute.tsx
+++ b/demos/pet-demo/src/components/PetDetailDeferredRoute.tsx
@@ -19,7 +19,7 @@ export const PetDetailDeferredRouteComponent = iso(`
       PetDetailDeferredRouteInnerComponent
     }
   }
-`)(function PetDetailRouteComponent(data) {
+`)(function PetDetailRouteComponent({ data }) {
   const { pet } = data;
   if (pet == null) {
     return <h1>Pet not found.</h1>;
@@ -33,7 +33,7 @@ export const PetDetailDeferredRouteInnerComponent = iso(`
     name
     PetCheckinsCard @loadable
   }
-`)((pet) => {
+`)(({ data: pet }) => {
   const navigateTo = useNavigateTo();
   const { fragmentReference: petCheckinsCard } = useClientSideDefer(
     pet.PetCheckinsCard,

--- a/demos/pet-demo/src/components/PetDetailRoute.tsx
+++ b/demos/pet-demo/src/components/PetDetailRoute.tsx
@@ -9,7 +9,7 @@ export const PetDetailRouteComponent = iso(`
   field Query.PetDetailRoute($id: ID!) @component {
     PetDetailRouteInner(actualId: $id) 
   }
-`)(function PetDetailRouteComponent(data) {
+`)(function PetDetailRouteComponent({ data }) {
   return <data.PetDetailRouteInner />;
 });
 
@@ -24,7 +24,7 @@ export const PetDetailRouteInner = iso(`
       PetStatsCard
     }
   }
-`)(function PetDetailRouteComponentInner(data) {
+`)(function PetDetailRouteComponentInner({ data }) {
   const navigateTo = useNavigateTo();
   const { pet } = data;
   if (pet == null) {

--- a/demos/pet-demo/src/components/PetPhraseCard.tsx
+++ b/demos/pet-demo/src/components/PetPhraseCard.tsx
@@ -7,7 +7,7 @@ field Pet.PetPhraseCard @component {
   id
   favorite_phrase
 }
-`)(function PetPhraseCardComponent(data) {
+`)(function PetPhraseCardComponent({ data }) {
   return (
     <Card
       variant="outlined"

--- a/demos/pet-demo/src/components/PetStatsCard.tsx
+++ b/demos/pet-demo/src/components/PetStatsCard.tsx
@@ -17,7 +17,7 @@ export const PetStatsCard = iso(`
       refetch_pet_stats(id: $id)
     }
   }
-`)(function PetStatsCardComponent(pet) {
+`)(function PetStatsCardComponent({ data: pet }) {
   return (
     <Card
       variant="outlined"

--- a/demos/pet-demo/src/components/PetSummaryCard.tsx
+++ b/demos/pet-demo/src/components/PetSummaryCard.tsx
@@ -11,7 +11,7 @@ export const PetSummaryCard = iso(`
     tagline
     FavoritePhraseLoader
   }
-`)(function PetSummaryCardComponent(data) {
+`)(function PetSummaryCardComponent({ data }) {
   const navigateTo = useNavigateTo();
   return (
     <Card

--- a/demos/pet-demo/src/components/PetTaglineCard.tsx
+++ b/demos/pet-demo/src/components/PetTaglineCard.tsx
@@ -9,7 +9,7 @@ field Pet.PetTaglineCard @component {
   id
   tagline
 }
-`)(function PetTaglineCardComponent(pet) {
+`)(function PetTaglineCardComponent({ data: pet }) {
   const {
     fragmentReference: mutationRef,
     loadFragmentReference: loadMutation,

--- a/demos/pet-demo/src/components/PetUpdater.tsx
+++ b/demos/pet-demo/src/components/PetUpdater.tsx
@@ -22,7 +22,7 @@ export const PetUpdater = iso(`
 
     __refetch
   }
-`)(function PetUpdaterComponent(pet) {
+`)(function PetUpdaterComponent({ data: pet }) {
   const [selected, setSelected] = useState<PetId | 'NONE'>('NONE');
   const [tagline, setTagline] = useState<string>(pet.tagline);
   // TODO the tagline can change. But we're storing a stale one in state.

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/param_type.ts
@@ -1,5 +1,10 @@
 
+import { type Variables } from '@isograph/react';
+
 export type AdItem__AdItemDisplay__param = {
-  advertiser: string,
-  message: string,
+  data: {
+    advertiser: string,
+    message: string,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplayWrapper/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplayWrapper/param_type.ts
@@ -1,6 +1,11 @@
 import { type AdItem__AdItemDisplay__output_type } from '../../AdItem/AdItemDisplay/output_type';
 
 import { type LoadableField } from '@isograph/react';
+import { type Variables } from '@isograph/react';
+
 export type AdItem__AdItemDisplayWrapper__param = {
-  AdItemDisplay: LoadableField<void, AdItem__AdItemDisplay__output_type>,
+  data: {
+    AdItemDisplay: LoadableField<void, AdItem__AdItemDisplay__output_type>,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemDisplay/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemDisplay/param_type.ts
@@ -2,12 +2,17 @@ import { type BlogItem__BlogItemMoreDetail__output_type } from '../../BlogItem/B
 import { type Image__ImageDisplayWrapper__output_type } from '../../Image/ImageDisplayWrapper/output_type';
 
 import { type LoadableField } from '@isograph/react';
+import { type Variables } from '@isograph/react';
+
 export type BlogItem__BlogItemDisplay__param = {
-  author: string,
-  title: string,
-  content: string,
-  BlogItemMoreDetail: LoadableField<void, BlogItem__BlogItemMoreDetail__output_type>,
-  image: ({
-    ImageDisplayWrapper: Image__ImageDisplayWrapper__output_type,
-  } | null),
+  data: {
+    author: string,
+    title: string,
+    content: string,
+    BlogItemMoreDetail: LoadableField<void, BlogItem__BlogItemMoreDetail__output_type>,
+    image: ({
+      ImageDisplayWrapper: Image__ImageDisplayWrapper__output_type,
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/param_type.ts
@@ -1,4 +1,9 @@
 
+import { type Variables } from '@isograph/react';
+
 export type BlogItem__BlogItemMoreDetail__param = {
-  moreContent: string,
+  data: {
+    moreContent: string,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Checkin/CheckinDisplay/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Checkin/CheckinDisplay/param_type.ts
@@ -1,7 +1,12 @@
 import { type ICheckin__make_super__output_type } from '../../ICheckin/make_super/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Checkin__CheckinDisplay__param = {
-  location: string,
-  time: string,
-  make_super: ICheckin__make_super__output_type,
+  data: {
+    location: string,
+    time: string,
+    make_super: ICheckin__make_super__output_type,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/param_type.ts
@@ -1,4 +1,9 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Image__ImageDisplay__param = {
-  url: string,
+  data: {
+    url: string,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplayWrapper/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplayWrapper/param_type.ts
@@ -1,6 +1,11 @@
 import { type Image__ImageDisplay__output_type } from '../../Image/ImageDisplay/output_type';
 
 import { type LoadableField } from '@isograph/react';
+import { type Variables } from '@isograph/react';
+
 export type Image__ImageDisplayWrapper__param = {
-  ImageDisplay: LoadableField<void, Image__ImageDisplay__output_type>,
+  data: {
+    ImageDisplay: LoadableField<void, Image__ImageDisplay__output_type>,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/param_type.ts
@@ -1,8 +1,13 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Mutation__SetTagline__param = {
-  set_pet_tagline: {
-    pet: {
-      tagline: string,
+  data: {
+    set_pet_tagline: {
+      pet: {
+        tagline: string,
+      },
     },
   },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/NewsfeedItem/NewsfeedAdOrBlog/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/NewsfeedItem/NewsfeedAdOrBlog/param_type.ts
@@ -1,11 +1,16 @@
 import { type AdItem__AdItemDisplayWrapper__output_type } from '../../AdItem/AdItemDisplayWrapper/output_type';
 import { type BlogItem__BlogItemDisplay__output_type } from '../../BlogItem/BlogItemDisplay/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type NewsfeedItem__NewsfeedAdOrBlog__param = {
-  adItem: ({
-    AdItemDisplayWrapper: AdItem__AdItemDisplayWrapper__output_type,
-  } | null),
-  blogItem: ({
-    BlogItemDisplay: BlogItem__BlogItemDisplay__output_type,
-  } | null),
+  data: {
+    adItem: ({
+      AdItemDisplayWrapper: AdItem__AdItemDisplayWrapper__output_type,
+    } | null),
+    blogItem: ({
+      BlogItemDisplay: BlogItem__BlogItemDisplay__output_type,
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/FavoritePhraseLoader/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/FavoritePhraseLoader/param_type.ts
@@ -1,4 +1,9 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__FavoritePhraseLoader__param = {
-  id: string,
+  data: {
+    id: string,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetBestFriendCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetBestFriendCard/param_type.ts
@@ -1,19 +1,24 @@
 import { type Pet__PetUpdater__output_type } from '../../Pet/PetUpdater/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__PetBestFriendCard__param = {
-  id: string,
-  /**
+  data: {
+    id: string,
+    /**
 # Pet.PetUpdater
 A component to test behavior with respect to mutations.
 You can update the best friend and the tagline.
-  */
-  PetUpdater: Pet__PetUpdater__output_type,
-  best_friend_relationship: ({
-    picture_together: (string | null),
-    best_friend: {
-      id: string,
-      name: string,
-      picture: string,
-    },
-  } | null),
+    */
+    PetUpdater: Pet__PetUpdater__output_type,
+    best_friend_relationship: ({
+      picture_together: (string | null),
+      best_friend: {
+        id: string,
+        name: string,
+        picture: string,
+      },
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/param_type.ts
@@ -1,9 +1,14 @@
 import { type Checkin__CheckinDisplay__output_type } from '../../Checkin/CheckinDisplay/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__PetCheckinsCard__param = {
-  id: string,
-  checkins: ({
-    CheckinDisplay: Checkin__CheckinDisplay__output_type,
+  data: {
     id: string,
-  })[],
+    checkins: ({
+      CheckinDisplay: Checkin__CheckinDisplay__output_type,
+      id: string,
+    })[],
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/param_type.ts
@@ -1,8 +1,13 @@
 import { type Checkin__CheckinDisplay__output_type } from '../../Checkin/CheckinDisplay/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__PetCheckinsCardList__param = {
-  checkins: ({
-    CheckinDisplay: Checkin__CheckinDisplay__output_type,
-    id: string,
-  })[],
+  data: {
+    checkins: ({
+      CheckinDisplay: Checkin__CheckinDisplay__output_type,
+      id: string,
+    })[],
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetDetailDeferredRouteInnerComponent/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetDetailDeferredRouteInnerComponent/param_type.ts
@@ -1,7 +1,12 @@
 import { type Pet__PetCheckinsCard__output_type } from '../../Pet/PetCheckinsCard/output_type';
 
 import { type LoadableField } from '@isograph/react';
+import { type Variables } from '@isograph/react';
+
 export type Pet__PetDetailDeferredRouteInnerComponent__param = {
-  name: string,
-  PetCheckinsCard: LoadableField<{skip?: number | null | void, limit?: number | null | void}, Pet__PetCheckinsCard__output_type>,
+  data: {
+    name: string,
+    PetCheckinsCard: LoadableField<{skip?: number | null | void, limit?: number | null | void}, Pet__PetCheckinsCard__output_type>,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetPhraseCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetPhraseCard/param_type.ts
@@ -1,5 +1,10 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__PetPhraseCard__param = {
-  id: string,
-  favorite_phrase: (string | null),
+  data: {
+    id: string,
+    favorite_phrase: (string | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetStatsCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetStatsCard/param_type.ts
@@ -1,16 +1,21 @@
 import { type PetStats__refetch_pet_stats__output_type } from '../../PetStats/refetch_pet_stats/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__PetStatsCard__param = {
-  id: string,
-  nickname: (string | null),
-  age: number,
-  stats: ({
-    weight: (number | null),
-    intelligence: (number | null),
-    cuteness: (number | null),
-    hunger: (number | null),
-    sociability: (number | null),
-    energy: (number | null),
-    refetch_pet_stats: PetStats__refetch_pet_stats__output_type,
-  } | null),
+  data: {
+    id: string,
+    nickname: (string | null),
+    age: number,
+    stats: ({
+      weight: (number | null),
+      intelligence: (number | null),
+      cuteness: (number | null),
+      hunger: (number | null),
+      sociability: (number | null),
+      energy: (number | null),
+      refetch_pet_stats: PetStats__refetch_pet_stats__output_type,
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetSummaryCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetSummaryCard/param_type.ts
@@ -1,9 +1,14 @@
 import { type Pet__FavoritePhraseLoader__output_type } from '../../Pet/FavoritePhraseLoader/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__PetSummaryCard__param = {
-  id: string,
-  name: string,
-  picture: string,
-  tagline: string,
-  FavoritePhraseLoader: Pet__FavoritePhraseLoader__output_type,
+  data: {
+    id: string,
+    name: string,
+    picture: string,
+    tagline: string,
+    FavoritePhraseLoader: Pet__FavoritePhraseLoader__output_type,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetTaglineCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetTaglineCard/param_type.ts
@@ -1,5 +1,10 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__PetTaglineCard__param = {
-  id: string,
-  tagline: string,
+  data: {
+    id: string,
+    tagline: string,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetUpdater/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetUpdater/param_type.ts
@@ -2,16 +2,21 @@ import { type Pet____refetch__output_type } from '../../Pet/__refetch/output_typ
 import { type Pet__set_best_friend__output_type } from '../../Pet/set_best_friend/output_type';
 import { type Pet__set_pet_tagline__output_type } from '../../Pet/set_pet_tagline/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__PetUpdater__param = {
-  set_best_friend: Pet__set_best_friend__output_type,
-  potential_new_best_friends: ({
-    id: string,
-    name: string,
-  })[],
-  set_pet_tagline: Pet__set_pet_tagline__output_type,
-  tagline: string,
-  /**
+  data: {
+    set_best_friend: Pet__set_best_friend__output_type,
+    potential_new_best_friends: ({
+      id: string,
+      name: string,
+    })[],
+    set_pet_tagline: Pet__set_pet_tagline__output_type,
+    tagline: string,
+    /**
 A refetch field for the Pet type.
-  */
-  __refetch: Pet____refetch__output_type,
+    */
+    __refetch: Pet____refetch__output_type,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/Unreachable2/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/Unreachable2/param_type.ts
@@ -1,4 +1,9 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__Unreachable2__param = {
-  id: string,
+  data: {
+    id: string,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/UnreachableFromEntrypoint/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/UnreachableFromEntrypoint/param_type.ts
@@ -1,8 +1,13 @@
 import { type Pet__Unreachable2__output_type } from '../../Pet/Unreachable2/output_type';
 import { type Pet__set_best_friend_do_not_use__output_type } from '../../Pet/set_best_friend_do_not_use/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Pet__UnreachableFromEntrypoint__param = {
-  id: string,
-  Unreachable2: Pet__Unreachable2__output_type,
-  set_best_friend_do_not_use: Pet__set_best_friend_do_not_use__output_type,
+  data: {
+    id: string,
+    Unreachable2: Pet__Unreachable2__output_type,
+    set_best_friend_do_not_use: Pet__set_best_friend_do_not_use__output_type,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/HomeRoute/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/HomeRoute/param_type.ts
@@ -1,8 +1,13 @@
 import { type Pet__PetSummaryCard__output_type } from '../../Pet/PetSummaryCard/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__HomeRoute__param = {
-  pets: ({
-    id: string,
-    PetSummaryCard: Pet__PetSummaryCard__output_type,
-  })[],
+  data: {
+    pets: ({
+      id: string,
+      PetSummaryCard: Pet__PetSummaryCard__output_type,
+    })[],
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/Newsfeed/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/Newsfeed/param_type.ts
@@ -2,11 +2,16 @@ import { type NewsfeedItem__NewsfeedAdOrBlog__output_type } from '../../Newsfeed
 import { type Viewer__NewsfeedPaginationComponent__output_type } from '../../Viewer/NewsfeedPaginationComponent/output_type';
 
 import { type LoadableField } from '@isograph/react';
+import { type Variables } from '@isograph/react';
+
 export type Query__Newsfeed__param = {
-  viewer: {
-    newsfeed: ({
-      NewsfeedAdOrBlog: NewsfeedItem__NewsfeedAdOrBlog__output_type,
-    })[],
-    NewsfeedPaginationComponent: LoadableField<{skip: number, limit: number}, Viewer__NewsfeedPaginationComponent__output_type>,
+  data: {
+    viewer: {
+      newsfeed: ({
+        NewsfeedAdOrBlog: NewsfeedItem__NewsfeedAdOrBlog__output_type,
+      })[],
+      NewsfeedPaginationComponent: LoadableField<{skip: number, limit: number}, Viewer__NewsfeedPaginationComponent__output_type>,
+    },
   },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetByName/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetByName/param_type.ts
@@ -1,7 +1,12 @@
 import { type Pet__PetDetailDeferredRouteInnerComponent__output_type } from '../../Pet/PetDetailDeferredRouteInnerComponent/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__PetByName__param = {
-  pet: ({
-    PetDetailDeferredRouteInnerComponent: Pet__PetDetailDeferredRouteInnerComponent__output_type,
-  } | null),
+  data: {
+    pet: ({
+      PetDetailDeferredRouteInnerComponent: Pet__PetDetailDeferredRouteInnerComponent__output_type,
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/param_type.ts
@@ -1,9 +1,14 @@
 import { type Pet__PetCheckinsCardList__output_type } from '../../Pet/PetCheckinsCardList/output_type';
 
 import { type LoadableField } from '@isograph/react';
+import { type Variables } from '@isograph/react';
+
 export type Query__PetCheckinListRoute__param = {
-  pet: ({
-    name: string,
-    PetCheckinsCardList: LoadableField<{skip?: number | null | void, limit?: number | null | void}, Pet__PetCheckinsCardList__output_type>,
-  } | null),
+  data: {
+    pet: ({
+      name: string,
+      PetCheckinsCardList: LoadableField<{skip?: number | null | void, limit?: number | null | void}, Pet__PetCheckinsCardList__output_type>,
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/param_type.ts
@@ -1,7 +1,12 @@
 import { type Pet__PetDetailDeferredRouteInnerComponent__output_type } from '../../Pet/PetDetailDeferredRouteInnerComponent/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__PetDetailDeferredRoute__param = {
-  pet: ({
-    PetDetailDeferredRouteInnerComponent: Pet__PetDetailDeferredRouteInnerComponent__output_type,
-  } | null),
+  data: {
+    pet: ({
+      PetDetailDeferredRouteInnerComponent: Pet__PetDetailDeferredRouteInnerComponent__output_type,
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/param_type.ts
@@ -1,5 +1,10 @@
 import { type Query__PetDetailRouteInner__output_type } from '../../Query/PetDetailRouteInner/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__PetDetailRoute__param = {
-  PetDetailRouteInner: Query__PetDetailRouteInner__output_type,
+  data: {
+    PetDetailRouteInner: Query__PetDetailRouteInner__output_type,
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRouteInner/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRouteInner/param_type.ts
@@ -4,13 +4,18 @@ import { type Pet__PetPhraseCard__output_type } from '../../Pet/PetPhraseCard/ou
 import { type Pet__PetStatsCard__output_type } from '../../Pet/PetStatsCard/output_type';
 import { type Pet__PetTaglineCard__output_type } from '../../Pet/PetTaglineCard/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Query__PetDetailRouteInner__param = {
-  pet: ({
-    name: string,
-    PetCheckinsCard: Pet__PetCheckinsCard__output_type,
-    PetBestFriendCard: Pet__PetBestFriendCard__output_type,
-    PetPhraseCard: Pet__PetPhraseCard__output_type,
-    PetTaglineCard: Pet__PetTaglineCard__output_type,
-    PetStatsCard: Pet__PetStatsCard__output_type,
-  } | null),
+  data: {
+    pet: ({
+      name: string,
+      PetCheckinsCard: Pet__PetCheckinsCard__output_type,
+      PetBestFriendCard: Pet__PetBestFriendCard__output_type,
+      PetPhraseCard: Pet__PetPhraseCard__output_type,
+      PetTaglineCard: Pet__PetTaglineCard__output_type,
+      PetStatsCard: Pet__PetStatsCard__output_type,
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/param_type.ts
@@ -1,7 +1,12 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Query__PetFavoritePhrase__param = {
-  pet: ({
-    name: string,
-    favorite_phrase: (string | null),
-  } | null),
+  data: {
+    pet: ({
+      name: string,
+      favorite_phrase: (string | null),
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/param_type.ts
@@ -1,7 +1,12 @@
 import { type NewsfeedItem__NewsfeedAdOrBlog__output_type } from '../../NewsfeedItem/NewsfeedAdOrBlog/output_type';
 
+import { type Variables } from '@isograph/react';
+
 export type Viewer__NewsfeedPaginationComponent__param = {
-  newsfeed: ({
-    NewsfeedAdOrBlog: NewsfeedItem__NewsfeedAdOrBlog__output_type,
-  })[],
+  data: {
+    newsfeed: ({
+      NewsfeedAdOrBlog: NewsfeedItem__NewsfeedAdOrBlog__output_type,
+    })[],
+  },
+  parameters: Variables,
 };

--- a/demos/pet-demo/src/components/__isograph/iso.ts
+++ b/demos/pet-demo/src/components/__isograph/iso.ts
@@ -1,4 +1,4 @@
-import type { IsographEntrypoint } from '@isograph/react';
+import type { IsographEntrypoint, ResolverFirstParameter, Variables } from '@isograph/react';
 import { type AdItem__AdItemDisplayWrapper__param } from './AdItem/AdItemDisplayWrapper/param_type';
 import { type AdItem__AdItemDisplay__param } from './AdItem/AdItemDisplay/param_type';
 import { type BlogItem__BlogItemDisplay__param } from './BlogItem/BlogItemDisplay/param_type';
@@ -42,9 +42,9 @@ import entrypoint_Query__PetFavoritePhrase from '../__isograph/Query/PetFavorite
 // This means that the type of the exported iso literal is exactly
 // the type of the passed-in function, which takes one parameter
 // of type TParam.
-type IdentityWithParam<TParam> = <TClientFieldReturn>(
+type IdentityWithParam<TParam extends Object> = <TClientFieldReturn, TVariables = Variables>(
   clientField: (param: TParam) => TClientFieldReturn
-) => (param: TParam) => TClientFieldReturn;
+) => (param: ResolverFirstParameter<TParam, TVariables>) => TClientFieldReturn;
 
 // This is the type given it to client fields with @component.
 // This means that the type of the exported iso literal is exactly
@@ -53,9 +53,13 @@ type IdentityWithParam<TParam> = <TClientFieldReturn>(
 //
 // TComponentProps becomes the types of the props you must pass
 // whenever the @component field is rendered.
-type IdentityWithParamComponent<TParam> = <TClientFieldReturn, TComponentProps = Record<string, never>>(
+type IdentityWithParamComponent<TParam extends Object> = <
+  TClientFieldReturn,
+  TComponentProps = Record<string, never>,
+  TVariables = Variables
+>(
   clientComponentField: (data: TParam, componentProps: TComponentProps) => TClientFieldReturn
-) => (data: TParam, componentProps: TComponentProps) => TClientFieldReturn;
+) => (data: ResolverFirstParameter<TParam, TVariables>, componentProps: TComponentProps) => TClientFieldReturn;
 
 type WhitespaceCharacter = ' ' | '\t' | '\n';
 type Whitespace<In> = In extends `${WhitespaceCharacter}${infer In}`

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -50,8 +50,13 @@ export function getOrCreateCachedComponent(
           );
         }
 
-        return readerWithRefetchQueries.readerArtifact.resolver(
+        const firstParameter = {
           data,
+          parameters: fragmentReference.variables,
+        };
+
+        return readerWithRefetchQueries.readerArtifact.resolver(
+          firstParameter,
           additionalRuntimeProps,
         );
       }

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -317,7 +317,12 @@ function readData<TReadFromStore>(
                 nestedReason: data,
               };
             } else {
-              target[field.alias] = field.readerArtifact.resolver(data.data);
+              const firstParameter = {
+                data: data.data,
+                parameters: variables,
+              };
+              target[field.alias] =
+                field.readerArtifact.resolver(firstParameter);
             }
             break;
           }

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -1,5 +1,5 @@
 import { Factory } from '@isograph/disposable-types';
-import { FragmentReference } from './FragmentReference';
+import { FragmentReference, Variables } from './FragmentReference';
 import {
   ComponentOrFieldName,
   DataId,
@@ -17,30 +17,43 @@ export type TopLevelReaderArtifact<
   TReadFromStore extends Object,
   TClientFieldValue,
   TComponentProps extends Record<string, never>,
+  TVariables = Variables,
 > =
-  | EagerReaderArtifact<TReadFromStore, TClientFieldValue>
-  | ComponentReaderArtifact<TReadFromStore, TComponentProps>;
+  | EagerReaderArtifact<TReadFromStore, TClientFieldValue, TVariables>
+  | ComponentReaderArtifact<TReadFromStore, TComponentProps, TVariables>;
 
 export type EagerReaderArtifact<
   TReadFromStore extends Object,
   TClientFieldValue,
+  TVariables = Variables,
 > = {
   readonly kind: 'EagerReaderArtifact';
   readonly readerAst: ReaderAst<TReadFromStore>;
-  readonly resolver: (data: TReadFromStore) => TClientFieldValue;
+  readonly resolver: (
+    data: ResolverFirstParameter<TReadFromStore, TVariables>,
+  ) => TClientFieldValue;
 };
 
 export type ComponentReaderArtifact<
   TReadFromStore extends Object,
   TComponentProps extends Record<string, unknown> = Record<string, never>,
+  TVariables = Variables,
 > = {
   readonly kind: 'ComponentReaderArtifact';
   readonly componentName: ComponentOrFieldName;
   readonly readerAst: ReaderAst<TReadFromStore>;
   readonly resolver: (
-    data: TReadFromStore,
+    data: ResolverFirstParameter<TReadFromStore, TVariables>,
     runtimeProps: TComponentProps,
   ) => React.ReactNode;
+};
+
+export type ResolverFirstParameter<
+  TReadFromStore extends Object,
+  TVariables = Variables,
+> = {
+  readonly data: TReadFromStore;
+  readonly parameters: TVariables;
 };
 
 export type RefetchReaderArtifact = {

--- a/libs/isograph-react/src/index.ts
+++ b/libs/isograph-react/src/index.ts
@@ -37,6 +37,7 @@ export {
   type ReaderScalarField,
   type TopLevelReaderArtifact,
   type LoadableField,
+  type ResolverFirstParameter,
 } from './core/reader';
 export {
   type NormalizationAst,

--- a/libs/isograph-react/src/react/useResult.ts
+++ b/libs/isograph-react/src/react/useResult.ts
@@ -45,7 +45,11 @@ export function useResult<TReadFromStore extends Object, TClientFieldValue>(
         networkRequestOptions,
         readerWithRefetchQueries.readerArtifact.readerAst,
       );
-      return readerWithRefetchQueries.readerArtifact.resolver(data);
+      const firstParameter = {
+        data: data,
+        parameters: fragmentReference.variables,
+      };
+      return readerWithRefetchQueries.readerArtifact.resolver(firstParameter);
     }
   }
 }

--- a/libs/isograph-react/src/tests/__isograph/Query/meName/param_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/meName/param_type.ts
@@ -1,6 +1,11 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Query__meName__param = {
-  me: {
-    name: string,
+  data: {
+    me: {
+      name: string,
+    },
   },
+  parameters: Variables,
 };

--- a/libs/isograph-react/src/tests/__isograph/Query/meNameSuccessor/param_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/meNameSuccessor/param_type.ts
@@ -1,11 +1,16 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Query__meNameSuccessor__param = {
-  me: {
-    name: string,
-    successor: ({
+  data: {
+    me: {
+      name: string,
       successor: ({
-        name: string,
+        successor: ({
+          name: string,
+        } | null),
       } | null),
-    } | null),
+    },
   },
+  parameters: Variables,
 };

--- a/libs/isograph-react/src/tests/__isograph/Query/nodeField/param_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/nodeField/param_type.ts
@@ -1,6 +1,11 @@
 
+import { type Variables } from '@isograph/react';
+
 export type Query__nodeField__param = {
-  node: ({
-    id: string,
-  } | null),
+  data: {
+    node: ({
+      id: string,
+    } | null),
+  },
+  parameters: Variables,
 };

--- a/libs/isograph-react/src/tests/__isograph/iso.ts
+++ b/libs/isograph-react/src/tests/__isograph/iso.ts
@@ -1,4 +1,4 @@
-import type { IsographEntrypoint } from '@isograph/react';
+import type { IsographEntrypoint, ResolverFirstParameter, Variables } from '@isograph/react';
 import { type Query__meNameSuccessor__param } from './Query/meNameSuccessor/param_type';
 import { type Query__meName__param } from './Query/meName/param_type';
 import { type Query__nodeField__param } from './Query/nodeField/param_type';
@@ -10,9 +10,9 @@ import entrypoint_Query__nodeField from '../__isograph/Query/nodeField/entrypoin
 // This means that the type of the exported iso literal is exactly
 // the type of the passed-in function, which takes one parameter
 // of type TParam.
-type IdentityWithParam<TParam> = <TClientFieldReturn>(
+type IdentityWithParam<TParam extends Object> = <TClientFieldReturn, TVariables = Variables>(
   clientField: (param: TParam) => TClientFieldReturn
-) => (param: TParam) => TClientFieldReturn;
+) => (param: ResolverFirstParameter<TParam, TVariables>) => TClientFieldReturn;
 
 // This is the type given it to client fields with @component.
 // This means that the type of the exported iso literal is exactly
@@ -21,9 +21,13 @@ type IdentityWithParam<TParam> = <TClientFieldReturn>(
 //
 // TComponentProps becomes the types of the props you must pass
 // whenever the @component field is rendered.
-type IdentityWithParamComponent<TParam> = <TClientFieldReturn, TComponentProps = Record<string, never>>(
+type IdentityWithParamComponent<TParam extends Object> = <
+  TClientFieldReturn,
+  TComponentProps = Record<string, never>,
+  TVariables = Variables
+>(
   clientComponentField: (data: TParam, componentProps: TComponentProps) => TClientFieldReturn
-) => (data: TParam, componentProps: TComponentProps) => TClientFieldReturn;
+) => (data: ResolverFirstParameter<TParam, TVariables>, componentProps: TComponentProps) => TClientFieldReturn;
 
 type WhitespaceCharacter = ' ' | '\t' | '\n';
 type Whitespace<In> = In extends `${WhitespaceCharacter}${infer In}`


### PR DESCRIPTION
Closes #116 

This PR exposes `parameters` field to `EagerReaderArtifact` and `ComponentReaderArtifact` resolvers.

It has been temporarily added as `Variables` type. In the next PR it should be replaced by a generated type.