### PR TITLE
chore: Run most Rust tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,20 @@ jobs:
         run: cargo clippy
       - name: 'Check working directory status'
         run: './scripts/check-git-status.sh'
+  
+  cargo_test:
+    name: Run cargo test (excluding relay tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+      - name: Run cargo test
+        run: cargo test
 
   all-checks-passed:
     name: All checks passed
@@ -215,6 +229,7 @@ jobs:
         build-website,
         prettier,
         rustfmt,
+        cargo_test,
         typecheck-demos,
       ]
     steps:


### PR DESCRIPTION
# chore: Run most Rust tests in CI

## What
- Adds another job to the CI Actions that runs `cargo test` for the entire repository

## How
- Copied the `rustfmt` job and tweaked it
- Added it to the dependent jobs for `all-checks-passed`