### PR TITLE
Deep compare arguments

### DIFF
--- a/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
+++ b/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
@@ -110,3 +110,82 @@ export function mergeObjectsUsingReaderAst(
 
   return canRecycle ? oldItemObject : newItemObject;
 }
+
+export function areEqualWithDeepComparison(
+  oldItem: unknown,
+  newItem: unknown,
+): boolean {
+  if (newItem === null) {
+    return oldItem === null;
+  }
+
+  if (newItem === undefined) {
+    return oldItem === undefined;
+  }
+
+  if (Array.isArray(newItem)) {
+    if (!Array.isArray(oldItem)) {
+      return false;
+    }
+
+    return areEqualArraysWithDeepComparison(oldItem, newItem);
+  }
+
+  if (typeof newItem === 'object') {
+    if (typeof oldItem !== 'object') {
+      return false;
+    }
+
+    if (oldItem === null) {
+      return false;
+    }
+
+    return areEqualObjectsWithDeepComparison(oldItem, newItem);
+  }
+
+  return newItem === oldItem;
+}
+
+export function areEqualArraysWithDeepComparison(
+  oldItems: ReadonlyArray<unknown>,
+  newItems: ReadonlyArray<unknown>,
+): boolean {
+  if (newItems.length !== oldItems.length) {
+    return false;
+  }
+
+  for (let i = 0; i < newItems.length; i++) {
+    if (!areEqualWithDeepComparison(oldItems[i], newItems[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function areEqualObjectsWithDeepComparison(
+  oldItemObject: object,
+  newItemObject: object,
+): boolean {
+  const oldKeys = Object.keys(oldItemObject);
+  const newKeys = Object.keys(newItemObject);
+
+  if (oldKeys.length !== newKeys.length) {
+    return false;
+  }
+
+  for (const oldKey of oldKeys) {
+    if (!(oldKey in newItemObject)) {
+      return false;
+    }
+    // @ts-expect-error
+    const oldValue = oldItemObject[oldKey];
+    // @ts-expect-error
+    const newValue = newItemObject[oldKey];
+
+    if (!areEqualWithDeepComparison(oldValue, newValue)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -4,16 +4,6 @@ import {
   ParentCache,
 } from '@isograph/react-disposable-state';
 import {
-  DataId,
-  ROOT_ID,
-  StoreRecord,
-  Link,
-  type IsographEnvironment,
-  DataTypeValue,
-  getLink,
-  FragmentSubscription,
-} from './IsographEnvironment';
-import {
   IsographEntrypoint,
   NormalizationAst,
   NormalizationInlineFragment,
@@ -21,13 +11,23 @@ import {
   NormalizationScalarField,
   RefetchQueryNormalizationArtifactWrapper,
 } from '../core/entrypoint';
-import { ReaderLinkedField, ReaderScalarField, type ReaderAst } from './reader';
-import { Argument, ArgumentValue } from './util';
-import { WithEncounteredRecords, readButDoNotEvaluate } from './read';
-import { FragmentReference, Variables } from './FragmentReference';
 import { mergeObjectsUsingReaderAst } from './areEqualWithDeepComparison';
+import { FragmentReference, Variables } from './FragmentReference';
+import {
+  DataId,
+  DataTypeValue,
+  FragmentSubscription,
+  Link,
+  ROOT_ID,
+  StoreRecord,
+  getLink,
+  type IsographEnvironment,
+} from './IsographEnvironment';
 import { makeNetworkRequest } from './makeNetworkRequest';
 import { wrapResolvedValue } from './PromiseWrapper';
+import { WithEncounteredRecords, readButDoNotEvaluate } from './read';
+import { ReaderLinkedField, ReaderScalarField, type ReaderAst } from './reader';
+import { Argument, ArgumentValue } from './util';
 
 const TYPENAME_FIELD_NAME = '__typename';
 
@@ -269,7 +269,9 @@ function callSubscriptions(
               subscription.encounteredDataAndRecords.item.data,
               newEncounteredDataAndRecords.item.data,
             );
-            if (mergedItem !== subscription.encounteredDataAndRecords.item) {
+            if (
+              mergedItem !== subscription.encounteredDataAndRecords.item.data
+            ) {
               // @ts-expect-error
               if (typeof window !== 'undefined' && window.__LOG) {
                 console.log('Deep equality - No', {

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -266,8 +266,8 @@ function callSubscriptions(
 
             const mergedItem = mergeObjectsUsingReaderAst(
               subscription.readerAst,
-              subscription.encounteredDataAndRecords.item,
-              newEncounteredDataAndRecords.item,
+              subscription.encounteredDataAndRecords.item.data,
+              newEncounteredDataAndRecords.item.data,
             );
             if (mergedItem !== subscription.encounteredDataAndRecords.item) {
               // @ts-expect-error

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -25,9 +25,13 @@ import { ReaderLinkedField, ReaderScalarField, type ReaderAst } from './reader';
 import { Argument, ArgumentValue } from './util';
 import { WithEncounteredRecords, readButDoNotEvaluate } from './read';
 import { FragmentReference, Variables } from './FragmentReference';
-import { mergeObjectsUsingReaderAst } from './areEqualWithDeepComparison';
+import {
+  areEqualObjectsWithDeepComparison,
+  mergeObjectsUsingReaderAst,
+} from './areEqualWithDeepComparison';
 import { makeNetworkRequest } from './makeNetworkRequest';
 import { wrapResolvedValue } from './PromiseWrapper';
+
 const TYPENAME_FIELD_NAME = '__typename';
 
 export function getOrCreateItemInSuspenseCache<
@@ -269,7 +273,11 @@ function callSubscriptions(
               newEncounteredDataAndRecords.item.data,
             );
             if (
-              mergedItem !== subscription.encounteredDataAndRecords.item.data
+              mergedItem !== subscription.encounteredDataAndRecords.item.data ||
+              !areEqualObjectsWithDeepComparison(
+                subscription.encounteredDataAndRecords.item.parameters,
+                newEncounteredDataAndRecords.item.parameters,
+              )
             ) {
               // @ts-expect-error
               if (typeof window !== 'undefined' && window.__LOG) {

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -4,6 +4,16 @@ import {
   ParentCache,
 } from '@isograph/react-disposable-state';
 import {
+  DataId,
+  ROOT_ID,
+  StoreRecord,
+  Link,
+  type IsographEnvironment,
+  DataTypeValue,
+  getLink,
+  FragmentSubscription,
+} from './IsographEnvironment';
+import {
   IsographEntrypoint,
   NormalizationAst,
   NormalizationInlineFragment,
@@ -11,24 +21,13 @@ import {
   NormalizationScalarField,
   RefetchQueryNormalizationArtifactWrapper,
 } from '../core/entrypoint';
-import { mergeObjectsUsingReaderAst } from './areEqualWithDeepComparison';
-import { FragmentReference, Variables } from './FragmentReference';
-import {
-  DataId,
-  DataTypeValue,
-  FragmentSubscription,
-  Link,
-  ROOT_ID,
-  StoreRecord,
-  getLink,
-  type IsographEnvironment,
-} from './IsographEnvironment';
-import { makeNetworkRequest } from './makeNetworkRequest';
-import { wrapResolvedValue } from './PromiseWrapper';
-import { WithEncounteredRecords, readButDoNotEvaluate } from './read';
 import { ReaderLinkedField, ReaderScalarField, type ReaderAst } from './reader';
 import { Argument, ArgumentValue } from './util';
-
+import { WithEncounteredRecords, readButDoNotEvaluate } from './read';
+import { FragmentReference, Variables } from './FragmentReference';
+import { mergeObjectsUsingReaderAst } from './areEqualWithDeepComparison';
+import { makeNetworkRequest } from './makeNetworkRequest';
+import { wrapResolvedValue } from './PromiseWrapper';
 const TYPENAME_FIELD_NAME = '__typename';
 
 export function getOrCreateItemInSuspenseCache<


### PR DESCRIPTION
`readerAst` is an array of ast nodes, there is no `readerAst.arguments`, it should be ok to compare these without ast, right?

Closes #126 
