### PR TITLE
add is_discriminator

### DIFF
--- a/crates/isograph_schema/src/isograph_schema.rs
+++ b/crates/isograph_schema/src/isograph_schema.rs
@@ -375,6 +375,8 @@ pub struct SchemaServerField<TData, TClientFieldVariableDefinitionAssociatedData
     // pub directives: Vec<Directive<ConstantValue>>,
     pub arguments:
         Vec<WithLocation<VariableDefinition<TClientFieldVariableDefinitionAssociatedData>>>,
+    // TODO remove this. This is indicative of poor modeling.
+    pub is_discriminator: bool,
 }
 
 impl<TData, TClientFieldVariableDefinitionAssociatedData: Clone>
@@ -391,6 +393,7 @@ impl<TData, TClientFieldVariableDefinitionAssociatedData: Clone>
             associated_data: convert(&self.associated_data)?,
             parent_type_id: self.parent_type_id,
             arguments: self.arguments.clone(),
+            is_discriminator: self.is_discriminator,
         })
     }
 
@@ -405,6 +408,7 @@ impl<TData, TClientFieldVariableDefinitionAssociatedData: Clone>
             associated_data: convert(&self.associated_data),
             parent_type_id: self.parent_type_id,
             arguments: self.arguments.clone(),
+            is_discriminator: self.is_discriminator,
         }
     }
 }
@@ -597,6 +601,7 @@ impl<T, VariableDefinitionInnerType> SchemaServerField<T, VariableDefinitionInne
             associated_data,
             parent_type_id,
             arguments,
+            is_discriminator,
         } = self;
         (
             SchemaServerField {
@@ -606,6 +611,7 @@ impl<T, VariableDefinitionInnerType> SchemaServerField<T, VariableDefinitionInne
                 associated_data: (),
                 parent_type_id,
                 arguments,
+                is_discriminator,
             },
             associated_data,
         )

--- a/crates/isograph_schema/src/process_type_definition.rs
+++ b/crates/isograph_schema/src/process_type_definition.rs
@@ -664,6 +664,7 @@ fn get_field_objects_ids_and_names(
                         .into_iter()
                         .map(graphql_input_value_definition_to_variable_definition)
                         .collect::<Result<Vec<_>, _>>()?,
+                    is_discriminator: false,
                 });
                 server_field_ids.push(next_server_field_id);
             }
@@ -695,6 +696,7 @@ fn get_field_objects_ids_and_names(
         associated_data: typename_type.clone(),
         parent_type_id,
         arguments: vec![],
+        is_discriminator: true,
     });
 
     if encountered_fields

--- a/crates/isograph_schema/src/validate_schema.rs
+++ b/crates/isograph_schema/src/validate_schema.rs
@@ -349,6 +349,7 @@ fn validate_and_transform_field(
                 associated_data: field_type,
                 parent_type_id: empty_field.parent_type_id,
                 arguments: valid_arguments,
+                is_discriminator: empty_field.is_discriminator,
             });
         }
     }


### PR DESCRIPTION
This PR adds `is_discriminator` field as a temporary solution for #147 to filter `__typename` field. Actual solution is #150.