### PR TITLE
fix github-demo project names

### DIFF
--- a/demos/github-demo/package.json
+++ b/demos/github-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-isograph-demo",
+  "name": "github-demo",
   "version": "0.2.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
github-demo compilation was broken in watch mode. pnpm filters projects by a project name from `package.json` rather than a folder name