### PR TITLE
use BTreeMap for SchemaObject

### DIFF
--- a/crates/isograph_compiler/src/refetch_fields.rs
+++ b/crates/isograph_compiler/src/refetch_fields.rs
@@ -1,4 +1,4 @@
-use std::collections::hash_map::Entry;
+use std::collections::btree_map::Entry;
 
 use intern::string_key::Intern;
 use isograph_lang_types::ServerObjectId;

--- a/crates/isograph_schema/src/isograph_schema.rs
+++ b/crates/isograph_schema/src/isograph_schema.rs
@@ -351,7 +351,7 @@ pub struct SchemaObject {
     /// to something else.
     pub id_field: Option<ServerStrongIdFieldId>,
     pub encountered_fields:
-        HashMap<SelectableFieldName, FieldDefinitionLocation<ServerFieldId, ClientFieldId>>,
+        BTreeMap<SelectableFieldName, FieldDefinitionLocation<ServerFieldId, ClientFieldId>>,
 }
 
 /// In GraphQL, ValidRefinement's are essentially the concrete types that an interface or

--- a/crates/isograph_schema/src/process_type_definition.rs
+++ b/crates/isograph_schema/src/process_type_definition.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::{hash_map::Entry, BTreeMap, HashMap};
 
 use crate::{
     EncounteredRootTypes, FieldDefinitionLocation, IsographObjectTypeDefinition,
@@ -608,8 +608,8 @@ fn get_typename_type(
 
 struct FieldObjectIdsEtc {
     unvalidated_schema_fields: Vec<UnvalidatedSchemaSchemaField>,
-    // TODO this should be HashMap<_, WithLocation<_>> or something
-    encountered_fields: HashMap<SelectableFieldName, UnvalidatedObjectFieldInfo>,
+    // TODO this should be BTreeMap<_, WithLocation<_>> or something
+    encountered_fields: BTreeMap<SelectableFieldName, UnvalidatedObjectFieldInfo>,
     // TODO this should not be a ServerFieldId, but a special type
     id_field: Option<ServerStrongIdFieldId>,
 }
@@ -627,7 +627,7 @@ fn get_field_objects_ids_and_names(
     options: ConfigOptions,
 ) -> ProcessTypeDefinitionResult<FieldObjectIdsEtc> {
     let new_field_count = new_fields.len();
-    let mut encountered_fields = HashMap::with_capacity(new_field_count);
+    let mut encountered_fields = BTreeMap::new();
     let mut unvalidated_fields = Vec::with_capacity(new_field_count);
     let mut server_field_ids = Vec::with_capacity(new_field_count + 1); // +1 for the typename
     let mut id_field = None;


### PR DESCRIPTION
We need a stable sort order for `encountered_fields` to implement #147 