### PR TITLE
add jsdoc to babel plugin

### DIFF
--- a/libs/isograph-babel-plugin/BabelPluginIsograph.js
+++ b/libs/isograph-babel-plugin/BabelPluginIsograph.js
@@ -10,7 +10,7 @@ const configExplorer = cosmiconfig('isograph', {
   },
 });
 
-/** @type {import("cosmiconfig").Config} */ 
+/** @type {import("cosmiconfig").Config} */
 let IsographConfig;
 const result = configExplorer.searchSync();
 if (result) {
@@ -21,17 +21,16 @@ if (result) {
   );
 }
 
-/** @typedef {import("@babel/core")} babel*/ 
+/** @typedef {import("@babel/core")} babel*/
 
-/** 
+/**
  * @typedef {Object} Context
  * @property  {typeof babel.types} [types]
- * */ 
+ * */
 
-
-/** 
+/**
  * @param {Context} context
- * @returns {babel.PluginObj} */ 
+ * @returns {babel.PluginObj} */
 module.exports = function BabelPluginIsograph(context) {
   const { types } = context;
   if (!types) {
@@ -41,7 +40,7 @@ module.exports = function BabelPluginIsograph(context) {
     );
   }
 
-  /** @type {babel.Visitor<babel.PluginPass>} */ 
+  /** @type {babel.Visitor<babel.PluginPass>} */
   const visitor = {
     CallExpression(path) {
       compileTag(types, path, IsographConfig);

--- a/libs/isograph-babel-plugin/BabelPluginIsograph.js
+++ b/libs/isograph-babel-plugin/BabelPluginIsograph.js
@@ -10,6 +10,7 @@ const configExplorer = cosmiconfig('isograph', {
   },
 });
 
+/** @type {import("cosmiconfig").Config} */ 
 let IsographConfig;
 const result = configExplorer.searchSync();
 if (result) {
@@ -20,6 +21,17 @@ if (result) {
   );
 }
 
+/** @typedef {import("@babel/core")} babel*/ 
+
+/** 
+ * @typedef {Object} Context
+ * @property  {typeof babel.types} [types]
+ * */ 
+
+
+/** 
+ * @param {Context} context
+ * @returns {babel.PluginObj} */ 
 module.exports = function BabelPluginIsograph(context) {
   const { types } = context;
   if (!types) {
@@ -29,6 +41,7 @@ module.exports = function BabelPluginIsograph(context) {
     );
   }
 
+  /** @type {babel.Visitor<babel.PluginPass>} */ 
   const visitor = {
     CallExpression(path) {
       compileTag(types, path, IsographConfig);

--- a/libs/isograph-babel-plugin/compileTag.js
+++ b/libs/isograph-babel-plugin/compileTag.js
@@ -44,7 +44,9 @@ function getTypeAndField(path) {
   }
 
   if (path.node.arguments[0].type !== 'TemplateLiteral') {
-    throw new Error("BabelPluginIsograph: Only template literals are allowed in iso fragments.");
+    throw new Error(
+      'BabelPluginIsograph: Only template literals are allowed in iso fragments.',
+    );
   }
 
   const quasis = path.node.arguments[0].quasis;

--- a/libs/isograph-babel-plugin/package.json
+++ b/libs/isograph-babel-plugin/package.json
@@ -15,6 +15,9 @@
     "url": "git+https://github.com/isographlabs/isograph.git",
     "directory": "libs/isograph-babel-plugin"
   },
+  "scripts": {
+    "tsc": "tsc"
+  },
   "dependencies": {
     "babel-plugin-macros": "^2.0.0",
     "cosmiconfig": "^5.0.5",
@@ -22,6 +25,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@babel/types": "^7.25.6",
+    "@types/babel__core": "^7.20.5",
+    "@types/cosmiconfig": "^5.0.3",
     "prettier": "2.8.8",
     "prettier-plugin-hermes-parser": "0.16.0"
   },

--- a/libs/isograph-babel-plugin/stub.ts
+++ b/libs/isograph-babel-plugin/stub.ts
@@ -3,5 +3,4 @@ declare module 'cosmiconfig' {
   export const loadJson: cosmiconfig.LoaderEntry;
 }
 
-export { };
-
+export {};

--- a/libs/isograph-babel-plugin/stub.ts
+++ b/libs/isograph-babel-plugin/stub.ts
@@ -1,0 +1,7 @@
+import type cosmiconfig from 'cosmiconfig';
+declare module 'cosmiconfig' {
+  export const loadJson: cosmiconfig.LoaderEntry;
+}
+
+export { };
+

--- a/libs/isograph-babel-plugin/tsconfig.json
+++ b/libs/isograph-babel-plugin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "lib": ["es2017", "DOM"]
+  },
+  "include": ["./**/*.ts", "./**/*.js"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,15 @@ importers:
       '@babel/core':
         specifier: ^7.20.0
         version: 7.25.2
+      '@babel/types':
+        specifier: ^7.25.6
+        version: 7.25.6
+      '@types/babel__core':
+        specifier: ^7.20.5
+        version: 7.20.5
+      '@types/cosmiconfig':
+        specifier: ^5.0.3
+        version: 5.0.3
       prettier:
         specifier: 2.8.8
         version: 2.8.8
@@ -4414,6 +4423,35 @@ packages:
       '@types/estree': 1.0.5
     dev: false
 
+  /@types/babel__core@7.20.5:
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+    dependencies:
+      '@babel/parser': 7.25.6
+      '@babel/types': 7.25.6
+      '@types/babel__generator': 7.6.8
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.20.6
+    dev: true
+
+  /@types/babel__generator@7.6.8:
+    resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
+    dependencies:
+      '@babel/types': 7.25.6
+    dev: true
+
+  /@types/babel__template@7.4.4:
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+    dependencies:
+      '@babel/parser': 7.25.6
+      '@babel/types': 7.25.6
+    dev: true
+
+  /@types/babel__traverse@7.20.6:
+    resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
+    dependencies:
+      '@babel/types': 7.25.6
+    dev: true
+
   /@types/body-parser@1.19.5:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
@@ -4449,6 +4487,12 @@ packages:
     dependencies:
       '@types/node': 20.6.0
     dev: false
+
+  /@types/cosmiconfig@5.0.3:
+    resolution: {integrity: sha512-HgTGG7X5y9pLl3pixeo2XtDEFD8rq2EuH+S4mK6teCnAwWMucQl6v1D43hI4Uw1VJh6nu59lxLkqXHRl4uwThA==}
+    dependencies:
+      '@types/node': 20.6.0
+    dev: true
 
   /@types/debug@4.1.12:
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -8486,7 +8530,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
     requiresBuild: true
     dependencies:
       bindings: 1.5.0


### PR DESCRIPTION
I would like to do #65 next, and having types would help a lot

I've used jsdoc to not add a build step for now, it can be added later, I hope that's ok