### PR TITLE
add tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,8 @@ dependencies = [
  "regex",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -760,6 +762,7 @@ dependencies = [
  "regex",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -770,6 +773,7 @@ dependencies = [
  "common_lang_types",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -1021,6 +1025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "object"
 version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1054,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1351,6 +1371,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +1625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,7 +1686,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1657,6 +1708,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1752,6 +1829,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,5 @@ serde_json = "1.0.108"
 strum = { version="0.25.0", features=["derive"] }
 thiserror = "1.0.40"
 tokio = { version="1.35.0", features=["full"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/crates/isograph_cli/Cargo.toml
+++ b/crates/isograph_cli/Cargo.toml
@@ -17,3 +17,5 @@ notify = { workspace = true }
 tokio = { workspace = true }
 notify-debouncer-full = { workspace = true }
 pretty-duration = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/isograph_cli/src/opt.rs
+++ b/crates/isograph_cli/src/opt.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
+use tracing::level_filters::LevelFilter;
 
 #[derive(Debug, Parser)]
 pub struct Opt {
@@ -26,6 +27,9 @@ pub(crate) struct CompileCommand {
     /// package.json under the `isograph` key.
     #[arg(long)]
     pub config: Option<PathBuf>,
+
+    #[arg(long, value_enum, default_value = "info")]
+    pub log_level: LevelFilter,
 }
 
 /// LSP

--- a/crates/isograph_compiler/Cargo.toml
+++ b/crates/isograph_compiler/Cargo.toml
@@ -22,3 +22,4 @@ notify = { workspace = true }
 tokio = { workspace = true }
 notify-debouncer-full = { workspace = true }
 pretty-duration = { workspace = true }
+tracing = { workspace = true }

--- a/crates/isograph_compiler/src/batch_compile.rs
+++ b/crates/isograph_compiler/src/batch_compile.rs
@@ -7,6 +7,7 @@ use isograph_lang_parser::IsographLiteralParseError;
 use isograph_schema::{ProcessClientFieldDeclarationError, ValidateSchemaError};
 use pretty_duration::pretty_duration;
 use thiserror::Error;
+use tracing::{error, info};
 
 use crate::{
     compiler_state::CompilerState, with_duration::WithDuration,
@@ -20,7 +21,7 @@ pub struct CompilationStats {
 }
 
 pub fn compile_and_print(config_location: PathBuf) -> Result<(), BatchCompileError> {
-    eprintln!("{}", "Starting to compile.".cyan());
+    info!("{}", "Starting to compile.".cyan());
     print_result(WithDuration::new(|| {
         CompilerState::new(config_location).batch_compile()
     }))
@@ -32,7 +33,7 @@ pub fn print_result(
     let elapsed_time = result.elapsed_time;
     match result.item {
         Ok(stats) => {
-            eprintln!(
+            info!(
                 "{}",
                 format!(
                     "Successfully compiled {} client fields and {} \
@@ -42,12 +43,11 @@ pub fn print_result(
                     stats.total_artifacts_written,
                     pretty_duration(&elapsed_time, None)
                 )
-                .bright_green()
             );
             Ok(())
         }
         Err(err) => {
-            eprintln!(
+            error!(
                 "{}\n{}\n{}",
                 "Error when compiling.\n".bright_red(),
                 err,

--- a/crates/isograph_config/Cargo.toml
+++ b/crates/isograph_config/Cargo.toml
@@ -11,3 +11,4 @@ common_lang_types = { path = "../common_lang_types" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 colorize = { workspace = true }
+tracing = { workspace = true }

--- a/crates/isograph_config/src/compilation_options.rs
+++ b/crates/isograph_config/src/compilation_options.rs
@@ -1,12 +1,11 @@
 use std::path::PathBuf;
 
 use serde::Deserialize;
+use tracing::warn;
 
 pub static ISOGRAPH_FOLDER: &str = "__isograph";
 
 use std::error::Error;
-
-use colorize::AnsiColor;
 
 #[derive(Debug, Clone)]
 pub struct CompilerConfig {
@@ -49,9 +48,7 @@ impl OptionalValidationLevel {
             OptionalValidationLevel::Ignore => Ok(()),
             OptionalValidationLevel::Warn => {
                 let warning = on_error();
-                // TODO pass to some sort of warning gatherer, this is weird!
-                // The fact that we know about colorize here is weird!
-                eprintln!("{}\n{}\n", "Warning:".yellow(), warning);
+                warn!("{warning}");
                 Ok(())
             }
             OptionalValidationLevel::Error => Err(on_error()),


### PR DESCRIPTION
Closes #239

This PR adds `tracing` to the compiler and exposes its `LevelFilter` enum as `--log-level` parameter with possible values: `trace`, `debug`, `info`, `warn`, `error`, `off`.

It can be later configured to measure spans duration or export data in various formats if needed.

Now we can use `debug!` or `trace!` macros to provide additional diagnostics.