### PR TITLE
Generate parameter types

### DIFF
--- a/crates/graphql_artifact_generation/src/format_parameter_type.rs
+++ b/crates/graphql_artifact_generation/src/format_parameter_type.rs
@@ -1,0 +1,172 @@
+use common_lang_types::SelectableFieldName;
+use graphql_lang_types::{GraphQLNonNullTypeAnnotation, GraphQLTypeAnnotation};
+
+use isograph_lang_types::{ClientFieldId, SelectableServerFieldId, ServerFieldId};
+use isograph_schema::{FieldDefinitionLocation, TypeAnnotation, UnionVariant, ValidatedSchema};
+
+pub(crate) fn format_parameter_type(
+    schema: &ValidatedSchema,
+    type_: GraphQLTypeAnnotation<SelectableServerFieldId>,
+    indentation_level: u8,
+) -> String {
+    match type_ {
+        GraphQLTypeAnnotation::Named(named_inner_type) => {
+            format!(
+                "{} | null | void",
+                format_server_field_type(schema, named_inner_type.item, indentation_level)
+            )
+        }
+        GraphQLTypeAnnotation::List(list) => {
+            format!(
+                "ReadonlyArray<{}> | null",
+                format_server_field_type(schema, *list.inner(), indentation_level)
+            )
+        }
+        GraphQLTypeAnnotation::NonNull(non_null) => match *non_null {
+            GraphQLNonNullTypeAnnotation::Named(named_inner_type) => {
+                format_server_field_type(schema, named_inner_type.item, indentation_level)
+            }
+            GraphQLNonNullTypeAnnotation::List(list) => {
+                format!(
+                    "ReadonlyArray<{}>",
+                    format_server_field_type(schema, *list.inner(), indentation_level)
+                )
+            }
+        },
+    }
+}
+
+fn format_server_field_type(
+    schema: &ValidatedSchema,
+    field: SelectableServerFieldId,
+    indentation_level: u8,
+) -> String {
+    match field {
+        SelectableServerFieldId::Object(object_id) => {
+            let mut s = "{\n".to_string();
+            for (name, field_definition) in schema
+                .server_field_data
+                .object(object_id)
+                .encountered_fields
+                .iter()
+                .filter(|x| matches!(
+                    x.1,
+                    FieldDefinitionLocation::Server(server_field_id) if schema.server_field(*server_field_id).is_discriminator == false),
+                )
+            {
+                let field_type =
+                    format_field_definition(schema, name, field_definition, indentation_level + 1);
+                s.push_str(&field_type)
+            }
+            s.push_str(&format!("{}}}", "  ".repeat(indentation_level as usize)));
+            s
+        }
+        SelectableServerFieldId::Scalar(scalar_id) => schema
+            .server_field_data
+            .scalar(scalar_id)
+            .javascript_name
+            .to_string(),
+    }
+}
+
+fn format_field_definition(
+    schema: &ValidatedSchema,
+    name: &SelectableFieldName,
+    type_: &FieldDefinitionLocation<ServerFieldId, ClientFieldId>,
+    indentation_level: u8,
+) -> String {
+    match type_ {
+        FieldDefinitionLocation::Server(server_field_id) => {
+            let type_annotation = &schema.server_field(*server_field_id).associated_data;
+            format!(
+                "{}readonly {}: {},\n",
+                "  ".repeat(indentation_level as usize),
+                name,
+                format_type_annotation(schema, type_annotation, indentation_level + 1),
+            )
+        }
+        FieldDefinitionLocation::Client(_) => {
+            panic!(
+                "Unexpected object. Client fields are not supported as parameters, yet. \
+                This is indicative of an unimplemented feature in Isograph."
+            )
+        }
+    }
+}
+
+fn format_type_annotation(
+    schema: &ValidatedSchema,
+    type_annotation: &TypeAnnotation<SelectableServerFieldId>,
+    indentation_level: u8,
+) -> String {
+    match &type_annotation {
+        TypeAnnotation::Scalar(scalar) => {
+            format_server_field_type(schema, *scalar, indentation_level + 1)
+        }
+        TypeAnnotation::Union(union_type_annotation) => {
+            if union_type_annotation.variants.is_empty() {
+                panic!("Unexpected union with not enough variants.");
+            }
+
+            let mut s = String::new();
+            if union_type_annotation.variants.len() > 1 || union_type_annotation.nullable {
+                s.push('(');
+                for (index, variant) in union_type_annotation.variants.iter().enumerate() {
+                    if index != 0 {
+                        s.push_str(" | ");
+                    }
+
+                    match variant {
+                        UnionVariant::Scalar(scalar) => {
+                            s.push_str(&format_server_field_type(
+                                schema,
+                                *scalar,
+                                indentation_level + 1,
+                            ));
+                        }
+                        UnionVariant::Plural(type_annotation) => {
+                            s.push_str("ReadonlyArray<");
+                            s.push_str(&format_type_annotation(
+                                schema,
+                                type_annotation,
+                                indentation_level + 1,
+                            ));
+                            s.push('>');
+                        }
+                    }
+                }
+                if union_type_annotation.nullable {
+                    s.push_str(" | null");
+                }
+                s.push(')');
+                s
+            } else {
+                let variant = union_type_annotation
+                    .variants
+                    .first()
+                    .expect("Expected variant to exist");
+                match variant {
+                    UnionVariant::Scalar(scalar) => {
+                        format_server_field_type(schema, *scalar, indentation_level + 1)
+                    }
+                    UnionVariant::Plural(type_annotation) => {
+                        format!(
+                            "ReadonlyArray<{}>",
+                            format_server_field_type(
+                                schema,
+                                type_annotation.inner(),
+                                indentation_level + 1
+                            )
+                        )
+                    }
+                }
+            }
+        }
+        TypeAnnotation::Plural(type_annotation) => {
+            format!(
+                "ReadonlyArray<{}>",
+                format_server_field_type(schema, type_annotation.inner(), indentation_level + 1)
+            )
+        }
+    }
+}

