### PR TITLE
change loadable field type generation

### DIFF
--- a/crates/graphql_artifact_generation/src/format_parameter_type.rs
+++ b/crates/graphql_artifact_generation/src/format_parameter_type.rs
@@ -51,7 +51,7 @@ fn format_server_field_type(
                 .iter()
                 .filter(|x| matches!(
                     x.1,
-                    FieldDefinitionLocation::Server(server_field_id) if schema.server_field(*server_field_id).is_discriminator == false),
+                    FieldDefinitionLocation::Server(server_field_id) if !schema.server_field(*server_field_id).is_discriminator),
                 )
             {
                 let field_type =

--- a/crates/graphql_artifact_generation/src/generate_artifacts.rs
+++ b/crates/graphql_artifact_generation/src/generate_artifacts.rs
@@ -11,10 +11,10 @@ use isograph_lang_types::{
     ServerFieldSelection, VariableDefinition,
 };
 use isograph_schema::{
-    get_missing_arguments, selection_map_wrapped, ClientFieldTraversalResult, ClientFieldVariant,
-    FieldDefinitionLocation, MissingArguments, NameAndArguments, NormalizationKey,
-    RequiresRefinement, SchemaObject, TypeAnnotation, UnionVariant, UserWrittenComponentVariant,
-    ValidatedClientField, ValidatedIsographSelectionVariant, ValidatedSchema, ValidatedSelection,
+    get_provided_arguments, selection_map_wrapped, ClientFieldTraversalResult, ClientFieldVariant,
+    FieldDefinitionLocation, NameAndArguments, NormalizationKey, RequiresRefinement, SchemaObject,
+    TypeAnnotation, UnionVariant, UserWrittenComponentVariant, ValidatedClientField,
+    ValidatedIsographSelectionVariant, ValidatedSchema, ValidatedSelection,
     ValidatedVariableDefinition,
 };
 use lazy_static::lazy_static;
@@ -391,8 +391,8 @@ pub(crate) fn generate_client_field_parameter_type(
     selection_map: &[WithSpan<ValidatedSelection>],
     parent_type: &SchemaObject,
     nested_client_field_imports: &mut ParamTypeImports,
+    loadable_fields: &mut ParamTypeImports,
     indentation_level: u8,
-    loadable_field_encountered: &mut bool,
 ) -> ClientFieldParameterType {
     // TODO use unwraps
     let mut client_field_parameter_type = "{\n".to_string();
@@ -403,8 +403,8 @@ pub(crate) fn generate_client_field_parameter_type(
             selection,
             parent_type,
             nested_client_field_imports,
+            loadable_fields,
             indentation_level + 1,
-            loadable_field_encountered,
         );
     }
     client_field_parameter_type.push_str(&format!("{}}}", "  ".repeat(indentation_level as usize)));
@@ -418,8 +418,8 @@ fn write_param_type_from_selection(
     selection: &WithSpan<ValidatedSelection>,
     parent_type: &SchemaObject,
     nested_client_field_imports: &mut ParamTypeImports,
+    loadable_fields: &mut ParamTypeImports,
     indentation_level: u8,
-    loadable_field_encountered: &mut bool,
 ) {
     match &selection.item {
         Selection::ServerField(field) => match field {
@@ -479,31 +479,40 @@ fn write_param_type_from_selection(
                             client_field.type_and_field.underscore_separated()
                         );
 
-                        let output_type = match scalar_field_selection
-                            .associated_data
-                            .selection_variant
-                        {
-                            ValidatedIsographSelectionVariant::Regular => inner_output_type,
-                            ValidatedIsographSelectionVariant::Loadable(_) => {
-                                let missing_arguments = get_missing_arguments(
-                                    client_field.variable_definitions.iter().map(|x| &x.item),
-                                    &scalar_field_selection.arguments,
-                                    true,
-                                );
+                        let output_type =
+                            match scalar_field_selection.associated_data.selection_variant {
+                                ValidatedIsographSelectionVariant::Regular => inner_output_type,
+                                ValidatedIsographSelectionVariant::Loadable(_) => {
+                                    loadable_fields.insert(client_field.type_and_field);
+                                    let provided_arguments = get_provided_arguments(
+                                        client_field.variable_definitions.iter().map(|x| &x.item),
+                                        &scalar_field_selection.arguments,
+                                    );
 
-                                let loadable_field_argument_type = if missing_arguments.is_empty() {
-                                    "void".to_string()
-                                } else {
-                                    get_loadable_field_type_from_missing_arguments(
-                                        schema,
-                                        missing_arguments,
+                                    let indent = "  ".repeat((indentation_level + 1) as usize);
+                                    let provided_args_type = if provided_arguments.is_empty() {
+                                        "".to_string()
+                                    } else {
+                                        format!(
+                                            ",\n{indent}{}",
+                                            get_loadable_field_type_from_arguments(
+                                                schema,
+                                                provided_arguments
+                                            )
+                                        )
+                                    };
+
+                                    format!(
+                                        "LoadableField<\n\
+                                    {indent}{}__param,\n\
+                                    {indent}{inner_output_type}\
+                                    {provided_args_type}\n\
+                                    {}>",
+                                        client_field.type_and_field.underscore_separated(),
+                                        "  ".repeat(indentation_level as usize),
                                     )
-                                };
-
-                                *loadable_field_encountered = true;
-                                format!("LoadableField<{loadable_field_argument_type}, {inner_output_type}>")
-                            }
-                        };
+                                }
+                            };
 
                         query_type_declaration.push_str(
                             &(format!(
@@ -543,8 +552,8 @@ fn write_param_type_from_selection(
                         &linked_field.selection_set,
                         object,
                         nested_client_field_imports,
+                        loadable_fields,
                         indentation_level,
-                        loadable_field_encountered,
                     )
                 });
                 query_type_declaration.push_str(&format!(
@@ -557,13 +566,13 @@ fn write_param_type_from_selection(
     }
 }
 
-fn get_loadable_field_type_from_missing_arguments(
+fn get_loadable_field_type_from_arguments(
     schema: &ValidatedSchema,
-    missing_arguments: MissingArguments,
+    arguments: Vec<ValidatedVariableDefinition>,
 ) -> String {
     let mut loadable_field_type = "{".to_string();
     let mut is_first = true;
-    for arg in missing_arguments.iter() {
+    for arg in arguments.iter() {
         if !is_first {
             loadable_field_type.push_str(", ");
         }

--- a/crates/graphql_artifact_generation/src/import_statements.rs
+++ b/crates/graphql_artifact_generation/src/import_statements.rs
@@ -51,3 +51,18 @@ pub(crate) fn param_type_imports_to_import_statement(
     }
     output
 }
+
+pub(crate) fn param_type_imports_to_import_param_statement(
+    param_type_imports: &ParamTypeImports,
+) -> String {
+    let mut output = String::new();
+    for type_and_field in param_type_imports.iter() {
+        output.push_str(&format!(
+            "import {{ type {}__param }} from '../../{}/{}/param_type';\n",
+            type_and_field.underscore_separated(),
+            type_and_field.type_name,
+            type_and_field.field_name,
+        ));
+    }
+    output
+}

--- a/crates/isograph_schema/src/validate_schema.rs
+++ b/crates/isograph_schema/src/validate_schema.rs
@@ -1165,6 +1165,25 @@ pub fn get_missing_arguments<'a>(
         .collect()
 }
 
+pub fn get_provided_arguments<'a>(
+    argument_definitions: impl Iterator<Item = &'a ValidatedVariableDefinition> + 'a,
+    arguments: &[WithLocation<SelectionFieldArgument>],
+) -> Vec<ValidatedVariableDefinition> {
+    argument_definitions
+        .filter_map(|definition| {
+            let user_has_supplied_argument = arguments
+                .iter()
+                // TODO do not call .lookup
+                .any(|arg| definition.name.item.lookup() == arg.item.name.item.lookup());
+            if user_has_supplied_argument {
+                Some(definition.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 type ValidateSchemaResult<T> = Result<T, WithLocation<ValidateSchemaError>>;
 
 #[derive(Debug, Error)]

--- a/demos/pet-demo/src/components/PetCheckinsCard.tsx
+++ b/demos/pet-demo/src/components/PetCheckinsCard.tsx
@@ -50,7 +50,7 @@ export const CheckinDisplay = iso(`
 });
 
 export const PetCheckinsCardList = iso(`
-  field Pet.PetCheckinsCardList($skip: Int, $limit: Int) {
+  field Pet.PetCheckinsCardList($skip: Int!, $limit: Int!) {
     checkins(skip: $skip, limit: $limit) {
       CheckinDisplay
       id

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplayWrapper/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplayWrapper/param_type.ts
@@ -1,9 +1,13 @@
 import { type AdItem__AdItemDisplay__output_type } from '../../AdItem/AdItemDisplay/output_type';
 import { type LoadableField } from '@isograph/react';
+import { type AdItem__AdItemDisplay__param } from '../../AdItem/AdItemDisplay/param_type';
 
 export type AdItem__AdItemDisplayWrapper__param = {
   readonly data: {
-    readonly AdItemDisplay: LoadableField<void, AdItem__AdItemDisplay__output_type>,
+    readonly AdItemDisplay: LoadableField<
+      AdItem__AdItemDisplay__param,
+      AdItem__AdItemDisplay__output_type
+    >,
   },
   readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemDisplay/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemDisplay/param_type.ts
@@ -1,13 +1,17 @@
 import { type BlogItem__BlogItemMoreDetail__output_type } from '../../BlogItem/BlogItemMoreDetail/output_type';
 import { type Image__ImageDisplayWrapper__output_type } from '../../Image/ImageDisplayWrapper/output_type';
 import { type LoadableField } from '@isograph/react';
+import { type BlogItem__BlogItemMoreDetail__param } from '../../BlogItem/BlogItemMoreDetail/param_type';
 
 export type BlogItem__BlogItemDisplay__param = {
   readonly data: {
     readonly author: string,
     readonly title: string,
     readonly content: string,
-    readonly BlogItemMoreDetail: LoadableField<void, BlogItem__BlogItemMoreDetail__output_type>,
+    readonly BlogItemMoreDetail: LoadableField<
+      BlogItem__BlogItemMoreDetail__param,
+      BlogItem__BlogItemMoreDetail__output_type
+    >,
     readonly image: ({
       readonly ImageDisplayWrapper: Image__ImageDisplayWrapper__output_type,
     } | null),

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplayWrapper/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplayWrapper/param_type.ts
@@ -1,9 +1,13 @@
 import { type Image__ImageDisplay__output_type } from '../../Image/ImageDisplay/output_type';
 import { type LoadableField } from '@isograph/react';
+import { type Image__ImageDisplay__param } from '../../Image/ImageDisplay/param_type';
 
 export type Image__ImageDisplayWrapper__param = {
   readonly data: {
-    readonly ImageDisplay: LoadableField<void, Image__ImageDisplay__output_type>,
+    readonly ImageDisplay: LoadableField<
+      Image__ImageDisplay__param,
+      Image__ImageDisplay__output_type
+    >,
   },
   readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/entrypoint.ts
@@ -7,7 +7,7 @@ const nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[] = [
   { artifact: refetchQuery0, allowedVariables: ["checkin_id", ] },
 ];
 
-const queryText = 'query PetCheckinsCardList ($skip: Int, $limit: Int, $id: ID!) {\
+const queryText = 'query PetCheckinsCardList ($skip: Int!, $limit: Int!, $id: ID!) {\
   node____id___v_id: node(id: $id) {\
     ... on Pet {\
       __typename,\

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/parameters_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/parameters_type.ts
@@ -1,4 +1,4 @@
 export type Pet__PetCheckinsCardList__parameters = {
-  readonly skip?: number | null | void,
-  readonly limit?: number | null | void,
+  readonly skip: number,
+  readonly limit: number,
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/PetDetailDeferredRouteInnerComponent/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetDetailDeferredRouteInnerComponent/param_type.ts
@@ -1,10 +1,14 @@
 import { type Pet__PetCheckinsCard__output_type } from '../../Pet/PetCheckinsCard/output_type';
 import { type LoadableField } from '@isograph/react';
+import { type Pet__PetCheckinsCard__param } from '../../Pet/PetCheckinsCard/param_type';
 
 export type Pet__PetDetailDeferredRouteInnerComponent__param = {
   readonly data: {
     readonly name: string,
-    readonly PetCheckinsCard: LoadableField<{readonly skip?: number | null | void, readonly limit?: number | null | void}, Pet__PetCheckinsCard__output_type>,
+    readonly PetCheckinsCard: LoadableField<
+      Pet__PetCheckinsCard__param,
+      Pet__PetCheckinsCard__output_type
+    >,
   },
   readonly parameters: Record<string, never>,
 };

--- a/demos/pet-demo/src/components/__isograph/Query/Newsfeed/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/Newsfeed/param_type.ts
@@ -1,6 +1,7 @@
 import { type NewsfeedItem__NewsfeedAdOrBlog__output_type } from '../../NewsfeedItem/NewsfeedAdOrBlog/output_type';
 import { type Viewer__NewsfeedPaginationComponent__output_type } from '../../Viewer/NewsfeedPaginationComponent/output_type';
 import { type LoadableField } from '@isograph/react';
+import { type Viewer__NewsfeedPaginationComponent__param } from '../../Viewer/NewsfeedPaginationComponent/param_type';
 
 export type Query__Newsfeed__param = {
   readonly data: {
@@ -8,7 +9,10 @@ export type Query__Newsfeed__param = {
       readonly newsfeed: ReadonlyArray<{
         readonly NewsfeedAdOrBlog: NewsfeedItem__NewsfeedAdOrBlog__output_type,
       }>,
-      readonly NewsfeedPaginationComponent: LoadableField<{readonly skip: number, readonly limit: number}, Viewer__NewsfeedPaginationComponent__output_type>,
+      readonly NewsfeedPaginationComponent: LoadableField<
+        Viewer__NewsfeedPaginationComponent__param,
+        Viewer__NewsfeedPaginationComponent__output_type
+      >,
     },
   },
   readonly parameters: Record<string, never>,

--- a/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/param_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/param_type.ts
@@ -1,6 +1,7 @@
 import { type Pet__FirstCheckinMakeSuperButton__output_type } from '../../Pet/FirstCheckinMakeSuperButton/output_type';
 import { type Pet__PetCheckinsCardList__output_type } from '../../Pet/PetCheckinsCardList/output_type';
 import { type LoadableField } from '@isograph/react';
+import { type Pet__PetCheckinsCardList__param } from '../../Pet/PetCheckinsCardList/param_type';
 import type { Query__PetCheckinListRoute__parameters } from './parameters_type';
 
 export type Query__PetCheckinListRoute__param = {
@@ -8,7 +9,10 @@ export type Query__PetCheckinListRoute__param = {
     readonly pet: ({
       readonly FirstCheckinMakeSuperButton: Pet__FirstCheckinMakeSuperButton__output_type,
       readonly name: string,
-      readonly PetCheckinsCardList: LoadableField<{readonly skip?: number | null | void, readonly limit?: number | null | void}, Pet__PetCheckinsCardList__output_type>,
+      readonly PetCheckinsCardList: LoadableField<
+        Pet__PetCheckinsCardList__param,
+        Pet__PetCheckinsCardList__output_type
+      >,
     } | null),
   },
   readonly parameters: Query__PetCheckinListRoute__parameters,

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -141,6 +141,10 @@ type StableId = string;
 /// Passing TArgs to the LoadableField should be cheap and do no "actual" work,
 /// except to stringify the args or whatnot. Calling the factory can be
 /// expensive. For example, doing so will probably trigger a network request.
-export type LoadableField<TArgs, TResult> = (
-  args: TArgs,
-) => [StableId, Factory<FragmentReference<any, TResult>>];
+export type LoadableField<
+  TReadFromStore extends { data: object; parameters: object },
+  TResult,
+  TProvidedArgs extends object = object,
+> = (
+  args: Omit<ExtractParameters<TReadFromStore>, keyof TProvidedArgs> | void,
+) => [StableId, Factory<FragmentReference<TReadFromStore, TResult>>];

--- a/libs/isograph-react/src/loadable-hooks/useClientSideDefer.ts
+++ b/libs/isograph-react/src/loadable-hooks/useClientSideDefer.ts
@@ -1,23 +1,36 @@
-import { FragmentReference } from '../core/FragmentReference';
+import {
+  ExtractParameters,
+  FragmentReference,
+} from '../core/FragmentReference';
 import { useIsographEnvironment } from '../react/IsographEnvironmentProvider';
 import { getOrCreateItemInSuspenseCache } from '../core/cache';
 import { useLazyDisposableState } from '@isograph/react-disposable-state';
 import { LoadableField } from '../core/reader';
 
-export function useClientSideDefer<TResult>(
-  loadableField: LoadableField<void, TResult>,
-): { fragmentReference: FragmentReference<any, TResult> };
+export function useClientSideDefer<
+  TReadFromStore extends { data: object; parameters: object },
+  TResult,
+>(
+  loadableField: LoadableField<TReadFromStore, TResult>,
+): { fragmentReference: FragmentReference<TReadFromStore, TResult> };
 
-export function useClientSideDefer<TArgs extends object, TResult>(
-  loadableField: LoadableField<TArgs, TResult>,
-  args: TArgs,
-): { fragmentReference: FragmentReference<any, TResult> };
+export function useClientSideDefer<
+  TReadFromStore extends { data: object; parameters: object },
+  TResult,
+  TProvidedArgs extends object,
+>(
+  loadableField: LoadableField<TReadFromStore, TResult, TProvidedArgs>,
+  args: Omit<ExtractParameters<TReadFromStore>, keyof TProvidedArgs>,
+): { fragmentReference: FragmentReference<TReadFromStore, TResult> };
 
-export function useClientSideDefer<TArgs extends object, TResult>(
-  loadableField: LoadableField<TArgs, TResult>,
-  args?: TArgs,
-): { fragmentReference: FragmentReference<any, TResult> } {
-  // @ts-expect-error args is missing iff it has the type void
+export function useClientSideDefer<
+  TReadFromStore extends { data: object; parameters: object },
+  TResult,
+  TProvidedArgs extends object,
+>(
+  loadableField: LoadableField<TReadFromStore, TResult, TProvidedArgs>,
+  args?: Omit<ExtractParameters<TReadFromStore>, keyof TProvidedArgs>,
+): { fragmentReference: FragmentReference<TReadFromStore, TResult> } {
   const [id, loader] = loadableField(args);
   const environment = useIsographEnvironment();
   const cache = getOrCreateItemInSuspenseCache(environment, id, loader);

--- a/libs/isograph-react/src/loadable-hooks/useImperativeLoadableField.ts
+++ b/libs/isograph-react/src/loadable-hooks/useImperativeLoadableField.ts
@@ -1,23 +1,40 @@
-import { FragmentReference } from '../core/FragmentReference';
+import {
+  ExtractParameters,
+  FragmentReference,
+} from '../core/FragmentReference';
 import {
   UnassignedState,
   useUpdatableDisposableState,
 } from '@isograph/react-disposable-state';
 import { LoadableField } from '../core/reader';
 
-type UseImperativeLoadableFieldReturn<TArgs, TResult> = {
-  fragmentReference: FragmentReference<any, TResult> | UnassignedState;
-  loadField: (args: TArgs) => void;
+type UseImperativeLoadableFieldReturn<
+  TReadFromStore extends { data: object; parameters: object },
+  TResult,
+  TProvidedArgs extends object,
+> = {
+  fragmentReference:
+    | FragmentReference<TReadFromStore, TResult>
+    | UnassignedState;
+  loadField: (
+    args: Omit<ExtractParameters<TReadFromStore>, keyof TProvidedArgs> | void,
+  ) => void;
 };
 
-export function useImperativeLoadableField<TArgs, TResult>(
-  loadableField: LoadableField<TArgs, TResult>,
-): UseImperativeLoadableFieldReturn<TArgs, TResult> {
+export function useImperativeLoadableField<
+  TReadFromStore extends { data: object; parameters: object },
+  TResult,
+  TProvidedArgs extends object,
+>(
+  loadableField: LoadableField<TReadFromStore, TResult, TProvidedArgs>,
+): UseImperativeLoadableFieldReturn<TReadFromStore, TResult, TProvidedArgs> {
   const { state, setState } =
-    useUpdatableDisposableState<FragmentReference<any, TResult>>();
+    useUpdatableDisposableState<FragmentReference<TReadFromStore, TResult>>();
 
   return {
-    loadField: (args: TArgs) => {
+    loadField: (
+      args: Omit<ExtractParameters<TReadFromStore>, keyof TProvidedArgs> | void,
+    ) => {
       const [_id, loader] = loadableField(args);
       setState(loader());
     },


### PR DESCRIPTION
This PR fixes `@ts-error` we temporarily added in #147.

Instead of calculating `missing_arguments` we now use generated `__parameters` and omit provided arguments. Provided arguments are generated inline for now. Probably can be put in a separate file later.