### PR TITLE
Replace `DataId` with `Link`

### DIFF
--- a/crates/graphql_artifact_generation/src/refetch_reader_artifact.rs
+++ b/crates/graphql_artifact_generation/src/refetch_reader_artifact.rs
@@ -129,7 +129,7 @@ fn generate_function_import_statement_for_refetch_reader() -> ClientFieldFunctio
         {indent}artifact: RefetchQueryNormalizationArtifact,\n\
         {indent}readOutData: any,\n\
         {indent}filteredVariables: any,\n\
-        {indent}rootId: Link,\n\
+        {indent}rootLink: Link,\n\
         {indent}// TODO type this\n\
         {indent}readerArtifact: TopLevelReaderArtifact<any, any, any> | null,\n\
         {indent}nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],\n\
@@ -144,7 +144,7 @@ fn generate_function_import_statement_for_refetch_reader() -> ClientFieldFunctio
         {indent}    readerArtifact,\n\
         {indent}    nestedRefetchQueries,\n\
         {indent}  }} as const),\n\
-        {indent}  root: rootId,\n\
+        {indent}  root: rootLink,\n\
         {indent}  variables,\n\
         {indent}  networkRequest,\n\
         {indent}}} as const;\n\
@@ -172,7 +172,7 @@ fn generate_function_import_statement_for_mutation_reader(
         {indent}artifact: RefetchQueryNormalizationArtifact,\n\
         {indent}readOutData: any,\n\
         {indent}filteredVariables: any,\n\
-        {indent}rootId: Link,\n\
+        {indent}rootLink: Link,\n\
         {indent}// TODO type this\n\
         {indent}readerArtifact: TopLevelReaderArtifact<any, any, any>,\n\
         {indent}nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],\n\
@@ -187,7 +187,7 @@ fn generate_function_import_statement_for_mutation_reader(
         {indent}    readerArtifact,\n\
         {indent}    nestedRefetchQueries,\n\
         {indent}  }} as const),\n\
-        {indent}  root: rootId,\n\
+        {indent}  root: rootLink,\n\
         {indent}  variables,\n\
         {indent}  networkRequest,\n\
         {indent}}} as const;\n\

--- a/crates/graphql_artifact_generation/src/refetch_reader_artifact.rs
+++ b/crates/graphql_artifact_generation/src/refetch_reader_artifact.rs
@@ -121,7 +121,7 @@ fn generate_function_import_statement_for_refetch_reader() -> ClientFieldFunctio
         "{include_read_out_data}\n\
         import {{ makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, \
         type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, \
-        type DataId, type TopLevelReaderArtifact }} \
+        type Link, type TopLevelReaderArtifact }} \
         from '@isograph/react';\n\
         import {{ type ItemCleanupPair }} from '@isograph/react-disposable-state';\n\
         const resolver = (\n\
@@ -129,7 +129,7 @@ fn generate_function_import_statement_for_refetch_reader() -> ClientFieldFunctio
         {indent}artifact: RefetchQueryNormalizationArtifact,\n\
         {indent}readOutData: any,\n\
         {indent}filteredVariables: any,\n\
-        {indent}rootId: DataId,\n\
+        {indent}rootId: Link,\n\
         {indent}// TODO type this\n\
         {indent}readerArtifact: TopLevelReaderArtifact<any, any, any> | null,\n\
         {indent}nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],\n\