--- a/crates/graphql_artifact_generation/src/iso_overload_file.rs
+++ b/crates/graphql_artifact_generation/src/iso_overload_file.rs
@@ -72,18 +72,16 @@ export function iso<T>(
 }
 
 pub(crate) fn build_iso_overload(schema: &ValidatedSchema) -> ArtifactPathAndContent {
-    let mut imports =
-        "import type { IsographEntrypoint, ResolverFirstParameter, Variables } from '@isograph/react';\n"
-            .to_string();
+    let mut imports = "import type { IsographEntrypoint } from '@isograph/react';\n".to_string();
     let mut content = String::from(
         "
 // This is the type given to regular client fields.
 // This means that the type of the exported iso literal is exactly
 // the type of the passed-in function, which takes one parameter
 // of type TParam.
-type IdentityWithParam<TParam extends object> = <TClientFieldReturn, TVariables = Variables>(
+type IdentityWithParam<TParam extends object> = <TClientFieldReturn>(
   clientField: (param: TParam) => TClientFieldReturn
-) => (param: ResolverFirstParameter<TParam, TVariables>) => TClientFieldReturn;
+) => (param: TParam) => TClientFieldReturn;
 
 // This is the type given it to client fields with @component.
 // This means that the type of the exported iso literal is exactly
@@ -95,10 +93,9 @@ type IdentityWithParam<TParam extends object> = <TClientFieldReturn, TVariables 
 type IdentityWithParamComponent<TParam extends object> = <
   TClientFieldReturn,
   TComponentProps = Record<string, never>,
-  TVariables = Variables
 >(
   clientComponentField: (data: TParam, componentProps: TComponentProps) => TClientFieldReturn
-) => (data: ResolverFirstParameter<TParam, TVariables>, componentProps: TComponentProps) => TClientFieldReturn;
+) => (data: TParam, componentProps: TComponentProps) => TClientFieldReturn;
 
 type WhitespaceCharacter = ' ' | '\\t' | '\\n';
 type Whitespace<In> = In extends `${WhitespaceCharacter}${infer In}`

--- a/crates/graphql_artifact_generation/src/lib.rs
+++ b/crates/graphql_artifact_generation/src/lib.rs
@@ -1,5 +1,6 @@
 mod eager_reader_artifact;
 mod entrypoint_artifact;
+mod format_parameter_type;
 mod generate_artifacts;
 mod imperatively_loaded_fields;
 mod import_statements;

--- a/demos/github-demo/src/isograph-components/PullRequestRoute.tsx
+++ b/demos/github-demo/src/isograph-components/PullRequestRoute.tsx
@@ -49,7 +49,6 @@ export function PullRequestRoute({
       pullRequestNumber: route.pullRequestNumber,
       repositoryName: route.repositoryName,
       repositoryOwner: route.repositoryOwner,
-      last: 20,
     },
   );
 

--- a/demos/github-demo/src/isograph-components/UserRoute.tsx
+++ b/demos/github-demo/src/isograph-components/UserRoute.tsx
@@ -47,7 +47,6 @@ export function UserRoute({
     iso(`entrypoint Query.UserPage`),
     {
       userLogin: route.userLogin,
-      first: 20,
     },
   );
   const Component = useResult(fragmentReference, {});

--- a/demos/github-demo/src/isograph-components/__isograph/Actor/UserLink/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Actor/UserLink/param_type.ts
@@ -1,12 +1,10 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Actor__UserLink__param = {
   readonly data: {
-        /**
+    /**
 The username of the actor.
     */
-readonly login: string,
+    readonly login: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/IssueComment/formattedCommentCreationDate/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/IssueComment/formattedCommentCreationDate/param_type.ts
@@ -1,12 +1,10 @@
 
-import { type Variables } from '@isograph/react';
-
 export type IssueComment__formattedCommentCreationDate__param = {
   readonly data: {
-        /**
+    /**
 Identifies the date and time when the object was created.
     */
-readonly createdAt: string,
+    readonly createdAt: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequest/CommentList/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequest/CommentList/param_type.ts
@@ -1,7 +1,5 @@
 import { type IssueComment__formattedCommentCreationDate__output_type } from '../../IssueComment/formattedCommentCreationDate/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type PullRequest__CommentList__param = {
   readonly data: {
     /**
@@ -16,27 +14,27 @@ A list of edges.
 The item at the end of the edge.
         */
         readonly node: ({
-                    /**
+          /**
 The Node ID of the IssueComment object
           */
-readonly id: string,
-                    /**
+          readonly id: string,
+          /**
 The body rendered to text.
           */
-readonly bodyText: string,
+          readonly bodyText: string,
           readonly formattedCommentCreationDate: IssueComment__formattedCommentCreationDate__output_type,
           /**
 The actor who authored the comment.
           */
           readonly author: ({
-                        /**
+            /**
 The username of the actor.
             */
-readonly login: string,
+            readonly login: string,
           } | null),
         } | null),
       } | null)> | null),
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequest/PullRequestLink/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequest/PullRequestLink/param_type.ts
@@ -1,30 +1,28 @@
 
-import { type Variables } from '@isograph/react';
-
 export type PullRequest__PullRequestLink__param = {
   readonly data: {
-        /**
+    /**
 Identifies the pull request number.
     */
-readonly number: number,
+    readonly number: number,
     /**
 The repository associated with this node.
     */
     readonly repository: {
-            /**
+      /**
 The name of the repository.
       */
-readonly name: string,
+      readonly name: string,
       /**
 The User owner of the repository.
       */
       readonly owner: {
-                /**
+        /**
 The username used to login.
         */
-readonly login: string,
+        readonly login: string,
       },
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequest/createdAtFormatted/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequest/createdAtFormatted/param_type.ts
@@ -1,12 +1,10 @@
 
-import { type Variables } from '@isograph/react';
-
 export type PullRequest__createdAtFormatted__param = {
   readonly data: {
-        /**
+    /**
 Identifies the date and time when the object was created.
     */
-readonly createdAt: string,
+    readonly createdAt: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequestConnection/PullRequestTable/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequestConnection/PullRequestTable/param_type.ts
@@ -2,8 +2,6 @@ import { type Actor__UserLink__output_type } from '../../Actor/UserLink/output_t
 import { type PullRequest__PullRequestLink__output_type } from '../../PullRequest/PullRequestLink/output_type';
 import { type PullRequest__createdAtFormatted__output_type } from '../../PullRequest/createdAtFormatted/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type PullRequestConnection__PullRequestTable__param = {
   readonly data: {
     /**
@@ -14,40 +12,40 @@ A list of edges.
 The item at the end of the edge.
       */
       readonly node: ({
-                /**
+        /**
 The Node ID of the PullRequest object
         */
-readonly id: string,
+        readonly id: string,
         readonly PullRequestLink: PullRequest__PullRequestLink__output_type,
-                /**
+        /**
 Identifies the pull request number.
         */
-readonly number: number,
-                /**
+        readonly number: number,
+        /**
 Identifies the pull request title.
         */
-readonly title: string,
+        readonly title: string,
         /**
 The actor who authored the comment.
         */
         readonly author: ({
           readonly UserLink: Actor__UserLink__output_type,
-                    /**
+          /**
 The username of the actor.
           */
-readonly login: string,
+          readonly login: string,
         } | null),
-                /**
+        /**
 `true` if the pull request is closed
         */
-readonly closed: boolean,
-                /**
+        readonly closed: boolean,
+        /**
 Returns a count of how many comments this pull request has received.
         */
-readonly totalCommentsCount: (number | null),
+        readonly totalCommentsCount: (number | null),
         readonly createdAtFormatted: PullRequest__createdAtFormatted__output_type,
       } | null),
     } | null)> | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/Header/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/Header/param_type.ts
@@ -1,19 +1,17 @@
 import { type User__Avatar__output_type } from '../../User/Avatar/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Query__Header__param = {
   readonly data: {
     /**
 The currently authenticated user.
     */
     readonly viewer: {
-            /**
+      /**
 The user's public profile name.
       */
-readonly name: (string | null),
+      readonly name: (string | null),
       readonly Avatar: User__Avatar__output_type,
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/param_type.ts
@@ -1,12 +1,10 @@
 import { type Query__Header__output_type } from '../../Query/Header/output_type';
 import { type Query__HomePageList__output_type } from '../../Query/HomePageList/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Query__HomePage__param = {
   readonly data: {
     readonly Header: Query__Header__output_type,
     readonly HomePageList: Query__HomePageList__output_type,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/HomePageList/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/HomePageList/param_type.ts
@@ -1,22 +1,20 @@
 import { type User__RepositoryList__output_type } from '../../User/RepositoryList/output_type';
 import { type User____refetch__output_type } from '../../User/__refetch/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Query__HomePageList__param = {
   readonly data: {
     /**
 The currently authenticated user.
     */
     readonly viewer: {
-            /**
+      /**
 The username used to login.
       */
-readonly login: string,
-            /**
+      readonly login: string,
+      /**
 The user's public profile name.
       */
-readonly name: (string | null),
+      readonly name: (string | null),
       readonly RepositoryList: User__RepositoryList__output_type,
       /**
 A refetch field for the User type.
@@ -24,5 +22,5 @@ A refetch field for the User type.
       readonly __refetch: User____refetch__output_type,
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/param_type.ts
@@ -1,12 +1,11 @@
 import { type Query__Header__output_type } from '../../Query/Header/output_type';
 import { type Query__PullRequestDetail__output_type } from '../../Query/PullRequestDetail/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__PullRequest__parameters } from './parameters_type';
 
 export type Query__PullRequest__param = {
   readonly data: {
     readonly Header: Query__Header__output_type,
     readonly PullRequestDetail: Query__PullRequestDetail__output_type,
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__PullRequest__parameters,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/parameters_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/parameters_type.ts
@@ -1,0 +1,5 @@
+export type Query__PullRequest__parameters = {
+  readonly repositoryOwner: string,
+  readonly repositoryName: string,
+  readonly pullRequestNumber: number,
+};

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/param_type.ts
@@ -1,6 +1,5 @@
 import { type PullRequest__CommentList__output_type } from '../../PullRequest/CommentList/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__PullRequestDetail__parameters } from './parameters_type';
 
 export type Query__PullRequestDetail__param = {
   readonly data: {
@@ -12,17 +11,17 @@ Lookup a given repository by the owner and repository name.
 Returns a single pull request from the current repository by number.
       */
       readonly pullRequest: ({
-                /**
+        /**
 Identifies the pull request title.
         */
-readonly title: string,
-                /**
+        readonly title: string,
+        /**
 The body rendered to HTML.
         */
-readonly bodyHTML: string,
+        readonly bodyHTML: string,
         readonly CommentList: PullRequest__CommentList__output_type,
       } | null),
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__PullRequestDetail__parameters,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/parameters_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/parameters_type.ts
@@ -1,0 +1,5 @@
+export type Query__PullRequestDetail__parameters = {
+  readonly repositoryOwner?: string | null | void,
+  readonly repositoryName?: string | null | void,
+  readonly pullRequestNumber?: number | null | void,
+};

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/param_type.ts
@@ -1,8 +1,7 @@
 import { type PullRequestConnection__PullRequestTable__output_type } from '../../PullRequestConnection/PullRequestTable/output_type';
 import { type Repository__RepositoryLink__output_type } from '../../Repository/RepositoryLink/output_type';
 import { type Starrable__IsStarred__output_type } from '../../Starrable/IsStarred/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__RepositoryDetail__parameters } from './parameters_type';
 
 export type Query__RepositoryDetail__param = {
   readonly data: {
@@ -11,19 +10,19 @@ Lookup a given repository by the owner and repository name.
     */
     readonly repository: ({
       readonly IsStarred: Starrable__IsStarred__output_type,
-            /**
+      /**
 The repository's name with owner.
       */
-readonly nameWithOwner: string,
+      readonly nameWithOwner: string,
       /**
 The repository parent, if this is a fork.
       */
       readonly parent: ({
         readonly RepositoryLink: Repository__RepositoryLink__output_type,
-                /**
+        /**
 The repository's name with owner.
         */
-readonly nameWithOwner: string,
+        readonly nameWithOwner: string,
       } | null),
       /**
 A list of pull requests that have been opened in the repository.
@@ -33,5 +32,5 @@ A list of pull requests that have been opened in the repository.
       },
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__RepositoryDetail__parameters,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/parameters_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/parameters_type.ts
@@ -1,0 +1,5 @@
+export type Query__RepositoryDetail__parameters = {
+  readonly first?: number | null | void,
+  readonly repositoryName?: string | null | void,
+  readonly repositoryOwner?: string | null | void,
+};

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/param_type.ts
@@ -1,12 +1,11 @@
 import { type Query__Header__output_type } from '../../Query/Header/output_type';
 import { type Query__RepositoryDetail__output_type } from '../../Query/RepositoryDetail/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__RepositoryPage__parameters } from './parameters_type';
 
 export type Query__RepositoryPage__param = {
   readonly data: {
     readonly Header: Query__Header__output_type,
     readonly RepositoryDetail: Query__RepositoryDetail__output_type,
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__RepositoryPage__parameters,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/parameters_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/parameters_type.ts
@@ -1,0 +1,5 @@
+export type Query__RepositoryPage__parameters = {
+  readonly repositoryName: string,
+  readonly repositoryOwner: string,
+  readonly first: number,
+};

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/param_type.ts
@@ -1,6 +1,5 @@
 import { type User__RepositoryList__output_type } from '../../User/RepositoryList/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__UserDetail__parameters } from './parameters_type';
 
 export type Query__UserDetail__param = {
   readonly data: {
@@ -8,12 +7,12 @@ export type Query__UserDetail__param = {
 Lookup a user by login.
     */
     readonly user: ({
-            /**
+      /**
 The user's public profile name.
       */
-readonly name: (string | null),
+      readonly name: (string | null),
       readonly RepositoryList: User__RepositoryList__output_type,
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__UserDetail__parameters,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/parameters_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__UserDetail__parameters = {
+  readonly userLogin?: string | null | void,
+};

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/param_type.ts
@@ -1,12 +1,11 @@
 import { type Query__Header__output_type } from '../../Query/Header/output_type';
 import { type Query__UserDetail__output_type } from '../../Query/UserDetail/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__UserPage__parameters } from './parameters_type';
 
 export type Query__UserPage__param = {
   readonly data: {
     readonly Header: Query__Header__output_type,
     readonly UserDetail: Query__UserDetail__output_type,
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__UserPage__parameters,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/parameters_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__UserPage__parameters = {
+  readonly userLogin: string,
+};

--- a/demos/github-demo/src/isograph-components/__isograph/Repository/RepositoryLink/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Repository/RepositoryLink/param_type.ts
@@ -1,25 +1,23 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Repository__RepositoryLink__param = {
   readonly data: {
-        /**
+    /**
 The Node ID of the Repository object
     */
-readonly id: string,
-        /**
+    readonly id: string,
+    /**
 The name of the repository.
     */
-readonly name: string,
+    readonly name: string,
     /**
 The User owner of the repository.
     */
     readonly owner: {
-            /**
+      /**
 The username used to login.
       */
-readonly login: string,
+      readonly login: string,
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Starrable/IsStarred/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Starrable/IsStarred/param_type.ts
@@ -1,16 +1,14 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Starrable__IsStarred__param = {
   readonly data: {
-        /**
+    /**
 Returns a count of how many stargazers there are on this object
     */
-readonly stargazerCount: number,
-        /**
+    readonly stargazerCount: number,
+    /**
 Returns a boolean indicating whether the viewing user has starred this starrable.
     */
-readonly viewerHasStarred: boolean,
+    readonly viewerHasStarred: boolean,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/User/Avatar/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/Avatar/param_type.ts
@@ -1,16 +1,14 @@
 
-import { type Variables } from '@isograph/react';
-
 export type User__Avatar__param = {
   readonly data: {
-        /**
+    /**
 The user's public profile name.
     */
-readonly name: (string | null),
-        /**
+    readonly name: (string | null),
+    /**
 A URL pointing to the user's public avatar.
     */
-readonly avatarUrl: string,
+    readonly avatarUrl: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/User/RepositoryList/param_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/RepositoryList/param_type.ts
@@ -1,7 +1,5 @@
 import { type Repository__RepositoryLink__output_type } from '../../Repository/RepositoryLink/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type User__RepositoryList__param = {
   readonly data: {
     /**
@@ -16,52 +14,52 @@ A list of edges.
 The item at the end of the edge.
         */
         readonly node: ({
-                    /**
+          /**
 The Node ID of the Repository object
           */
-readonly id: string,
+          readonly id: string,
           readonly RepositoryLink: Repository__RepositoryLink__output_type,
-                    /**
+          /**
 The name of the repository.
           */
-readonly name: string,
-                    /**
+          readonly name: string,
+          /**
 The repository's name with owner.
           */
-readonly nameWithOwner: string,
-                    /**
+          readonly nameWithOwner: string,
+          /**
 The description of the repository.
           */
-readonly description: (string | null),
-                    /**
+          readonly description: (string | null),
+          /**
 Returns how many forks there are of this repository in the whole network.
           */
-readonly forkCount: number,
+          readonly forkCount: number,
           /**
 A list of pull requests that have been opened in the repository.
           */
           readonly pullRequests: {
-                        /**
+            /**
 Identifies the total count of items in the connection.
             */
-readonly totalCount: number,
+            readonly totalCount: number,
           },
-                    /**
+          /**
 Returns a count of how many stargazers there are on this object
           */
-readonly stargazerCount: number,
+          readonly stargazerCount: number,
           /**
 A list of users watching the repository.
           */
           readonly watchers: {
-                        /**
+            /**
 Identifies the total count of items in the connection.
             */
-readonly totalCount: number,
+            readonly totalCount: number,
           },
         } | null),
       } | null)> | null),
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/iso.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/iso.ts
@@ -1,4 +1,4 @@
-import type { IsographEntrypoint, ResolverFirstParameter, Variables } from '@isograph/react';
+import type { IsographEntrypoint } from '@isograph/react';
 import { type Actor__UserLink__param } from './Actor/UserLink/param_type';
 import { type IssueComment__formattedCommentCreationDate__param } from './IssueComment/formattedCommentCreationDate/param_type';
 import { type PullRequest__CommentList__param } from './PullRequest/CommentList/param_type';
@@ -27,9 +27,9 @@ import entrypoint_Query__UserPage from '../__isograph/Query/UserPage/entrypoint'
 // This means that the type of the exported iso literal is exactly
 // the type of the passed-in function, which takes one parameter
 // of type TParam.
-type IdentityWithParam<TParam extends object> = <TClientFieldReturn, TVariables = Variables>(
+type IdentityWithParam<TParam extends object> = <TClientFieldReturn>(
   clientField: (param: TParam) => TClientFieldReturn
-) => (param: ResolverFirstParameter<TParam, TVariables>) => TClientFieldReturn;
+) => (param: TParam) => TClientFieldReturn;
 
 // This is the type given it to client fields with @component.
 // This means that the type of the exported iso literal is exactly
@@ -41,10 +41,9 @@ type IdentityWithParam<TParam extends object> = <TClientFieldReturn, TVariables 
 type IdentityWithParamComponent<TParam extends object> = <
   TClientFieldReturn,
   TComponentProps = Record<string, never>,
-  TVariables = Variables
 >(
   clientComponentField: (data: TParam, componentProps: TComponentProps) => TClientFieldReturn
-) => (data: ResolverFirstParameter<TParam, TVariables>, componentProps: TComponentProps) => TClientFieldReturn;
+) => (data: TParam, componentProps: TComponentProps) => TClientFieldReturn;
 
 type WhitespaceCharacter = ' ' | '\t' | '\n';
 type Whitespace<In> = In extends `${WhitespaceCharacter}${infer In}`

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/param_type.ts
@@ -1,10 +1,8 @@
 
-import { type Variables } from '@isograph/react';
-
 export type AdItem__AdItemDisplay__param = {
   readonly data: {
     readonly advertiser: string,
     readonly message: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplayWrapper/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplayWrapper/param_type.ts
@@ -1,11 +1,9 @@
 import { type AdItem__AdItemDisplay__output_type } from '../../AdItem/AdItemDisplay/output_type';
-
 import { type LoadableField } from '@isograph/react';
-import { type Variables } from '@isograph/react';
 
 export type AdItem__AdItemDisplayWrapper__param = {
   readonly data: {
     readonly AdItemDisplay: LoadableField<void, AdItem__AdItemDisplay__output_type>,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemDisplay/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemDisplay/param_type.ts
@@ -1,8 +1,6 @@
 import { type BlogItem__BlogItemMoreDetail__output_type } from '../../BlogItem/BlogItemMoreDetail/output_type';
 import { type Image__ImageDisplayWrapper__output_type } from '../../Image/ImageDisplayWrapper/output_type';
-
 import { type LoadableField } from '@isograph/react';
-import { type Variables } from '@isograph/react';
 
 export type BlogItem__BlogItemDisplay__param = {
   readonly data: {
@@ -14,5 +12,5 @@ export type BlogItem__BlogItemDisplay__param = {
       readonly ImageDisplayWrapper: Image__ImageDisplayWrapper__output_type,
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/param_type.ts
@@ -1,9 +1,7 @@
 
-import { type Variables } from '@isograph/react';
-
 export type BlogItem__BlogItemMoreDetail__param = {
   readonly data: {
     readonly moreContent: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Checkin/CheckinDisplay/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Checkin/CheckinDisplay/param_type.ts
@@ -1,12 +1,10 @@
 import { type ICheckin__make_super__output_type } from '../../ICheckin/make_super/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Checkin__CheckinDisplay__param = {
   readonly data: {
     readonly location: string,
     readonly time: string,
     readonly make_super: ICheckin__make_super__output_type,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/param_type.ts
@@ -1,9 +1,7 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Image__ImageDisplay__param = {
   readonly data: {
     readonly url: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplayWrapper/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplayWrapper/param_type.ts
@@ -1,11 +1,9 @@
 import { type Image__ImageDisplay__output_type } from '../../Image/ImageDisplay/output_type';
-
 import { type LoadableField } from '@isograph/react';
-import { type Variables } from '@isograph/react';
 
 export type Image__ImageDisplayWrapper__param = {
   readonly data: {
     readonly ImageDisplay: LoadableField<void, Image__ImageDisplay__output_type>,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/param_type.ts
@@ -1,5 +1,4 @@
-
-import { type Variables } from '@isograph/react';
+import type { Mutation__SetTagline__parameters } from './parameters_type';
 
 export type Mutation__SetTagline__param = {
   readonly data: {
@@ -9,5 +8,5 @@ export type Mutation__SetTagline__param = {
       },
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Mutation__SetTagline__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/parameters_type.ts
@@ -1,0 +1,6 @@
+export type Mutation__SetTagline__parameters = {
+  readonly input: {
+    readonly id: string,
+    readonly tagline: string,
+  },
+};

--- a/demos/pet-demo/src/components/__isograph/NewsfeedItem/NewsfeedAdOrBlog/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/NewsfeedItem/NewsfeedAdOrBlog/param_type.ts
@@ -1,8 +1,6 @@
 import { type AdItem__AdItemDisplayWrapper__output_type } from '../../AdItem/AdItemDisplayWrapper/output_type';
 import { type BlogItem__BlogItemDisplay__output_type } from '../../BlogItem/BlogItemDisplay/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type NewsfeedItem__NewsfeedAdOrBlog__param = {
   readonly data: {
     readonly adItem: ({
@@ -12,5 +10,5 @@ export type NewsfeedItem__NewsfeedAdOrBlog__param = {
       readonly BlogItemDisplay: BlogItem__BlogItemDisplay__output_type,
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/FavoritePhraseLoader/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/FavoritePhraseLoader/param_type.ts
@@ -1,9 +1,7 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__FavoritePhraseLoader__param = {
   readonly data: {
     readonly id: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/FirstCheckinMakeSuperButton/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/FirstCheckinMakeSuperButton/param_type.ts
@@ -1,7 +1,5 @@
 import { type ICheckin__make_super__output_type } from '../../ICheckin/make_super/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__FirstCheckinMakeSuperButton__param = {
   readonly data: {
     readonly checkins: ReadonlyArray<{
@@ -9,5 +7,5 @@ export type Pet__FirstCheckinMakeSuperButton__param = {
       readonly location: string,
     }>,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetBestFriendCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetBestFriendCard/param_type.ts
@@ -1,7 +1,5 @@
 import { type Pet__PetUpdater__output_type } from '../../Pet/PetUpdater/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__PetBestFriendCard__param = {
   readonly data: {
     readonly id: string,
@@ -20,5 +18,5 @@ You can update the best friend and the tagline.
       },
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/param_type.ts
@@ -1,6 +1,5 @@
 import { type Checkin__CheckinDisplay__output_type } from '../../Checkin/CheckinDisplay/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Pet__PetCheckinsCard__parameters } from './parameters_type';
 
 export type Pet__PetCheckinsCard__param = {
   readonly data: {
@@ -10,5 +9,5 @@ export type Pet__PetCheckinsCard__param = {
       readonly id: string,
     }>,
   },
-  readonly parameters: Variables,
+  readonly parameters: Pet__PetCheckinsCard__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/parameters_type.ts
@@ -1,0 +1,4 @@
+export type Pet__PetCheckinsCard__parameters = {
+  readonly skip?: number | null | void,
+  readonly limit?: number | null | void,
+};

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/param_type.ts
@@ -1,6 +1,5 @@
 import { type Checkin__CheckinDisplay__output_type } from '../../Checkin/CheckinDisplay/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Pet__PetCheckinsCardList__parameters } from './parameters_type';
 
 export type Pet__PetCheckinsCardList__param = {
   readonly data: {
@@ -9,5 +8,5 @@ export type Pet__PetCheckinsCardList__param = {
       readonly id: string,
     }>,
   },
-  readonly parameters: Variables,
+  readonly parameters: Pet__PetCheckinsCardList__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/parameters_type.ts
@@ -1,0 +1,4 @@
+export type Pet__PetCheckinsCardList__parameters = {
+  readonly skip?: number | null | void,
+  readonly limit?: number | null | void,
+};

--- a/demos/pet-demo/src/components/__isograph/Pet/PetDetailDeferredRouteInnerComponent/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetDetailDeferredRouteInnerComponent/param_type.ts
@@ -1,12 +1,10 @@
 import { type Pet__PetCheckinsCard__output_type } from '../../Pet/PetCheckinsCard/output_type';
-
 import { type LoadableField } from '@isograph/react';
-import { type Variables } from '@isograph/react';
 
 export type Pet__PetDetailDeferredRouteInnerComponent__param = {
   readonly data: {
     readonly name: string,
     readonly PetCheckinsCard: LoadableField<{readonly skip?: number | null | void, readonly limit?: number | null | void}, Pet__PetCheckinsCard__output_type>,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetPhraseCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetPhraseCard/param_type.ts
@@ -1,10 +1,8 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__PetPhraseCard__param = {
   readonly data: {
     readonly id: string,
     readonly favorite_phrase: (string | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetStatsCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetStatsCard/param_type.ts
@@ -1,7 +1,5 @@
 import { type PetStats__refetch_pet_stats__output_type } from '../../PetStats/refetch_pet_stats/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__PetStatsCard__param = {
   readonly data: {
     readonly id: string,
@@ -17,5 +15,5 @@ export type Pet__PetStatsCard__param = {
       readonly refetch_pet_stats: PetStats__refetch_pet_stats__output_type,
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetSummaryCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetSummaryCard/param_type.ts
@@ -1,7 +1,5 @@
 import { type Pet__FavoritePhraseLoader__output_type } from '../../Pet/FavoritePhraseLoader/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__PetSummaryCard__param = {
   readonly data: {
     readonly id: string,
@@ -10,5 +8,5 @@ export type Pet__PetSummaryCard__param = {
     readonly tagline: string,
     readonly FavoritePhraseLoader: Pet__FavoritePhraseLoader__output_type,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetTaglineCard/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetTaglineCard/param_type.ts
@@ -1,10 +1,8 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__PetTaglineCard__param = {
   readonly data: {
     readonly id: string,
     readonly tagline: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetUpdater/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetUpdater/param_type.ts
@@ -2,8 +2,6 @@ import { type Pet____refetch__output_type } from '../../Pet/__refetch/output_typ
 import { type Pet__set_best_friend__output_type } from '../../Pet/set_best_friend/output_type';
 import { type Pet__set_pet_tagline__output_type } from '../../Pet/set_pet_tagline/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__PetUpdater__param = {
   readonly data: {
     readonly set_best_friend: Pet__set_best_friend__output_type,
@@ -18,5 +16,5 @@ A refetch field for the Pet type.
     */
     readonly __refetch: Pet____refetch__output_type,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/Unreachable2/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/Unreachable2/param_type.ts
@@ -1,9 +1,7 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__Unreachable2__param = {
   readonly data: {
     readonly id: string,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/UnreachableFromEntrypoint/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/UnreachableFromEntrypoint/param_type.ts
@@ -1,13 +1,11 @@
 import { type Pet__Unreachable2__output_type } from '../../Pet/Unreachable2/output_type';
 import { type Pet__set_best_friend_do_not_use__output_type } from '../../Pet/set_best_friend_do_not_use/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Pet__UnreachableFromEntrypoint__param = {
   readonly data: {
     readonly id: string,
     readonly Unreachable2: Pet__Unreachable2__output_type,
     readonly set_best_friend_do_not_use: Pet__set_best_friend_do_not_use__output_type,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/HomeRoute/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/HomeRoute/param_type.ts
@@ -1,7 +1,5 @@
 import { type Pet__PetSummaryCard__output_type } from '../../Pet/PetSummaryCard/output_type';
 
-import { type Variables } from '@isograph/react';
-
 export type Query__HomeRoute__param = {
   readonly data: {
     readonly pets: ReadonlyArray<{
@@ -9,5 +7,5 @@ export type Query__HomeRoute__param = {
       readonly PetSummaryCard: Pet__PetSummaryCard__output_type,
     }>,
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/Newsfeed/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/Newsfeed/param_type.ts
@@ -1,8 +1,6 @@
 import { type NewsfeedItem__NewsfeedAdOrBlog__output_type } from '../../NewsfeedItem/NewsfeedAdOrBlog/output_type';
 import { type Viewer__NewsfeedPaginationComponent__output_type } from '../../Viewer/NewsfeedPaginationComponent/output_type';
-
 import { type LoadableField } from '@isograph/react';
-import { type Variables } from '@isograph/react';
 
 export type Query__Newsfeed__param = {
   readonly data: {
@@ -13,5 +11,5 @@ export type Query__Newsfeed__param = {
       readonly NewsfeedPaginationComponent: LoadableField<{readonly skip: number, readonly limit: number}, Viewer__NewsfeedPaginationComponent__output_type>,
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetByName/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetByName/param_type.ts
@@ -1,6 +1,5 @@
 import { type Pet__PetDetailDeferredRouteInnerComponent__output_type } from '../../Pet/PetDetailDeferredRouteInnerComponent/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__PetByName__parameters } from './parameters_type';
 
 export type Query__PetByName__param = {
   readonly data: {
@@ -8,5 +7,5 @@ export type Query__PetByName__param = {
       readonly PetDetailDeferredRouteInnerComponent: Pet__PetDetailDeferredRouteInnerComponent__output_type,
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__PetByName__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetByName/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetByName/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__PetByName__parameters = {
+  readonly name: string,
+};

--- a/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/param_type.ts
@@ -1,8 +1,7 @@
 import { type Pet__FirstCheckinMakeSuperButton__output_type } from '../../Pet/FirstCheckinMakeSuperButton/output_type';
 import { type Pet__PetCheckinsCardList__output_type } from '../../Pet/PetCheckinsCardList/output_type';
-
 import { type LoadableField } from '@isograph/react';
-import { type Variables } from '@isograph/react';
+import type { Query__PetCheckinListRoute__parameters } from './parameters_type';
 
 export type Query__PetCheckinListRoute__param = {
   readonly data: {
@@ -12,5 +11,5 @@ export type Query__PetCheckinListRoute__param = {
       readonly PetCheckinsCardList: LoadableField<{readonly skip?: number | null | void, readonly limit?: number | null | void}, Pet__PetCheckinsCardList__output_type>,
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__PetCheckinListRoute__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__PetCheckinListRoute__parameters = {
+  readonly id: string,
+};

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/param_type.ts
@@ -1,6 +1,5 @@
 import { type Pet__PetDetailDeferredRouteInnerComponent__output_type } from '../../Pet/PetDetailDeferredRouteInnerComponent/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__PetDetailDeferredRoute__parameters } from './parameters_type';
 
 export type Query__PetDetailDeferredRoute__param = {
   readonly data: {
@@ -8,5 +7,5 @@ export type Query__PetDetailDeferredRoute__param = {
       readonly PetDetailDeferredRouteInnerComponent: Pet__PetDetailDeferredRouteInnerComponent__output_type,
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__PetDetailDeferredRoute__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__PetDetailDeferredRoute__parameters = {
+  readonly id: string,
+};

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/param_type.ts
@@ -1,10 +1,9 @@
 import { type Query__PetDetailRouteInner__output_type } from '../../Query/PetDetailRouteInner/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__PetDetailRoute__parameters } from './parameters_type';
 
 export type Query__PetDetailRoute__param = {
   readonly data: {
     readonly PetDetailRouteInner: Query__PetDetailRouteInner__output_type,
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__PetDetailRoute__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__PetDetailRoute__parameters = {
+  readonly id: string,
+};

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRouteInner/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRouteInner/param_type.ts
@@ -3,8 +3,7 @@ import { type Pet__PetCheckinsCard__output_type } from '../../Pet/PetCheckinsCar
 import { type Pet__PetPhraseCard__output_type } from '../../Pet/PetPhraseCard/output_type';
 import { type Pet__PetStatsCard__output_type } from '../../Pet/PetStatsCard/output_type';
 import { type Pet__PetTaglineCard__output_type } from '../../Pet/PetTaglineCard/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Query__PetDetailRouteInner__parameters } from './parameters_type';
 
 export type Query__PetDetailRouteInner__param = {
   readonly data: {
@@ -17,5 +16,5 @@ export type Query__PetDetailRouteInner__param = {
       readonly PetStatsCard: Pet__PetStatsCard__output_type,
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__PetDetailRouteInner__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRouteInner/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRouteInner/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__PetDetailRouteInner__parameters = {
+  readonly actualId: string,
+};

--- a/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/param_type.ts
@@ -1,5 +1,4 @@
-
-import { type Variables } from '@isograph/react';
+import type { Query__PetFavoritePhrase__parameters } from './parameters_type';
 
 export type Query__PetFavoritePhrase__param = {
   readonly data: {
@@ -8,5 +7,5 @@ export type Query__PetFavoritePhrase__param = {
       readonly favorite_phrase: (string | null),
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__PetFavoritePhrase__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__PetFavoritePhrase__parameters = {
+  readonly id: string,
+};

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/param_type.ts
@@ -1,6 +1,5 @@
 import { type NewsfeedItem__NewsfeedAdOrBlog__output_type } from '../../NewsfeedItem/NewsfeedAdOrBlog/output_type';
-
-import { type Variables } from '@isograph/react';
+import type { Viewer__NewsfeedPaginationComponent__parameters } from './parameters_type';
 
 export type Viewer__NewsfeedPaginationComponent__param = {
   readonly data: {
@@ -8,5 +7,5 @@ export type Viewer__NewsfeedPaginationComponent__param = {
       readonly NewsfeedAdOrBlog: NewsfeedItem__NewsfeedAdOrBlog__output_type,
     }>,
   },
-  readonly parameters: Variables,
+  readonly parameters: Viewer__NewsfeedPaginationComponent__parameters,
 };

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/parameters_type.ts
@@ -1,0 +1,4 @@
+export type Viewer__NewsfeedPaginationComponent__parameters = {
+  readonly skip: number,
+  readonly limit: number,
+};

--- a/demos/pet-demo/src/components/__isograph/iso.ts
+++ b/demos/pet-demo/src/components/__isograph/iso.ts
@@ -1,4 +1,4 @@
-import type { IsographEntrypoint, ResolverFirstParameter, Variables } from '@isograph/react';
+import type { IsographEntrypoint } from '@isograph/react';
 import { type AdItem__AdItemDisplayWrapper__param } from './AdItem/AdItemDisplayWrapper/param_type';
 import { type AdItem__AdItemDisplay__param } from './AdItem/AdItemDisplay/param_type';
 import { type BlogItem__BlogItemDisplay__param } from './BlogItem/BlogItemDisplay/param_type';
@@ -43,9 +43,9 @@ import entrypoint_Query__PetFavoritePhrase from '../__isograph/Query/PetFavorite
 // This means that the type of the exported iso literal is exactly
 // the type of the passed-in function, which takes one parameter
 // of type TParam.
-type IdentityWithParam<TParam extends object> = <TClientFieldReturn, TVariables = Variables>(
+type IdentityWithParam<TParam extends object> = <TClientFieldReturn>(
   clientField: (param: TParam) => TClientFieldReturn
-) => (param: ResolverFirstParameter<TParam, TVariables>) => TClientFieldReturn;
+) => (param: TParam) => TClientFieldReturn;
 
 // This is the type given it to client fields with @component.
 // This means that the type of the exported iso literal is exactly
@@ -57,10 +57,9 @@ type IdentityWithParam<TParam extends object> = <TClientFieldReturn, TVariables 
 type IdentityWithParamComponent<TParam extends object> = <
   TClientFieldReturn,
   TComponentProps = Record<string, never>,
-  TVariables = Variables
 >(
   clientComponentField: (data: TParam, componentProps: TComponentProps) => TClientFieldReturn
-) => (data: ResolverFirstParameter<TParam, TVariables>, componentProps: TComponentProps) => TClientFieldReturn;
+) => (data: TParam, componentProps: TComponentProps) => TClientFieldReturn;
 
 type WhitespaceCharacter = ' ' | '\t' | '\n';
 type Whitespace<In> = In extends `${WhitespaceCharacter}${infer In}`

--- a/libs/isograph-react/src/core/FragmentReference.ts
+++ b/libs/isograph-react/src/core/FragmentReference.ts
@@ -7,6 +7,18 @@ export type VariableValue = string | number | boolean | null | object;
 
 export type Variables = { readonly [index: string]: VariableValue };
 
+export type ExtractData<T> = T extends {
+  data: infer D extends object;
+}
+  ? D
+  : never;
+
+export type ExtractParameters<T> = T extends {
+  parameters: infer P extends Variables;
+}
+  ? P
+  : Variables;
+
 export type FragmentReference<
   TReadFromStore extends { parameters: object; data: object },
   TClientFieldValue,
@@ -16,7 +28,7 @@ export type FragmentReference<
     ReaderWithRefetchQueries<TReadFromStore, TClientFieldValue>
   >;
   readonly root: DataId;
-  readonly variables: Variables;
+  readonly variables: ExtractParameters<TReadFromStore>;
   readonly networkRequest: PromiseWrapper<void, any>;
 };
 

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -24,7 +24,11 @@ import {
 import { ReaderLinkedField, ReaderScalarField, type ReaderAst } from './reader';
 import { Argument, ArgumentValue } from './util';
 import { WithEncounteredRecords, readButDoNotEvaluate } from './read';
-import { FragmentReference, Variables } from './FragmentReference';
+import {
+  FragmentReference,
+  Variables,
+  ExtractParameters,
+} from './FragmentReference';
 import { mergeObjectsUsingReaderAst } from './areEqualWithDeepComparison';
 import { makeNetworkRequest } from './makeNetworkRequest';
 import { wrapResolvedValue } from './PromiseWrapper';
@@ -82,7 +86,7 @@ export function getOrCreateCacheForArtifact<
 >(
   environment: IsographEnvironment,
   entrypoint: IsographEntrypoint<TReadFromStore, TClientFieldValue>,
-  variables: Variables,
+  variables: ExtractParameters<TReadFromStore>,
 ): ParentCache<FragmentReference<TReadFromStore, TClientFieldValue>> {
   const cacheKey = entrypoint.queryText + JSON.stringify(stableCopy(variables));
   const factory = () => {
@@ -198,9 +202,7 @@ export function subscribe<
     fragmentReference,
     readerAst,
   };
-  // @ts-expect-error
   environment.subscriptions.add(fragmentSubscription);
-  // @ts-expect-error
   return () => environment.subscriptions.delete(fragmentSubscription);
 }
 

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -5,7 +5,12 @@ import {
   IsographEntrypoint,
   RefetchQueryNormalizationArtifactWrapper,
 } from './entrypoint';
-import { FragmentReference, Variables } from './FragmentReference';
+import {
+  FragmentReference,
+  Variables,
+  ExtractData,
+  ExtractParameters,
+} from './FragmentReference';
 import {
   assertLink,
   DataId,
@@ -26,7 +31,7 @@ import { Arguments } from './util';
 
 export type WithEncounteredRecords<T> = {
   readonly encounteredRecords: Set<DataId>;
-  readonly item: T;
+  readonly item: ExtractData<T>;
 };
 
 export function readButDoNotEvaluate<
@@ -88,7 +93,7 @@ export function readButDoNotEvaluate<
 type ReadDataResult<TReadFromStore> =
   | {
       readonly kind: 'Success';
-      readonly data: TReadFromStore;
+      readonly data: ExtractData<TReadFromStore>;
       readonly encounteredRecords: Set<DataId>;
     }
   | {
@@ -101,7 +106,7 @@ function readData<TReadFromStore>(
   environment: IsographEnvironment,
   ast: ReaderAst<TReadFromStore>,
   root: DataId,
-  variables: Variables,
+  variables: ExtractParameters<TReadFromStore>,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
   networkRequest: PromiseWrapper<void, any>,
   networkRequestOptions: NetworkRequestReaderOptions,

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -1,5 +1,9 @@
 import { Factory } from '@isograph/disposable-types';
-import { FragmentReference, Variables } from './FragmentReference';
+import {
+  FragmentReference,
+  ExtractParameters,
+  ExtractData,
+} from './FragmentReference';
 import {
   ComponentOrFieldName,
   DataId,
@@ -17,43 +21,39 @@ export type TopLevelReaderArtifact<
   TReadFromStore extends { parameters: object; data: object },
   TClientFieldValue,
   TComponentProps extends Record<string, never>,
-  TVariables = Variables,
 > =
-  | EagerReaderArtifact<TReadFromStore, TClientFieldValue, TVariables>
-  | ComponentReaderArtifact<TReadFromStore, TComponentProps, TVariables>;
+  | EagerReaderArtifact<TReadFromStore, TClientFieldValue>
+  | ComponentReaderArtifact<TReadFromStore, TComponentProps>;
 
 export type EagerReaderArtifact<
   TReadFromStore extends { parameters: object; data: object },
   TClientFieldValue,
-  TVariables = Variables,
 > = {
   readonly kind: 'EagerReaderArtifact';
   readonly readerAst: ReaderAst<TReadFromStore>;
   readonly resolver: (
-    data: ResolverFirstParameter<TReadFromStore, TVariables>,
+    data: ResolverFirstParameter<TReadFromStore>,
   ) => TClientFieldValue;
 };
 
 export type ComponentReaderArtifact<
   TReadFromStore extends { parameters: object; data: object },
   TComponentProps extends Record<string, unknown> = Record<string, never>,
-  TVariables = Variables,
 > = {
   readonly kind: 'ComponentReaderArtifact';
   readonly componentName: ComponentOrFieldName;
   readonly readerAst: ReaderAst<TReadFromStore>;
   readonly resolver: (
-    data: ResolverFirstParameter<TReadFromStore, TVariables>,
+    data: ResolverFirstParameter<TReadFromStore>,
     runtimeProps: TComponentProps,
   ) => React.ReactNode;
 };
 
 export type ResolverFirstParameter<
-  TReadFromStore extends object,
-  TVariables = Variables,
+  TReadFromStore extends { data: object; parameters: object },
 > = {
-  readonly data: TReadFromStore;
-  readonly parameters: TVariables;
+  data: ExtractData<TReadFromStore>;
+  parameters: ExtractParameters<TReadFromStore>;
 };
 
 export type RefetchReaderArtifact = {

--- a/libs/isograph-react/src/index.ts
+++ b/libs/isograph-react/src/index.ts
@@ -63,6 +63,8 @@ export {
 export {
   type FragmentReference,
   type Variables,
+  type ExtractParameters,
+  type ExtractData,
   stableIdForFragmentReference,
 } from './core/FragmentReference';
 

--- a/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
@@ -169,6 +169,7 @@ export function useSkipLimitPagination<
         }
         return clonedRefCountedPointer;
       });
+      // @ts-expect-error
       clonedPointers.push(newPointer);
 
       const totalItemCleanupPair: ItemCleanupPair<

--- a/libs/isograph-react/src/react/useImperativeReference.ts
+++ b/libs/isograph-react/src/react/useImperativeReference.ts
@@ -3,7 +3,10 @@ import {
   useUpdatableDisposableState,
 } from '@isograph/react-disposable-state';
 import { IsographEntrypoint } from '../core/entrypoint';
-import { FragmentReference, Variables } from '../core/FragmentReference';
+import {
+  FragmentReference,
+  ExtractParameters,
+} from '../core/FragmentReference';
 import { useIsographEnvironment } from './IsographEnvironmentProvider';
 import { ROOT_ID } from '../core/IsographEnvironment';
 import { makeNetworkRequest } from '../core/makeNetworkRequest';
@@ -20,7 +23,7 @@ export function useImperativeReference<
   fragmentReference:
     | FragmentReference<TReadFromStore, TClientFieldValue>
     | UnassignedState;
-  loadFragmentReference: (variables: Variables) => void;
+  loadFragmentReference: (variables: ExtractParameters<TReadFromStore>) => void;
 } {
   const { state, setState } =
     useUpdatableDisposableState<
@@ -29,7 +32,7 @@ export function useImperativeReference<
   const environment = useIsographEnvironment();
   return {
     fragmentReference: state,
-    loadFragmentReference: (variables: Variables) => {
+    loadFragmentReference: (variables: ExtractParameters<TReadFromStore>) => {
       const [networkRequest, disposeNetworkRequest] = makeNetworkRequest(
         environment,
         entrypoint,

--- a/libs/isograph-react/src/react/useLazyReference.ts
+++ b/libs/isograph-react/src/react/useLazyReference.ts
@@ -1,4 +1,7 @@
-import { FragmentReference, Variables } from '../core/FragmentReference';
+import {
+  FragmentReference,
+  ExtractParameters,
+} from '../core/FragmentReference';
 import { useIsographEnvironment } from './IsographEnvironmentProvider';
 import { IsographEntrypoint } from '../core/entrypoint';
 import { getOrCreateCacheForArtifact } from '../core/cache';
@@ -9,7 +12,7 @@ export function useLazyReference<
   TClientFieldValue,
 >(
   entrypoint: IsographEntrypoint<TReadFromStore, TClientFieldValue>,
-  variables: Variables,
+  variables: ExtractParameters<TReadFromStore>,
 ): {
   fragmentReference: FragmentReference<TReadFromStore, TClientFieldValue>;
 } {

--- a/libs/isograph-react/src/react/useReadAndSubscribe.ts
+++ b/libs/isograph-react/src/react/useReadAndSubscribe.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import {
   FragmentReference,
   stableIdForFragmentReference,
+  ExtractData,
 } from '../core/FragmentReference';
 import {
   NetworkRequestReaderOptions,
@@ -22,7 +23,7 @@ export function useReadAndSubscribe<
   fragmentReference: FragmentReference<TReadFromStore, any>,
   networkRequestOptions: NetworkRequestReaderOptions,
   readerAst: ReaderAst<TReadFromStore>,
-): TReadFromStore {
+): ExtractData<TReadFromStore> {
   const environment = useIsographEnvironment();
   const [readOutDataAndRecords, setReadOutDataAndRecords] = useState(() =>
     readButDoNotEvaluate(environment, fragmentReference, networkRequestOptions),

--- a/libs/isograph-react/src/react/useResult.ts
+++ b/libs/isograph-react/src/react/useResult.ts
@@ -48,11 +48,11 @@ export function useResult<
         networkRequestOptions,
         readerWithRefetchQueries.readerArtifact.readerAst,
       );
-      const firstParameter = {
+      const param = {
         data: data,
         parameters: fragmentReference.variables,
       };
-      return readerWithRefetchQueries.readerArtifact.resolver(firstParameter);
+      return readerWithRefetchQueries.readerArtifact.resolver(param);
     }
   }
 }

--- a/libs/isograph-react/src/tests/__isograph/Query/meName/param_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/meName/param_type.ts
@@ -1,11 +1,9 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Query__meName__param = {
   readonly data: {
     readonly me: {
       readonly name: string,
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/libs/isograph-react/src/tests/__isograph/Query/meNameSuccessor/param_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/meNameSuccessor/param_type.ts
@@ -1,6 +1,4 @@
 
-import { type Variables } from '@isograph/react';
-
 export type Query__meNameSuccessor__param = {
   readonly data: {
     readonly me: {
@@ -12,5 +10,5 @@ export type Query__meNameSuccessor__param = {
       } | null),
     },
   },
-  readonly parameters: Variables,
+  readonly parameters: Record<string, never>,
 };

--- a/libs/isograph-react/src/tests/__isograph/Query/nodeField/param_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/nodeField/param_type.ts
@@ -1,5 +1,4 @@
-
-import { type Variables } from '@isograph/react';
+import type { Query__nodeField__parameters } from './parameters_type';
 
 export type Query__nodeField__param = {
   readonly data: {
@@ -7,5 +6,5 @@ export type Query__nodeField__param = {
       readonly id: string,
     } | null),
   },
-  readonly parameters: Variables,
+  readonly parameters: Query__nodeField__parameters,
 };

--- a/libs/isograph-react/src/tests/__isograph/Query/nodeField/parameters_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/nodeField/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__nodeField__parameters = {
+  readonly id: string,
+};

--- a/libs/isograph-react/src/tests/__isograph/iso.ts
+++ b/libs/isograph-react/src/tests/__isograph/iso.ts
@@ -1,4 +1,4 @@
-import type { IsographEntrypoint, ResolverFirstParameter, Variables } from '@isograph/react';
+import type { IsographEntrypoint } from '@isograph/react';
 import { type Query__meNameSuccessor__param } from './Query/meNameSuccessor/param_type';
 import { type Query__meName__param } from './Query/meName/param_type';
 import { type Query__nodeField__param } from './Query/nodeField/param_type';
@@ -10,9 +10,9 @@ import entrypoint_Query__nodeField from '../__isograph/Query/nodeField/entrypoin
 // This means that the type of the exported iso literal is exactly
 // the type of the passed-in function, which takes one parameter
 // of type TParam.
-type IdentityWithParam<TParam extends object> = <TClientFieldReturn, TVariables = Variables>(
+type IdentityWithParam<TParam extends object> = <TClientFieldReturn>(
   clientField: (param: TParam) => TClientFieldReturn
-) => (param: ResolverFirstParameter<TParam, TVariables>) => TClientFieldReturn;
+) => (param: TParam) => TClientFieldReturn;
 
 // This is the type given it to client fields with @component.
 // This means that the type of the exported iso literal is exactly
@@ -24,10 +24,9 @@ type IdentityWithParam<TParam extends object> = <TClientFieldReturn, TVariables 
 type IdentityWithParamComponent<TParam extends object> = <
   TClientFieldReturn,
   TComponentProps = Record<string, never>,
-  TVariables = Variables
 >(
   clientComponentField: (data: TParam, componentProps: TComponentProps) => TClientFieldReturn
-) => (data: ResolverFirstParameter<TParam, TVariables>, componentProps: TComponentProps) => TClientFieldReturn;
+) => (data: TParam, componentProps: TComponentProps) => TClientFieldReturn;
 
 type WhitespaceCharacter = ' ' | '\t' | '\n';
 type Whitespace<In> = In extends `${WhitespaceCharacter}${infer In}`


### PR DESCRIPTION
This PR introduces type generation for `parameters` field that makes autocomplete work for resolver parameters, mutation and `useLazyReference` arguments.

There are a couple of open questions though:

1. We need to filter out `__typename` variables from mutation inputs and I'm not sure where is the good place for it
2. Should we generate parameters for a client field type when it's used as a parameter? It's just 2 lines of code, but what's a use case for it?
3. In the github-demo, inside `HomeRoot` there is a parameter that is used as a `lazyLoadReference` parameter, but is absent in the `Query.HomePage` field. It resides deeper in the child component `RepositoryList`. Should we expose all children parameters in the parent component then?
4. `encountered_fields` in `SelectableServerFieldId::Object` are not sorted and field order is not stable for now. Can we replace `HashMap` with `BTreeMap` for `encountered_fields`?