### PR TITLE
chore: Move from cargo-watch to bacon

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,120 @@
+# This is a configuration file for the bacon tool
+#
+# Bacon repository: https://github.com/Canop/bacon
+# Complete help on configuration: https://dystroy.org/bacon/config/
+# You can also check bacon's own bacon.toml file
+#  as an example: https://github.com/Canop/bacon/blob/main/bacon.toml
+
+default_job = "check"
+
+# Build and watch-libs are custom jobs, the rest of the file is from the Bacon default configuration
+[jobs.build]
+command = [
+	"cargo", "build",
+	"--color", "always",
+]
+need_stdout = false
+
+[jobs.watch-libs]
+command = ["pnpm", "-r", "compile"]
+need_stdout = true
+
+[jobs.check]
+command = ["cargo", "check", "--color", "always"]
+need_stdout = false
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets", "--color", "always"]
+need_stdout = false
+
+# Run clippy on the default target
+[jobs.clippy]
+command = [
+    "cargo", "clippy",
+    "--color", "always",
+]
+need_stdout = false
+
+# Run clippy on all targets
+# To disable some lints, you may change the job this way:
+#    [jobs.clippy-all]
+#    command = [
+#        "cargo", "clippy",
+#        "--all-targets",
+#        "--color", "always",
+#    	 "--",
+#    	 "-A", "clippy::bool_to_int_with_if",
+#    	 "-A", "clippy::collapsible_if",
+#    	 "-A", "clippy::derive_partial_eq_without_eq",
+#    ]
+# need_stdout = false
+[jobs.clippy-all]
+command = [
+    "cargo", "clippy",
+    "--all-targets",
+    "--color", "always",
+]
+need_stdout = false
+
+# This job lets you run
+# - all tests: bacon test
+# - a specific test: bacon test -- config::test_default_files
+# - the tests of a package: bacon test -- -- -p config
+[jobs.test]
+command = [
+    "cargo", "test", "--color", "always",
+    "--", "--color", "always", # see https://github.com/Canop/bacon/issues/124
+]
+need_stdout = true
+
+[jobs.nextest]
+command = ["cargo", "nextest", "run", "--color", "always", "--hide-progress-bar", "--failure-output", "final"]
+need_stdout = true
+analyzer = "nextest"
+
+[jobs.doc]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = false
+
+# If the doc compiles, then it opens in your browser and bacon switches
+# to the previous job
+[jobs.doc-open]
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back" # so that we don't open the browser at each change
+
+# You can run your application and have the result displayed in bacon,
+# *if* it makes sense for this crate.
+# Don't forget the `--color always` part or the errors won't be
+# properly parsed.
+# If your program never stops (eg a server), you may set `background`
+# to false to have the cargo run output immediately displayed instead
+# of waiting for program's end. If you prefer to have it restarted at
+# every change, then uncomment the 'on_change_strategy' line.
+[jobs.run]
+command = [
+    "cargo", "run",
+    "--color", "always",
+    # put launch parameters for your program behind a `--` separator
+]
+need_stdout = true
+allow_warnings = true
+background = true
+#on_change_strategy = "kill_then_restart"
+
+# This parameterized job runs the example of your choice, as soon
+# as the code compiles.
+# Call it as
+#    bacon ex -- my-example
+[jobs.ex]
+command = ["cargo", "run", "--color", "always", "--example"]
+need_stdout = true
+allow_warnings = true
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal global prefs.toml file instead.
+[keybindings]
+# alt-m = "job:my-job"
+c = "job:clippy-all" # comment this to have 'c' run clippy on only the default target

--- a/docs-website/docs/development-workflow.md
+++ b/docs-website/docs/development-workflow.md
@@ -33,7 +33,7 @@ These commands will install the appropriate node.js and pnpm version used by Iso
 
 Isograph currently uses `rustc 1.81.0 (eeb90cda1 2024-09-04)`. Rust is fairly stable and we don't rely on anything crazy, so it should be safe to keep your `rustc` up-to-date.
 
-You should also install `cargo watch` via `cargo install cargo-watch`.
+You should also install [`bacon`](https://dystroy.org/bacon/) via `cargo install --locked bacon`.
 
 ## Commands related to the compiler and Rust
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "vitest": "^2.1.2"
   },
   "scripts": {
-    "watch-rs": "cargo watch -x build -d 0.1 -w ./crates/",
-    "check-rs": "cargo watch -x check -d 0.1 -w ./crates/",
+    "watch-rs": "bacon -j build -p ./crates/",
+    "check-rs": "bacon -j check -p ./crates/",
     "build": "cargo build",
     "watch-pet-demo": "./target/debug/isograph_cli --config ./demos/pet-demo/isograph.config.json --watch",
     "watch-github-demo": "./target/debug/isograph_cli --config ./demos/github-demo/isograph.config.json --watch",
@@ -19,7 +19,7 @@
     "build-pet-demo": "./target/debug/isograph_cli --config ./demos/pet-demo/isograph.config.json",
     "build-isograph-react-demo": "./target/debug/isograph_cli --config ./libs/isograph-react/isograph.config.json",
     "build-vite-demo": "./target/debug/isograph_cli --config ./demos/vite-demo/isograph.config.json",
-    "watch-libs": "cargo watch -s 'pnpm -r compile' -d 0.1 -w ./libs",
+    "watch-libs": "bacon -j watch-libs -p ./libs",
     "format": "pnpm run format-prettier && pnpm run format-rust",
     "format-prettier": "prettier --config ./.prettierrc.json --write .",
     "format-rust": "cargo fmt",


### PR DESCRIPTION
# chore: Move from cargo-watch to bacon

## What
- Closes #195 by moving `cargo-watch` to `bacon`, the tool blessed by the creator of `cargo-watch`
- Slightly changes the developer experience. The console output isn't as pretty for the `pnpm` commands, and `bacon`  _completely_ takes over the terminal while running. All of it seems to work the same, **although I'd appreciate a bit of testing from someone with more experience working on Isograph before it goes in!**
- Updated the documentation to encourage developers to install `bacon`

## How
1. Wrote down what the flags all did in `cargo-watch`:
- `-x` means command to execute on change
- `-d` is file update debounce time in seconds (does not have `bacon` equivalent)
- `-w` is watch directory
- `-s` is shell command to execute on change (does not have flag equivalent, jobs are defined in `bacon.toml`)

2. Found matching ones (where the existed) in `bacon`:
- `-j` is job to launch (rough equivalent of `-x` and `-s`)
- `-p` is path to watch (equivalent of `-w`)

3. Generated the `bacon.toml` with `bacon --init`

4. Added the `build` and `watch-libs` jobs to capture the same functionality as `pnpm run watch-rs` and `pnpm run watch-libs`. There is no native `build` command for `bacon` (it just has `check`) and they [recommended making a custom job](https://github.com/Canop/bacon/issues/238#issuecomment-2407138772)

5. Updated the commands in `package.json`
