### PR TITLE
fix: Add noUncheckedIndexAccess to tsconfig

### DIFF
--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -516,7 +516,7 @@ function normalizeLinkedField(
     const dataIds: (Link | null)[] = [];
     for (let i = 0; i < networkResponseData.length; i++) {
       const networkResponseObject = networkResponseData[i];
-      if (networkResponseObject === null) {
+      if (networkResponseObject == null) {
         dataIds.push(null);
         continue;
       }

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -643,11 +643,11 @@ function generateChildVariableMap(
   const childVars: Writable<Variables> = {};
   for (const [name, value] of fieldArguments) {
     if (value.kind === 'Variable') {
-      const hting = variables[value.name];
-      if (hting == null) {
-        throw new Error('Variable ' + value.name + ' is not defined');
+      const variable = variables[value.name];
+      if (variable == null) {
+        throw new Error('Variable ' + value.name + ' is not missing');
       }
-      childVars[name] = hting;
+      childVars[name] = variable;
     } else {
       childVars[name] = value.value;
     }

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -374,15 +374,13 @@ function readData<TReadFromStore>(
       }
       case 'Resolver': {
         const usedRefetchQueries = field.usedRefetchQueries;
-        const resolverRefetchQueries = usedRefetchQueries.map(
-          (index) => {
-            const resolverRefetchQuery = nestedRefetchQueries[index];
-            if (resolverRefetchQuery == null) {
-                throw new Error('resolverRefetchQuery is null in Resolver');
-            }
-            return resolverRefetchQuery;
-          },
-        );
+        const resolverRefetchQueries = usedRefetchQueries.map((index) => {
+          const resolverRefetchQuery = nestedRefetchQueries[index];
+          if (resolverRefetchQuery == null) {
+            throw new Error('resolverRefetchQuery is null in Resolver');
+          }
+          return resolverRefetchQuery;
+        });
 
         switch (field.readerArtifact.kind) {
           case 'EagerReaderArtifact': {
@@ -645,7 +643,11 @@ function generateChildVariableMap(
   const childVars: Writable<Variables> = {};
   for (const [name, value] of fieldArguments) {
     if (value.kind === 'Variable') {
-      childVars[name] = variables[value.name];
+      const hting = variables[value.name];
+      if (hting == null) {
+        throw new Error('Variable ' + value.name + ' is not defined');
+      }
+      childVars[name] = hting;
     } else {
       childVars[name] = value.value;
     }

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -342,12 +342,11 @@ function readData<TReadFromStore>(
           };
         } else {
           const refetchQueryIndex = field.refetchQuery;
-          if (refetchQueryIndex == null) {
-            throw new Error('refetchQueryIndex is null in RefetchField');
-          }
           const refetchQuery = nestedRefetchQueries[refetchQueryIndex];
           if (refetchQuery == null) {
-            throw new Error('refetchQuery is null in RefetchField');
+            throw new Error(
+              'refetchQuery is null in RefetchField. This is indicative of a bug in Isograph.',
+            );
           }
           const refetchQueryArtifact = refetchQuery.artifact;
           const allowedVariables = refetchQuery.allowedVariables;
@@ -377,7 +376,9 @@ function readData<TReadFromStore>(
         const resolverRefetchQueries = usedRefetchQueries.map((index) => {
           const resolverRefetchQuery = nestedRefetchQueries[index];
           if (resolverRefetchQuery == null) {
-            throw new Error('resolverRefetchQuery is null in Resolver');
+            throw new Error(
+              'resolverRefetchQuery is null in Resolver. This is indicative of a bug in Isograph.',
+            );
           }
           return resolverRefetchQuery;
         });
@@ -644,10 +645,11 @@ function generateChildVariableMap(
   for (const [name, value] of fieldArguments) {
     if (value.kind === 'Variable') {
       const variable = variables[value.name];
-      if (variable == null) {
-        throw new Error('Variable ' + value.name + ' is not missing');
+      // Variable could be null if it was not provided but has a default case,
+      // so we allow the loop to continue rather than throwing an error.
+      if (variable != null) {
+        childVars[name] = variable;
       }
-      childVars[name] = variable;
     } else {
       childVars[name] = value.value;
     }

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -343,9 +343,12 @@ function readData<TReadFromStore>(
         } else {
           const refetchQueryIndex = field.refetchQuery;
           if (refetchQueryIndex == null) {
-            throw new Error('refetchQuery is null in RefetchField');
+            throw new Error('refetchQueryIndex is null in RefetchField');
           }
           const refetchQuery = nestedRefetchQueries[refetchQueryIndex];
+          if (refetchQuery == null) {
+            throw new Error('refetchQuery is null in RefetchField');
+          }
           const refetchQueryArtifact = refetchQuery.artifact;
           const allowedVariables = refetchQuery.allowedVariables;
 
@@ -372,7 +375,13 @@ function readData<TReadFromStore>(
       case 'Resolver': {
         const usedRefetchQueries = field.usedRefetchQueries;
         const resolverRefetchQueries = usedRefetchQueries.map(
-          (index) => nestedRefetchQueries[index],
+          (index) => {
+            const resolverRefetchQuery = nestedRefetchQueries[index];
+            if (resolverRefetchQuery == null) {
+                throw new Error('resolverRefetchQuery is null in Resolver');
+            }
+            return resolverRefetchQuery;
+          },
         );
 
         switch (field.readerArtifact.kind) {

--- a/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
@@ -114,8 +114,13 @@ export function useConnectionSpecPagination<
         fragmentReference.readerWithRefetchQueries,
       );
 
+      const data = readOutDataAndRecords[i]?.item;
+      if (data == null) {
+        throw new Error('Parameter data is unexpectedly null');
+      }
+
       const firstParameter = {
-        data: readOutDataAndRecords[i].item,
+        data,
         parameters: fragmentReference.variables,
       };
 
@@ -165,10 +170,17 @@ export function useConnectionSpecPagination<
           fragmentReference.readerWithRefetchQueries,
         );
 
+        const records = readOutDataAndRecords[i];
+        if (records == null) {
+          throw new Error(
+            'subscribeCompletedFragmentReferences records is unexpectedly null',
+          );
+        }
+
         return {
           fragmentReference,
           readerAst: readerWithRefetchQueries.readerArtifact.readerAst,
-          records: readOutDataAndRecords[i],
+          records,
           callback(_data) {
             rerender({});
           },
@@ -224,10 +236,9 @@ export function useConnectionSpecPagination<
 
   const loadedReferences = state === UNASSIGNED_STATE ? [] : state;
 
-  const mostRecentItem: LoadedFragmentReference<
-    TReadFromStore,
-    Connection<TItem>
-  > | null = loadedReferences[loadedReferences.length - 1];
+  const mostRecentItem:
+    | LoadedFragmentReference<TReadFromStore, Connection<TItem>>
+    | undefined = loadedReferences[loadedReferences.length - 1];
   const mostRecentFragmentReference =
     mostRecentItem?.[0].getItemIfNotDisposed();
 

--- a/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
@@ -114,9 +114,12 @@ export function useConnectionSpecPagination<
         fragmentReference.readerWithRefetchQueries,
       );
 
+      // invariant: readOutDataAndRecords.length === completedReferences.length
       const data = readOutDataAndRecords[i]?.item;
       if (data == null) {
-        throw new Error('Parameter data is unexpectedly null');
+        throw new Error(
+          'Parameter data is unexpectedly null. This is indicative of a bug in Isograph.',
+        );
       }
 
       const firstParameter = {

--- a/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
@@ -106,8 +106,13 @@ export function useSkipLimitPagination<
         fragmentReference.readerWithRefetchQueries,
       );
 
+      const data = readOutDataAndRecords[i]?.item;
+      if (data == null) {
+        throw new Error('Parameter data is unexpectedly null');
+      }
+
       const firstParameter = {
-        data: readOutDataAndRecords[i].item,
+        data,
         parameters: fragmentReference.variables,
       };
 
@@ -150,10 +155,17 @@ export function useSkipLimitPagination<
           fragmentReference.readerWithRefetchQueries,
         );
 
+        const records = readOutDataAndRecords[i];
+        if (records == null) {
+          throw new Error(
+            'subscribeCompletedFragmentReferences records is unexpectedly null',
+          );
+        }
+
         return {
           fragmentReference,
           readerAst: readerWithRefetchQueries.readerArtifact.readerAst,
-          records: readOutDataAndRecords[i],
+          records,
           callback(_data) {
             rerender({});
           },
@@ -209,8 +221,9 @@ export function useSkipLimitPagination<
 
   const loadedReferences = state === UNASSIGNED_STATE ? [] : state;
 
-  const mostRecentItem: LoadedFragmentReference<TReadFromStore, TItem> | undefined =
-    loadedReferences[loadedReferences.length - 1];
+  const mostRecentItem:
+    | LoadedFragmentReference<TReadFromStore, TItem>
+    | undefined = loadedReferences[loadedReferences.length - 1];
   const mostRecentFragmentReference =
     mostRecentItem?.[0].getItemIfNotDisposed();
 

--- a/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
@@ -106,9 +106,12 @@ export function useSkipLimitPagination<
         fragmentReference.readerWithRefetchQueries,
       );
 
+      // invariant: readOutDataAndRecords.length === completedReferences.length
       const data = readOutDataAndRecords[i]?.item;
       if (data == null) {
-        throw new Error('Parameter data is unexpectedly null');
+        throw new Error(
+          'Parameter data is unexpectedly null. This is indicative of a bug in Isograph.',
+        );
       }
 
       const firstParameter = {

--- a/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
@@ -209,7 +209,7 @@ export function useSkipLimitPagination<
 
   const loadedReferences = state === UNASSIGNED_STATE ? [] : state;
 
-  const mostRecentItem: LoadedFragmentReference<TReadFromStore, TItem> | null =
+  const mostRecentItem: LoadedFragmentReference<TReadFromStore, TItem> | undefined =
     loadedReferences[loadedReferences.length - 1];
   const mostRecentFragmentReference =
     mostRecentItem?.[0].getItemIfNotDisposed();

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,6 +14,7 @@
     "noFallthroughCasesInSwitch": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
     "paths": {
       "@isograph/*": ["./libs/*"]
     },


### PR DESCRIPTION
# fix: Add noUncheckedIndexAccess to tsconfig

## What
- Adds the `noUncheckedIndexAccess` option to the base `tsconfig.json` file
- Fixes the errors that appeared
- Resolves #213 

## How
- Added line to the file
- Fixed issues primarily by throwing errors, as each area of the code expects it to exist and something is very wrong if it doesn't
- Loosened equality checks in some places so all falsey values are caught
- Changed a few `null`s to `undefined`s because accessing an index that doesn't exist (or accessing an array with `undefined` as an index value returns `undefined`)