### PR TITLE
Publish windows compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,12 +305,18 @@ jobs:
         with:
           name: isograph_cli-macos-arm64
           path: libs/isograph-compiler/artifacts/macos-arm64
+      - name: Download artifact isograph_cli-bin-win-x64
+        uses: actions/download-artifact@v4
+        with:
+          name: isograph_cli-bin-win-x64
+          path: libs/isograph-compiler/artifacts/win-x64
       - name: Mark binaries as executable
         run: |
           chmod +x libs/isograph-compiler/artifacts/linux-x64/isograph_cli
           chmod +x libs/isograph-compiler/artifacts/linux-arm64/isograph_cli
           chmod +x libs/isograph-compiler/artifacts/macos-x64/isograph_cli
           chmod +x libs/isograph-compiler/artifacts/macos-arm64/isograph_cli
+          chmod +x libs/isograph-compiler/artifacts/win-x64/isograph_cli.exe
       - name: Publish to NPM
         run: |
           for pkg in libs/*; do
@@ -373,6 +379,7 @@ jobs:
           chmod +x libs/isograph-compiler/artifacts/linux-arm64/isograph_cli
           chmod +x libs/isograph-compiler/artifacts/macos-x64/isograph_cli
           chmod +x libs/isograph-compiler/artifacts/macos-arm64/isograph_cli
+          chmod +x libs/isograph-compiler/artifacts/win-x64/isograph_cli.exe
       - name: Publish latest version to NPM
         run: |
           for pkg in libs/*; do


### PR DESCRIPTION
I thought I've fixed it before but it turns out I've only fixed it for `versioned-releases` not `main-releases`