### PR TITLE
chore: Fix vite-demo type checking

### DIFF
--- a/demos/vite-demo/package.json
+++ b/demos/vite-demo/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "tsc": "echo TODO figure out why this fails in CI",
+    "tsc": "tsc -noEmit",
     "iso": "../../target/debug/isograph_cli --config ./isograph.config.json",
     "iso-watch": "../../target/debug/isograph_cli --config ./isograph.config.json --watch"
   },


### PR DESCRIPTION
# chore: Fix vite-demo type checking

## What
- Fixes the `vite-demo` `tsc` command

## How
- Added the `--noEmit` flag. The `tsc` error was about an output file not matching an input file, but that's not really something we're concerned about. So by using the `--noEmit` flag, no compiler output is created, which is what was causing the problem! Types within the demo are still fully checked, so we lose nothing from this tweak