### PR TITLE
publish compiler for win64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,11 @@ jobs:
         with:
           name: isograph_cli-macos-arm64
           path: libs/isograph-compiler/artifacts/macos-arm64
+      - name: Download artifact isograph_cli-bin-win-x64
+        uses: actions/download-artifact@v4
+        with:
+          name: isograph_cli-bin-win-x64
+          path: libs/isograph-compiler/artifacts/win-x64
       - name: Mark binaries as executable
         run: |
           chmod +x libs/isograph-compiler/artifacts/linux-x64/isograph_cli

--- a/libs/isograph-compiler/index.js
+++ b/libs/isograph-compiler/index.js
@@ -12,8 +12,7 @@ if (process.platform === 'darwin' && process.arch === 'x64') {
 } else if (process.platform === 'linux' && process.arch === 'arm64') {
   binary = path.join(__dirname, 'artifacts', 'linux-arm64', 'isograph_cli');
 } else if (process.platform === 'win32' && process.arch === 'x64') {
-  throw new Error('Platform not supported yet');
-  // binary = path.join(__dirname, "artifacts", "win-x64", "isograph_cli.exe");
+  binary = path.join(__dirname, 'artifacts', 'win-x64', 'isograph_cli.exe');
 } else {
   throw new Error('Platform not supported yet');
   // binary = null;


### PR DESCRIPTION
Seems like we are building the compiler for win 64, but not publishing it