### PR TITLE
fix unsupported token panic

### DIFF
--- a/crates/common_lang_types/src/location.rs
+++ b/crates/common_lang_types/src/location.rs
@@ -106,6 +106,12 @@ impl<T: Error> Error for WithLocation<T> {
     }
 }
 
+impl<T: Error> From<WithLocation<T>> for Vec<WithLocation<T>> {
+    fn from(value: WithLocation<T>) -> Self {
+        vec![value]
+    }
+}
+
 impl<T: fmt::Display> fmt::Display for WithLocation<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}\n{}", self.item, self.location)

--- a/crates/isograph_compiler/src/batch_compile.rs
+++ b/crates/isograph_compiler/src/batch_compile.rs
@@ -357,7 +357,7 @@ fn extract_iso_literals(
                         entrypoint_declarations_and_text_sources.push((decl, text_source))
                     }
                 },
-                Err(e) => isograph_literal_parse_errors.push(e),
+                Err(e) => isograph_literal_parse_errors.extend(e),
             }
         }
     }
@@ -376,7 +376,8 @@ fn process_iso_literal_extraction(
     iso_literal_extraction: IsoLiteralExtraction<'_>,
     file_name: SourceFileName,
     interned_file_path: FilePath,
-) -> Result<(IsoLiteralExtractionResult, TextSource), WithLocation<IsographLiteralParseError>> {
+) -> Result<(IsoLiteralExtractionResult, TextSource), Vec<WithLocation<IsographLiteralParseError>>>
+{
     let IsoLiteralExtraction {
         iso_literal_text,
         iso_literal_start_index,
@@ -396,7 +397,8 @@ fn process_iso_literal_extraction(
         return Err(WithLocation::new(
             IsographLiteralParseError::ExpectedParenthesesAroundIsoLiteral,
             Location::new(text_source, Span::todo_generated()),
-        ));
+        )
+        .into());
     }
 
     // TODO return errors if any occurred, otherwise Ok
@@ -416,7 +418,8 @@ fn process_iso_literal_extraction(
             return Err(WithLocation::new(
                 IsographLiteralParseError::ExpectedAssociatedJsFunction,
                 Location::new(text_source, Span::todo_generated()),
-            ));
+            )
+            .into());
         }
     }
 

--- a/crates/isograph_lang_parser/src/token_kind.rs
+++ b/crates/isograph_lang_parser/src/token_kind.rs
@@ -75,6 +75,9 @@ pub enum IsographLangTokenKind {
     // Comments
     // #[regex("#[^\n\r]*")]
     // SingleLineComment,
+    #[regex("//")]
+    ErrWrongSingleLineComment,
+
     // Whitespace
     #[token(",")]
     Comma,
@@ -182,6 +185,9 @@ impl fmt::Display for IsographLangTokenKind {
             }
             IsographLangTokenKind::ErrorNumberLiteralTrailingInvalid => {
                 "unsupported number (int or float) literal"
+            }
+            IsographLangTokenKind::ErrWrongSingleLineComment => {
+                "unsupported single line comment (use '#' instead)"
             }
             IsographLangTokenKind::Comma => "comma (',')",
             IsographLangTokenKind::Colon => "colon (':')",

--- a/crates/isograph_lang_parser/src/token_kind.rs
+++ b/crates/isograph_lang_parser/src/token_kind.rs
@@ -75,7 +75,7 @@ pub enum IsographLangTokenKind {
     // Comments
     // #[regex("#[^\n\r]*")]
     // SingleLineComment,
-    #[regex("//")]
+    #[token("//")]
     ErrWrongSingleLineComment,
 
     // Whitespace


### PR DESCRIPTION
This PR adds a new error token type to handle unexpected single line comment token `//` and collects all other encountered unexpected tokens.

Closes #58 