@@ -162,7 +162,7 @@ fn generate_function_import_statement_for_mutation_reader(
     ClientFieldFunctionImportStatement(format!(
         "{include_read_out_data}\n\
         import {{ makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, \
-        type DataId, type TopLevelReaderArtifact, \
+        type Link, type TopLevelReaderArtifact, \
         type FragmentReference, \
         type RefetchQueryNormalizationArtifactWrapper \
         }} from '@isograph/react';\n\
@@ -172,7 +172,7 @@ fn generate_function_import_statement_for_mutation_reader(
         {indent}artifact: RefetchQueryNormalizationArtifact,\n\
         {indent}readOutData: any,\n\
         {indent}filteredVariables: any,\n\
-        {indent}rootId: DataId,\n\
+        {indent}rootId: Link,\n\
         {indent}// TODO type this\n\
         {indent}readerArtifact: TopLevelReaderArtifact<any, any, any>,\n\
         {indent}nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],\n\

--- a/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/refetch_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/refetch_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type DataId, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/refetch_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/github-demo/src/isograph-components/__isograph/User/__refetch/refetch_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/__refetch/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/github-demo/src/isograph-components/__isograph/User/__refetch/refetch_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/__refetch/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type DataId, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/github-demo/src/isograph-components/__isograph/User/__refetch/refetch_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/__refetch/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/pages/_app.tsx
+++ b/demos/pet-demo/pages/_app.tsx
@@ -32,7 +32,7 @@ function makeNetworkRequest<T>(queryText: string, variables: any): Promise<T> {
 }
 const missingFieldHandler = (
   storeRecord: StoreRecord,
-  root: DataId,
+  root: Link,
   fieldName: string,
   arguments_: { [index: string]: any } | null,
   variables: { [index: string]: any } | null,
@@ -59,7 +59,11 @@ const missingFieldHandler = (
     //
     // N.B. this **not** correct. We need to pass the correct variables/args here.
     // But it works for this demo.
-    if (fieldName === 'pet' && variables?.id != null && root === '__ROOT') {
+    if (
+      fieldName === 'pet' &&
+      variables?.id != null &&
+      root.__link === '__ROOT'
+    ) {
       return { __link: variables.id };
     }
   } else {

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type DataId, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type DataId, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/ICheckin/make_super/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/ICheckin/make_super/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.checkin_id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any>,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/ICheckin/make_super/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/ICheckin/make_super/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type DataId, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any>,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/ICheckin/make_super/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/ICheckin/make_super/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.checkin_id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type DataId, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type DataId, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type DataId, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/Pet/__refetch/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/__refetch/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/Pet/__refetch/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/__refetch/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type DataId, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/Pet/__refetch/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/__refetch/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/Pet/set_best_friend/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/set_best_friend/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type DataId, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any>,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/Pet/set_best_friend/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/set_best_friend/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/Pet/set_best_friend/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/set_best_friend/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any>,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
@@ -5,14 +5,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type DataId, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any>,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
@@ -1,11 +1,11 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.input = variables.input ?? {};
   variables.input.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
@@ -1,18 +1,18 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.input = variables.input ?? {};
   variables.input.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any>,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -27,7 +27,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/PetStats/refetch_pet_stats/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/PetStats/refetch_pet_stats/refetch_reader.ts
@@ -1,9 +1,9 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/demos/pet-demo/src/components/__isograph/PetStats/refetch_pet_stats/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/PetStats/refetch_pet_stats/refetch_reader.ts
@@ -3,14 +3,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type DataId, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any>,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/PetStats/refetch_pet_stats/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/PetStats/refetch_pet_stats/refetch_reader.ts
@@ -1,16 +1,16 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type Link, type TopLevelReaderArtifact, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any>,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -25,7 +25,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/refetch_reader.ts
@@ -1,17 +1,17 @@
-import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
+import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: Link,
+  rootLink: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -26,7 +26,7 @@ const resolver = (
       readerArtifact,
       nestedRefetchQueries,
     } as const),
-    root: rootId,
+    root: rootLink,
     variables,
     networkRequest,
   } as const;

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/refetch_reader.ts
@@ -4,14 +4,14 @@ const includeReadOutData = (variables: any, readOutData: any) => {
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type DataId, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,
   artifact: RefetchQueryNormalizationArtifact,
   readOutData: any,
   filteredVariables: any,
-  rootId: DataId,
+  rootId: Link,
   // TODO type this
   readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/refetch_reader.ts
@@ -1,10 +1,10 @@
-import type { ReaderAst, RefetchQueryNormalizationArtifact, RefetchReaderArtifact } from '@isograph/react';
+import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
   variables.id = readOutData.id;
   return variables;
 };
 
-import { makeNetworkRequest, wrapResolvedValue, type FragmentReference, type IsographEnvironment, type Link, type RefetchQueryNormalizationArtifactWrapper, type TopLevelReaderArtifact } from '@isograph/react';
+import { makeNetworkRequest, wrapResolvedValue, type IsographEnvironment, type FragmentReference, type RefetchQueryNormalizationArtifactWrapper, type Link, type TopLevelReaderArtifact } from '@isograph/react';
 import { type ItemCleanupPair } from '@isograph/react-disposable-state';
 const resolver = (
   environment: IsographEnvironment,

--- a/libs/isograph-react/src/core/FragmentReference.ts
+++ b/libs/isograph-react/src/core/FragmentReference.ts
@@ -1,4 +1,4 @@
-import { DataId } from './IsographEnvironment';
+import { type Link } from './IsographEnvironment';
 import { ReaderWithRefetchQueries } from '../core/entrypoint';
 import { PromiseWrapper } from './PromiseWrapper';
 
@@ -27,7 +27,7 @@ export type FragmentReference<
   readonly readerWithRefetchQueries: PromiseWrapper<
     ReaderWithRefetchQueries<TReadFromStore, TClientFieldValue>
   >;
-  readonly root: DataId;
+  readonly root: Link;
   readonly variables: ExtractParameters<TReadFromStore>;
   readonly networkRequest: PromiseWrapper<void, any>;
 };
@@ -35,7 +35,7 @@ export type FragmentReference<
 export function stableIdForFragmentReference(
   fragmentReference: FragmentReference<any, any>,
 ): string {
-  return `${fragmentReference.root}/TODO_FRAGMENT_NAME/${serializeVariables(fragmentReference.variables ?? {})}`;
+  return `${fragmentReference.root.__link}/TODO_FRAGMENT_NAME/${serializeVariables(fragmentReference.variables ?? {})}`;
 }
 
 function serializeVariables(variables: Variables) {

--- a/libs/isograph-react/src/core/IsographEnvironment.ts
+++ b/libs/isograph-react/src/core/IsographEnvironment.ts
@@ -30,7 +30,7 @@ export type FragmentSubscription<
 type AnyChangesToRecordSubscription = {
   readonly kind: 'AnyChangesToRecord';
   readonly callback: () => void;
-  readonly recordId: DataId;
+  readonly recordId: Link;
 };
 
 type AnyRecordSubscription = {
@@ -67,7 +67,7 @@ export type IsographEnvironment = {
 
 export type MissingFieldHandler = (
   storeRecord: StoreRecord,
-  root: DataId,
+  root: Link,
   fieldName: string,
   arguments_: { [index: string]: any } | null,
   variables: Variables | null,
@@ -140,7 +140,7 @@ export function createIsographStore(): IsographStore {
 
 export function defaultMissingFieldHandler(
   _storeRecord: StoreRecord,
-  _root: DataId,
+  _root: Link,
   fieldName: string,
   arguments_: { [index: string]: any } | null,
   variables: Variables | null,

--- a/libs/isograph-react/src/core/IsographEnvironment.ts
+++ b/libs/isograph-react/src/core/IsographEnvironment.ts
@@ -1,9 +1,9 @@
 import { ParentCache } from '@isograph/react-disposable-state';
+import { RetainedQuery } from './garbageCollection';
+import { WithEncounteredRecords } from './read';
 import { FragmentReference, Variables } from './FragmentReference';
 import { PromiseWrapper, wrapPromise } from './PromiseWrapper';
 import { IsographEntrypoint } from './entrypoint';
-import { RetainedQuery } from './garbageCollection';
-import { WithEncounteredRecords } from './read';
 import type { ReaderAst } from './reader';
 import { LogFunction, WrappedLogFunction } from './logging';
 

--- a/libs/isograph-react/src/core/IsographEnvironment.ts
+++ b/libs/isograph-react/src/core/IsographEnvironment.ts
@@ -1,9 +1,9 @@
 import { ParentCache } from '@isograph/react-disposable-state';
-import { RetainedQuery } from './garbageCollection';
-import { WithEncounteredRecords } from './read';
 import { FragmentReference, Variables } from './FragmentReference';
 import { PromiseWrapper, wrapPromise } from './PromiseWrapper';
 import { IsographEntrypoint } from './entrypoint';
+import { RetainedQuery } from './garbageCollection';
+import { WithEncounteredRecords } from './read';
 import type { ReaderAst } from './reader';
 
 export type ComponentOrFieldName = string;
@@ -30,7 +30,7 @@ export type FragmentSubscription<
 type AnyChangesToRecordSubscription = {
   readonly kind: 'AnyChangesToRecord';
   readonly callback: () => void;
-  readonly recordId: Link;
+  readonly recordLink: Link;
 };
 
 type AnyRecordSubscription = {

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -727,7 +727,7 @@ export const SECOND_SPLIT_KEY = '___';
 
 // Returns a key to look up an item in the store
 function getDataIdOfNetworkResponse(
-  parentrecordLink: Link,
+  parentRecordLink: Link,
   dataToNormalize: NetworkResponseObject,
   astNode: NormalizationLinkedField | NormalizationScalarField,
   variables: Variables,
@@ -741,7 +741,7 @@ function getDataIdOfNetworkResponse(
     return dataId;
   }
 
-  let storeKey = `${parentrecordLink.__link}.${astNode.fieldName}`;
+  let storeKey = `${parentRecordLink.__link}.${astNode.fieldName}`;
   if (index != null) {
     storeKey += `.${index}`;
   }

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -106,7 +106,7 @@ export function getOrCreateCacheForArtifact<
           nestedRefetchQueries:
             entrypoint.readerWithRefetchQueries.nestedRefetchQueries,
         }),
-        root: ROOT_ID,
+        root: { __link: ROOT_ID },
         variables,
         networkRequest: networkRequest,
       },
@@ -154,7 +154,7 @@ export function normalizeData(
     normalizationAst,
     networkResponse,
     environment.store.__ROOT,
-    ROOT_ID,
+    { __link: ROOT_ID },
     variables as any,
     nestedRefetchQueries,
     encounteredIds,
@@ -185,7 +185,7 @@ export function subscribeToAnyChange(
 
 export function subscribeToAnyChangesToRecord(
   environment: IsographEnvironment,
-  recordId: DataId,
+  recordId: Link,
   callback: () => void,
 ): () => void {
   const subscription = {
@@ -222,7 +222,7 @@ export function subscribe<
 
 export function onNextChangeToRecord(
   environment: IsographEnvironment,
-  recordId: DataId,
+  recordId: Link,
 ): Promise<void> {
   return new Promise((resolve) => {
     const unsubscribe = subscribeToAnyChangesToRecord(
@@ -319,7 +319,9 @@ function callSubscriptions(
           return;
         }
         case 'AnyChangesToRecord': {
-          if (recordsEncounteredWhenNormalizing.has(subscription.recordId)) {
+          if (
+            recordsEncounteredWhenNormalizing.has(subscription.recordId.__link)
+          ) {
             subscription.callback();
           }
           return;
@@ -352,7 +354,7 @@ function normalizeDataIntoRecord(
   normalizationAst: NormalizationAst,
   networkResponseParentRecord: NetworkResponseObject,
   targetParentRecord: StoreRecord,
-  targetParentRecordId: DataId,
+  targetParentRecordId: Link,
   variables: Variables,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
   mutableEncounteredIds: Set<DataId>,
@@ -410,7 +412,7 @@ function normalizeDataIntoRecord(
     }
   }
   if (recordHasBeenUpdated) {
-    mutableEncounteredIds.add(targetParentRecordId);
+    mutableEncounteredIds.add(targetParentRecordId.__link);
   }
   return recordHasBeenUpdated;
 }
@@ -446,7 +448,7 @@ function normalizeLinkedField(
   astNode: NormalizationLinkedField,
   networkResponseParentRecord: NetworkResponseObject,
   targetParentRecord: StoreRecord,
-  targetParentRecordId: DataId,
+  targetParentRecordId: Link,
   variables: Variables,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
   mutableEncounteredIds: Set<DataId>,
@@ -515,7 +517,7 @@ function normalizeInlineFragment(
   astNode: NormalizationInlineFragment,
   networkResponseParentRecord: NetworkResponseObject,
   targetParentRecord: StoreRecord,
-  targetParentRecordId: DataId,
+  targetParentRecordId: Link,
   variables: Variables,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
   mutableEncounteredIds: Set<DataId>,
@@ -563,7 +565,7 @@ function normalizeNetworkResponseObject(
   environment: IsographEnvironment,
   astNode: NormalizationLinkedField,
   networkResponseData: NetworkResponseObject,
-  targetParentRecordId: string,
+  targetParentRecordId: Link,
   variables: Variables,
   index: number | null,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -585,7 +587,7 @@ function normalizeNetworkResponseObject(
     astNode.selections,
     networkResponseData,
     newStoreRecord,
-    newStoreRecordId,
+    { __link: newStoreRecordId },
     variables,
     nestedRefetchQueries,
     mutableEncounteredIds,
@@ -723,7 +725,7 @@ export const SECOND_SPLIT_KEY = '___';
 
 // Returns a key to look up an item in the store
 function getDataIdOfNetworkResponse(
-  parentRecordId: DataId,
+  parentrecordId: Link,
   dataToNormalize: NetworkResponseObject,
   astNode: NormalizationLinkedField | NormalizationScalarField,
   variables: Variables,
@@ -737,7 +739,7 @@ function getDataIdOfNetworkResponse(
     return dataId;
   }
 
-  let storeKey = `${parentRecordId}.${astNode.fieldName}`;
+  let storeKey = `${parentrecordId.__link}.${astNode.fieldName}`;
   if (index != null) {
     storeKey += `.${index}`;
   }

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -16,9 +16,9 @@ export function getOrCreateCachedComponent(
   // time.
   const cachedComponentsById = environment.componentCache;
 
-  cachedComponentsById[fragmentReference.root] =
-    cachedComponentsById[fragmentReference.root] ?? {};
-  const componentsByName = cachedComponentsById[fragmentReference.root];
+  const recordId = fragmentReference.root.__link;
+
+  const componentsByName = (cachedComponentsById[recordId] ??= {});
 
   componentsByName[componentName] = componentsByName[componentName] ?? {};
   const byArgs = componentsByName[componentName];

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -1,7 +1,7 @@
-import { useReadAndSubscribe } from '../react/useReadAndSubscribe';
 import { stableCopy } from './cache';
-import { FragmentReference } from './FragmentReference';
 import { IsographEnvironment } from './IsographEnvironment';
+import { FragmentReference } from './FragmentReference';
+import { useReadAndSubscribe } from '../react/useReadAndSubscribe';
 import { NetworkRequestReaderOptions } from './read';
 import { readPromise } from './PromiseWrapper';
 import { logMessage } from './logging';

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -1,9 +1,9 @@
-import { stableCopy } from './cache';
-import { IsographEnvironment } from './IsographEnvironment';
-import { FragmentReference } from './FragmentReference';
 import { useReadAndSubscribe } from '../react/useReadAndSubscribe';
-import { NetworkRequestReaderOptions } from './read';
+import { stableCopy } from './cache';
+import { FragmentReference } from './FragmentReference';
+import { IsographEnvironment } from './IsographEnvironment';
 import { readPromise } from './PromiseWrapper';
+import { NetworkRequestReaderOptions } from './read';
 
 export function getOrCreateCachedComponent(
   environment: IsographEnvironment,
@@ -16,9 +16,9 @@ export function getOrCreateCachedComponent(
   // time.
   const cachedComponentsById = environment.componentCache;
 
-  const recordId = fragmentReference.root.__link;
+  const recordLink = fragmentReference.root.__link;
 
-  const componentsByName = (cachedComponentsById[recordId] ??= {});
+  const componentsByName = (cachedComponentsById[recordLink] ??= {});
 
   componentsByName[componentName] = componentsByName[componentName] ?? {};
   const byArgs = componentsByName[componentName];

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -44,7 +44,7 @@ export function getOrCreateCachedComponent(
         logMessage(environment, {
           kind: 'ComponentRerendered',
           componentName,
-          rootId: fragmentReference.root,
+          rootLink: fragmentReference.root,
         });
 
         const firstParameter = {

--- a/libs/isograph-react/src/core/logging.ts
+++ b/libs/isograph-react/src/core/logging.ts
@@ -1,9 +1,9 @@
 import { CleanupFn } from '@isograph/disposable-types';
 import {
-  DataId,
   IsographEnvironment,
   IsographStore,
   StoreRecord,
+  type Link,
 } from './IsographEnvironment';
 import {
   IsographEntrypoint,
@@ -43,7 +43,7 @@ export type LogMessage =
   | {
       kind: 'ComponentRerendered';
       componentName: string;
-      rootId: DataId;
+      rootLink: Link;
     }
   | {
       kind: 'MakeNetworkRequest';
@@ -61,7 +61,7 @@ export type LogMessage =
     }
   | {
       kind: 'MissingFieldHandlerCalled';
-      root: DataId;
+      root: Link;
       storeRecord: StoreRecord;
       fieldName: string;
       arguments: Arguments | null;

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -6,10 +6,10 @@ import {
   RefetchQueryNormalizationArtifactWrapper,
 } from './entrypoint';
 import {
-  FragmentReference,
-  Variables,
   ExtractData,
   ExtractParameters,
+  FragmentReference,
+  Variables,
 } from './FragmentReference';
 import {
   assertLink,
@@ -78,11 +78,11 @@ export function readButDoNotEvaluate<
     ) {
       // TODO assert that the network request state is not Err
       throw new Promise((resolve, reject) => {
-        onNextChangeToRecord(environment, response.recordId).then(resolve);
+        onNextChangeToRecord(environment, response.recordLink).then(resolve);
         fragmentReference.networkRequest.promise.catch(reject);
       });
     }
-    throw onNextChangeToRecord(environment, response.recordId);
+    throw onNextChangeToRecord(environment, response.recordLink);
   } else {
     return {
       encounteredRecords: mutableEncounteredRecords,
@@ -101,7 +101,7 @@ type ReadDataResult<TReadFromStore> =
       readonly kind: 'MissingData';
       readonly reason: string;
       readonly nestedReason?: ReadDataResult<unknown>;
-      readonly recordId: Link;
+      readonly recordLink: Link;
     };
 
 function readData<TReadFromStore>(
@@ -120,7 +120,7 @@ function readData<TReadFromStore>(
     return {
       kind: 'MissingData',
       reason: 'No record for root ' + root.__link,
-      recordId: root,
+      recordLink: root,
     };
   }
 
@@ -146,7 +146,7 @@ function readData<TReadFromStore>(
             kind: 'MissingData',
             reason:
               'No value for ' + storeRecordName + ' on root ' + root.__link,
-            recordId: root,
+            recordLink: root,
           };
         }
         target[field.alias ?? field.fieldName] = value;
@@ -169,7 +169,7 @@ function readData<TReadFromStore>(
                   root.__link +
                   '. Link is ' +
                   JSON.stringify(item),
-                recordId: root,
+                recordLink: root,
               };
             } else if (link === null) {
               results.push(null);
@@ -196,7 +196,7 @@ function readData<TReadFromStore>(
                   '. Link is ' +
                   JSON.stringify(item),
                 nestedReason: result,
-                recordId: result.recordId,
+                recordLink: result.recordLink,
               };
             }
             results.push(result.data);
@@ -226,7 +226,7 @@ function readData<TReadFromStore>(
                 root.__link +
                 '. Link is ' +
                 JSON.stringify(value),
-              recordId: root,
+              recordLink: root,
             };
           } else {
             link = altLink;
@@ -252,7 +252,7 @@ function readData<TReadFromStore>(
             reason:
               'Missing data for ' + storeRecordName + ' on root ' + root.__link,
             nestedReason: data,
-            recordId: data.recordId,
+            recordLink: data.recordLink,
           };
         }
         target[field.alias ?? field.fieldName] = data.data;
@@ -280,7 +280,7 @@ function readData<TReadFromStore>(
             reason:
               'Missing data for ' + field.alias + ' on root ' + root.__link,
             nestedReason: data,
-            recordId: data.recordId,
+            recordLink: data.recordLink,
           };
         } else {
           const refetchQueryIndex = field.refetchQuery;
@@ -335,7 +335,7 @@ function readData<TReadFromStore>(
                 reason:
                   'Missing data for ' + field.alias + ' on root ' + root.__link,
                 nestedReason: data,
-                recordId: data.recordId,
+                recordLink: data.recordLink,
               };
             } else {
               const firstParameter = {
@@ -392,7 +392,7 @@ function readData<TReadFromStore>(
             reason:
               'Missing data for ' + field.alias + ' on root ' + root.__link,
             nestedReason: refetchReaderParams,
-            recordId: refetchReaderParams.recordId,
+            recordLink: refetchReaderParams.recordLink,
           };
         } else {
           target[field.alias] = (args: any) => {

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -6,10 +6,10 @@ import {
   RefetchQueryNormalizationArtifactWrapper,
 } from './entrypoint';
 import {
-  ExtractData,
-  ExtractParameters,
   FragmentReference,
   Variables,
+  ExtractData,
+  ExtractParameters,
 } from './FragmentReference';
 import {
   assertLink,

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -1,8 +1,8 @@
 import { Factory } from '@isograph/disposable-types';
 import {
-  ExtractData,
-  ExtractParameters,
   FragmentReference,
+  ExtractParameters,
+  ExtractData,
 } from './FragmentReference';
 import {
   ComponentOrFieldName,

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -1,8 +1,8 @@
 import { Factory } from '@isograph/disposable-types';
 import {
-  FragmentReference,
-  ExtractParameters,
   ExtractData,
+  ExtractParameters,
+  FragmentReference,
 } from './FragmentReference';
 import {
   ComponentOrFieldName,
@@ -66,7 +66,7 @@ export type RefetchReaderArtifact = {
     variables: any,
     // TODO type this better
     filteredVariables: any,
-    rootId: Link,
+    rootLink: Link,
     readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
     // TODO type this better
     nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -6,8 +6,8 @@ import {
 } from './FragmentReference';
 import {
   ComponentOrFieldName,
-  DataId,
   IsographEnvironment,
+  type Link,
 } from './IsographEnvironment';
 import {
   IsographEntrypoint,
@@ -66,7 +66,7 @@ export type RefetchReaderArtifact = {
     variables: any,
     // TODO type this better
     filteredVariables: any,
-    rootId: DataId,
+    rootId: Link,
     readerArtifact: TopLevelReaderArtifact<any, any, any> | null,
     // TODO type this better
     nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],

--- a/libs/isograph-react/src/react/useImperativeReference.ts
+++ b/libs/isograph-react/src/react/useImperativeReference.ts
@@ -47,7 +47,7 @@ export function useImperativeReference<
             nestedRefetchQueries:
               entrypoint.readerWithRefetchQueries.nestedRefetchQueries,
           }),
-          root: ROOT_ID,
+          root: { __link: ROOT_ID },
           variables,
           networkRequest,
         },


### PR DESCRIPTION
The demos are working, the question is, should I replace all the variable names as well `recordId` -> `recordLink`, `rootId` -> `rootLink`, `targetParentRecordId` -> `targetParentRecordLink`