### PR TITLE
add magic `link` field

### DIFF
--- a/crates/graphql_artifact_generation/src/eager_reader_artifact.rs
+++ b/crates/graphql_artifact_generation/src/eager_reader_artifact.rs
@@ -167,7 +167,7 @@ pub(crate) fn generate_eager_reader_condition_artifact(
         {}{reader_output_type}\n\
         > = {{\n\
         {}kind: \"EagerReaderArtifact\",\n\
-        {}resolver: ({{ data }}) => data.__typename === \"{concrete_type}\",\n\
+        {}resolver: ({{ data }}) => data.__typename === \"{concrete_type}\" ? data.__link : null,\n\
         {}readerAst,\n\
         }};\n\n\
         export default artifact;\n",

--- a/crates/graphql_artifact_generation/src/eager_reader_artifact.rs
+++ b/crates/graphql_artifact_generation/src/eager_reader_artifact.rs
@@ -196,7 +196,7 @@ pub(crate) fn generate_eager_reader_param_type_artifact(
 
     let mut param_type_imports = BTreeSet::new();
     let mut loadable_fields = BTreeSet::new();
-    let mut link_fields = BTreeSet::new();
+    let mut link_fields = false;
     let client_field_parameter_type = generate_client_field_parameter_type(
         schema,
         client_field.selection_set_for_parent_query(),
@@ -211,7 +211,7 @@ pub(crate) fn generate_eager_reader_param_type_artifact(
         param_type_imports_to_import_statement(&param_type_imports, file_extensions);
     let reader_param_type = format!("{}__{}__param", parent_type.name, client_field.name);
 
-    let link_field_imports = if !link_fields.is_empty() {
+    let link_field_imports = if link_fields {
         "import type { Link } from '@isograph/react';\n".to_string()
     } else {
         "".to_string()

--- a/crates/graphql_artifact_generation/src/eager_reader_artifact.rs
+++ b/crates/graphql_artifact_generation/src/eager_reader_artifact.rs
@@ -212,37 +212,20 @@ pub(crate) fn generate_eager_reader_param_type_artifact(
     let reader_param_type = format!("{}__{}__param", parent_type.name, client_field.name);
 
     let link_field_imports = if !link_fields.is_empty() {
-        Some("type Link")
+        "import type { Link } from '@isograph/react';\n".to_string()
     } else {
-        None
+        "".to_string()
     };
 
     let loadable_field_imports = if !loadable_fields.is_empty() {
         let param_imports =
             param_type_imports_to_import_param_statement(&loadable_fields, file_extensions);
-
-        Some(("type LoadableField, type ExtractParameters", param_imports))
+        format!(
+            "import {{ type LoadableField, type ExtractParameters }} from '@isograph/react';\n\
+            {param_imports}"
+        )
     } else {
-        None
-    };
-
-    let isograph_react_imports = match (link_field_imports, loadable_field_imports) {
-        (None, None) => "".to_string(),
-        (Some(link_field_import), None) => {
-            format!("import {{ {link_field_import} }} from '@isograph/react';\n")
-        }
-        (None, Some((loadable_field_imports, param_imports))) => {
-            format!(
-                "import {{ {loadable_field_imports} }} from '@isograph/react';\n\
-                {param_imports}"
-            )
-        }
-        (Some(link_field_import), Some((loadable_field_imports, param_imports))) => {
-            format!(
-                "import {{ {link_field_import}, {loadable_field_imports} }} from '@isograph/react';\n\
-                {param_imports}"
-            )
-        }
+        "".to_string()
     };
 
     let (parameters_import, parameters_type) = if !client_field.variable_definitions.is_empty() {
@@ -259,7 +242,8 @@ pub(crate) fn generate_eager_reader_param_type_artifact(
     let indent = "  ";
     let param_type_content = format!(
         "{param_type_import_statement}\
-        {isograph_react_imports}\
+        {link_field_imports}\
+        {loadable_field_imports}\
         {parameters_import}\n\
         export type {reader_param_type} = {{\n\
         {indent}readonly data: {client_field_parameter_type},\n\

--- a/crates/graphql_artifact_generation/src/generate_artifacts.rs
+++ b/crates/graphql_artifact_generation/src/generate_artifacts.rs
@@ -530,7 +530,7 @@ fn write_param_type_from_selection(
 
                     match client_field.variant {
                         ClientFieldVariant::Link => {
-                            link_fields.insert(());
+                            *link_fields = true;
                             let output_type = "Link";
                             query_type_declaration.push_str(
                                 &(format!(

--- a/crates/graphql_artifact_generation/src/generate_artifacts.rs
+++ b/crates/graphql_artifact_generation/src/generate_artifacts.rs
@@ -131,7 +131,7 @@ pub fn get_artifact_path_and_content(
             }
             FieldType::ClientField(encountered_client_field_id) => {
                 let encountered_client_field = schema.client_field(*encountered_client_field_id);
-                // Generate reader ASTs for all encountered client fields, which may be reader or refetch reader
+
                 match &encountered_client_field.variant {
                     ClientFieldVariant::Link => (),
                     ClientFieldVariant::UserWritten(info) => {

--- a/crates/graphql_artifact_generation/src/import_statements.rs
+++ b/crates/graphql_artifact_generation/src/import_statements.rs
@@ -22,6 +22,7 @@ impl ImportedFileCategory {
 
 pub(crate) type ReaderImports = BTreeSet<(ObjectTypeAndFieldName, ImportedFileCategory)>;
 pub(crate) type ParamTypeImports = BTreeSet<ObjectTypeAndFieldName>;
+pub(crate) type LinkImports = BTreeSet<()>;
 
 pub(crate) fn reader_imports_to_import_statement(
     reader_imports: &ReaderImports,

--- a/crates/graphql_artifact_generation/src/import_statements.rs
+++ b/crates/graphql_artifact_generation/src/import_statements.rs
@@ -22,7 +22,7 @@ impl ImportedFileCategory {
 
 pub(crate) type ReaderImports = BTreeSet<(ObjectTypeAndFieldName, ImportedFileCategory)>;
 pub(crate) type ParamTypeImports = BTreeSet<ObjectTypeAndFieldName>;
-pub(crate) type LinkImports = BTreeSet<()>;
+pub(crate) type LinkImports = bool;
 
 pub(crate) fn reader_imports_to_import_statement(
     reader_imports: &ReaderImports,

--- a/crates/graphql_artifact_generation/src/iso_overload_file.rs
+++ b/crates/graphql_artifact_generation/src/iso_overload_file.rs
@@ -263,6 +263,7 @@ fn user_written_fields(
         .iter()
         .filter_map(|client_field| match client_field {
             ClientType::ClientField(client_field) => match client_field.variant {
+                ClientFieldVariant::Link => None,
                 ClientFieldVariant::UserWritten(info) => {
                     Some((client_field, info.user_written_component_variant))
                 }

--- a/crates/graphql_artifact_generation/src/reader_ast.rs
+++ b/crates/graphql_artifact_generation/src/reader_ast.rs
@@ -225,7 +225,6 @@ fn scalar_client_defined_field_ast_node(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn link_variant_ast_node(
     scalar_field_selection: &ValidatedScalarFieldSelection,
     indentation_level: u8,

--- a/crates/isograph_compiler/src/source_files.rs
+++ b/crates/isograph_compiler/src/source_files.rs
@@ -67,6 +67,7 @@ impl SourceFiles {
         process_iso_literals(schema, self.contains_iso)?;
         process_exposed_fields(schema)?;
         schema.add_fields_to_subtypes(&outcome.type_refinement_maps.supertype_to_subtype_map)?;
+        schema.add_link_fields()?;
         schema
             .add_pointers_to_supertypes(&outcome.type_refinement_maps.subtype_to_supertype_map)?;
         add_refetch_fields_to_objects(schema)?;

--- a/crates/isograph_schema/src/add_link_fields.rs
+++ b/crates/isograph_schema/src/add_link_fields.rs
@@ -26,7 +26,7 @@ impl UnvalidatedSchema {
                     variant: ClientFieldVariant::Link,
                     type_and_field: ObjectTypeAndFieldName {
                         field_name,
-                        type_name: "ID".intern().into(),
+                        type_name: object.name,
                     },
                     refetch_strategy: None,
                 }));

--- a/crates/isograph_schema/src/add_link_fields.rs
+++ b/crates/isograph_schema/src/add_link_fields.rs
@@ -1,0 +1,61 @@
+use common_lang_types::{Location, WithLocation};
+use intern::string_key::Intern;
+
+use crate::{
+    ClientField, ClientFieldVariant, ClientType, FieldType, ObjectTypeAndFieldName,
+    ProcessTypeDefinitionError, ProcessTypeDefinitionResult, UnvalidatedSchema,
+};
+
+impl UnvalidatedSchema {
+    /// For each supertype (e.g. Node), add the fields defined on it (e.g. Node.MyComponent)
+    /// to subtypes (e.g. creating User.MyComponent).
+    ///
+    /// We do not transfer server fields (because that makes no sense in GraphQL, but does
+    /// it make sense otherwise??) and refetch fields (which are already defined on all valid
+    /// types.)
+    ///
+    /// TODO confirm we don't do this for unions...
+    pub fn add_link_fields(&mut self) -> ProcessTypeDefinitionResult<()> {
+        for object in &mut self.server_field_data.server_objects {
+            let field_name = "__link".intern().into();
+            let next_client_field_id = self.client_fields.len().into();
+            self.client_fields
+                .push(ClientType::ClientField(ClientField {
+                    description: Some(
+                        format!("A store Link for the {} type.", object.name)
+                            .intern()
+                            .into(),
+                    ),
+                    id: next_client_field_id,
+                    name: field_name,
+                    parent_object_id: object.id,
+                    variable_definitions: vec![],
+                    reader_selection_set: Some(vec![]),
+                    variant: ClientFieldVariant::Link,
+                    type_and_field: ObjectTypeAndFieldName {
+                        field_name,
+                        type_name: "ID".intern().into(),
+                    },
+                    refetch_strategy: None,
+                }));
+
+            if object
+                .encountered_fields
+                .insert(
+                    field_name,
+                    FieldType::ClientField(ClientType::ClientField(next_client_field_id)),
+                )
+                .is_some()
+            {
+                return Err(WithLocation::new(
+                    ProcessTypeDefinitionError::FieldExistsOnType {
+                        field_name,
+                        parent_type: object.name,
+                    },
+                    Location::generated(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/isograph_schema/src/add_link_fields.rs
+++ b/crates/isograph_schema/src/add_link_fields.rs
@@ -17,7 +17,7 @@ impl UnvalidatedSchema {
     /// TODO confirm we don't do this for unions...
     pub fn add_link_fields(&mut self) -> ProcessTypeDefinitionResult<()> {
         for object in &mut self.server_field_data.server_objects {
-            let field_name = "__link".intern().into();
+            let field_name = "link".intern().into();
             let next_client_field_id = self.client_fields.len().into();
             self.client_fields
                 .push(ClientType::ClientField(ClientField {

--- a/crates/isograph_schema/src/add_link_fields.rs
+++ b/crates/isograph_schema/src/add_link_fields.rs
@@ -1,15 +1,14 @@
-use common_lang_types::{Location, WithLocation};
-use intern::string_key::Intern;
-
 use crate::{
     ClientField, ClientFieldVariant, ClientType, FieldType, ObjectTypeAndFieldName,
-    ProcessTypeDefinitionError, ProcessTypeDefinitionResult, UnvalidatedSchema,
+    ProcessTypeDefinitionError, ProcessTypeDefinitionResult, UnvalidatedSchema, LINK_FIELD_NAME,
 };
+use common_lang_types::{Location, WithLocation};
+use intern::string_key::Intern;
 
 impl UnvalidatedSchema {
     pub fn add_link_fields(&mut self) -> ProcessTypeDefinitionResult<()> {
         for object in &mut self.server_field_data.server_objects {
-            let field_name = "link".intern().into();
+            let field_name = (*LINK_FIELD_NAME).into();
             let next_client_field_id = self.client_fields.len().into();
             self.client_fields
                 .push(ClientType::ClientField(ClientField {

--- a/crates/isograph_schema/src/add_link_fields.rs
+++ b/crates/isograph_schema/src/add_link_fields.rs
@@ -7,14 +7,6 @@ use crate::{
 };
 
 impl UnvalidatedSchema {
-    /// For each supertype (e.g. Node), add the fields defined on it (e.g. Node.MyComponent)
-    /// to subtypes (e.g. creating User.MyComponent).
-    ///
-    /// We do not transfer server fields (because that makes no sense in GraphQL, but does
-    /// it make sense otherwise??) and refetch fields (which are already defined on all valid
-    /// types.)
-    ///
-    /// TODO confirm we don't do this for unions...
     pub fn add_link_fields(&mut self) -> ProcessTypeDefinitionResult<()> {
         for object in &mut self.server_field_data.server_objects {
             let field_name = "link".intern().into();

--- a/crates/isograph_schema/src/add_pointers_to_supertypes.rs
+++ b/crates/isograph_schema/src/add_pointers_to_supertypes.rs
@@ -4,7 +4,7 @@ use intern::string_key::Intern;
 use isograph_lang_types::{ScalarFieldSelection, ServerFieldSelection};
 
 use crate::{
-    FieldType, ProcessTypeDefinitionError, ProcessTypeDefinitionResult, SchemaObject,
+    ClientType, FieldType, ProcessTypeDefinitionError, ProcessTypeDefinitionResult, SchemaObject,
     SchemaServerField, SchemaServerFieldVariant, ServerFieldTypeAssociatedData,
     ServerFieldTypeAssociatedDataInlineFragment, UnvalidatedSchema,
     ValidatedIsographSelectionVariant, ValidatedScalarFieldAssociatedData,
@@ -56,7 +56,31 @@ impl UnvalidatedSchema {
                     Span::todo_generated(),
                 );
 
-                let condition_selection_set = vec![typename_selection];
+                let link_selection = WithSpan::new(
+                    ServerFieldSelection::ScalarField(ScalarFieldSelection {
+                        arguments: vec![],
+                        associated_data: ValidatedScalarFieldAssociatedData {
+                            location: FieldType::ClientField(
+                                match *subtype
+                                    .encountered_fields
+                                    .get(&"__link".intern().into())
+                                    .expect("Expected __link to exist")
+                                    .as_client_field()
+                                    .expect("Expected __link to be client field")
+                                {
+                                    ClientType::ClientField(client_field_id) => client_field_id,
+                                },
+                            ),
+                            selection_variant: ValidatedIsographSelectionVariant::Regular,
+                        },
+                        directives: vec![],
+                        name: WithLocation::new("__link".intern().into(), Location::generated()),
+                        reader_alias: None,
+                    }),
+                    Span::todo_generated(),
+                );
+
+                let condition_selection_set = vec![typename_selection, link_selection];
 
                 let server_field = SchemaServerField {
                     description: Some(

--- a/crates/isograph_schema/src/add_pointers_to_supertypes.rs
+++ b/crates/isograph_schema/src/add_pointers_to_supertypes.rs
@@ -63,10 +63,10 @@ impl UnvalidatedSchema {
                             location: FieldType::ClientField(
                                 match *subtype
                                     .encountered_fields
-                                    .get(&"__link".intern().into())
-                                    .expect("Expected __link to exist")
+                                    .get(&"link".intern().into())
+                                    .expect("Expected link to exist")
                                     .as_client_field()
-                                    .expect("Expected __link to be client field")
+                                    .expect("Expected link to be client field")
                                 {
                                     ClientType::ClientField(client_field_id) => client_field_id,
                                 },
@@ -74,7 +74,7 @@ impl UnvalidatedSchema {
                             selection_variant: ValidatedIsographSelectionVariant::Regular,
                         },
                         directives: vec![],
-                        name: WithLocation::new("__link".intern().into(), Location::generated()),
+                        name: WithLocation::new("link".intern().into(), Location::generated()),
                         reader_alias: None,
                     }),
                     Span::todo_generated(),

--- a/crates/isograph_schema/src/add_pointers_to_supertypes.rs
+++ b/crates/isograph_schema/src/add_pointers_to_supertypes.rs
@@ -8,7 +8,7 @@ use crate::{
     SchemaServerField, SchemaServerFieldVariant, ServerFieldTypeAssociatedData,
     ServerFieldTypeAssociatedDataInlineFragment, UnvalidatedSchema,
     ValidatedIsographSelectionVariant, ValidatedScalarFieldAssociatedData,
-    ValidatedTypeRefinementMap,
+    ValidatedTypeRefinementMap, LINK_FIELD_NAME,
 };
 use common_lang_types::Location;
 impl UnvalidatedSchema {
@@ -63,7 +63,7 @@ impl UnvalidatedSchema {
                             location: FieldType::ClientField(
                                 match *subtype
                                     .encountered_fields
-                                    .get(&"link".intern().into())
+                                    .get(&(*LINK_FIELD_NAME).into())
                                     .expect("Expected link to exist")
                                     .as_client_field()
                                     .expect("Expected link to be client field")
@@ -74,7 +74,7 @@ impl UnvalidatedSchema {
                             selection_variant: ValidatedIsographSelectionVariant::Regular,
                         },
                         directives: vec![],
-                        name: WithLocation::new("link".intern().into(), Location::generated()),
+                        name: WithLocation::new(*LINK_FIELD_NAME, Location::generated()),
                         reader_alias: None,
                     }),
                     Span::todo_generated(),

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -44,6 +44,7 @@ lazy_static! {
     pub static ref REFETCH_FIELD_NAME: ScalarFieldName = "__refetch".intern().into();
     pub static ref NODE_FIELD_NAME: LinkedFieldName = "node".intern().into();
     pub static ref TYPENAME_FIELD_NAME: ScalarFieldName = "__typename".intern().into();
+    pub static ref LINK_FIELD_NAME: ScalarFieldName = "link".intern().into();
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -18,7 +18,7 @@ use lazy_static::lazy_static;
 use crate::{
     categorize_field_loadability, create_transformed_name_and_arguments,
     expose_field_directive::RequiresRefinement, transform_arguments_with_child_context,
-    transform_name_and_arguments_with_child_variable_context, FieldType,
+    transform_name_and_arguments_with_child_variable_context, ClientFieldVariant, FieldType,
     ImperativelyLoadedFieldVariant, Loadability, NameAndArguments, PathToRefetchField,
     RootOperationName, SchemaObject, SchemaServerFieldVariant, UnvalidatedVariableDefinition,
     ValidatedClientField, ValidatedIsographSelectionVariant, ValidatedScalarFieldSelection,
@@ -713,16 +713,22 @@ fn merge_validated_selections_into_selection_map(
                                     variant,
                                 );
                             }
-                            None => merge_non_loadable_scalar_client_field(
-                                parent_type,
-                                schema,
-                                parent_map,
-                                merge_traversal_state,
-                                newly_encountered_scalar_client_field,
-                                encountered_client_field_map,
-                                variable_context,
-                                &scalar_field_selection.arguments,
-                            ),
+                            None => match newly_encountered_scalar_client_field.variant {
+                                ClientFieldVariant::Link => {}
+                                ClientFieldVariant::ImperativelyLoadedField(_)
+                                | ClientFieldVariant::UserWritten(_) => {
+                                    merge_non_loadable_scalar_client_field(
+                                        parent_type,
+                                        schema,
+                                        parent_map,
+                                        merge_traversal_state,
+                                        newly_encountered_scalar_client_field,
+                                        encountered_client_field_map,
+                                        variable_context,
+                                        &scalar_field_selection.arguments,
+                                    )
+                                }
+                            },
                         }
 
                         merge_traversal_state

--- a/crates/isograph_schema/src/lib.rs
+++ b/crates/isograph_schema/src/lib.rs
@@ -1,5 +1,6 @@
 mod accessible_client_fields_iterator;
 mod add_fields_to_subtypes;
+mod add_link_fields;
 mod add_pointers_to_supertypes;
 mod argument_map;
 mod create_merged_selection_set;

--- a/crates/isograph_schema/src/process_client_field_declaration.rs
+++ b/crates/isograph_schema/src/process_client_field_declaration.rs
@@ -199,6 +199,7 @@ pub struct UserWrittenClientFieldInfo {
 pub enum ClientFieldVariant {
     UserWritten(UserWrittenClientFieldInfo),
     ImperativelyLoadedField(ImperativelyLoadedFieldVariant),
+    Link,
 }
 
 lazy_static! {

--- a/crates/isograph_schema/src/validate_schema.rs
+++ b/crates/isograph_schema/src/validate_schema.rs
@@ -331,6 +331,7 @@ pub fn categorize_field_loadability<'a>(
     selection_variant: &'a ValidatedIsographSelectionVariant,
 ) -> Option<Loadability<'a>> {
     match &client_field.variant {
+        ClientFieldVariant::Link => None,
         ClientFieldVariant::UserWritten(_) => match selection_variant {
             ValidatedIsographSelectionVariant::Regular => None,
             ValidatedIsographSelectionVariant::Loadable((l, _)) => {

--- a/demos/github-demo/src/isograph-components/__isograph/User/asUser/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/asUser/resolver_reader.ts
@@ -1,4 +1,4 @@
-import type { EagerReaderArtifact, ReaderAst } from '@isograph/react';
+import type { EagerReaderArtifact, ReaderAst, Link } from '@isograph/react';
 
 const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }> = [
   {
@@ -9,16 +9,16 @@ const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }
   },
   {
     kind: "Link",
-    alias: "__link",
+    alias: "link",
   },
 ];
 
 const artifact: EagerReaderArtifact<
   { data: any, parameters: Record<PropertyKey, never> },
-  boolean
+  Link | null
 > = {
   kind: "EagerReaderArtifact",
-  resolver: ({ data }) => data.__typename === "User" ? data.__link : null,
+  resolver: ({ data }) => data.__typename === "User" ? data.link : null,
   readerAst,
 };
 

--- a/demos/github-demo/src/isograph-components/__isograph/User/asUser/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/asUser/resolver_reader.ts
@@ -7,6 +7,10 @@ const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }
     alias: null,
     arguments: null,
   },
+  {
+    kind: "Link",
+    alias: "__link",
+  },
 ];
 
 const artifact: EagerReaderArtifact<
@@ -14,7 +18,7 @@ const artifact: EagerReaderArtifact<
   boolean
 > = {
   kind: "EagerReaderArtifact",
-  resolver: ({ data }) => data.__typename === "User",
+  resolver: ({ data }) => data.__typename === "User" ? data.__link : null,
   readerAst,
 };
 

--- a/demos/pet-demo/src/components/__isograph/AdItem/asAdItem/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/asAdItem/resolver_reader.ts
@@ -7,6 +7,10 @@ const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }
     alias: null,
     arguments: null,
   },
+  {
+    kind: "Link",
+    alias: "__link",
+  },
 ];
 
 const artifact: EagerReaderArtifact<
@@ -14,7 +18,7 @@ const artifact: EagerReaderArtifact<
   boolean
 > = {
   kind: "EagerReaderArtifact",
-  resolver: ({ data }) => data.__typename === "AdItem",
+  resolver: ({ data }) => data.__typename === "AdItem" ? data.__link : null,
   readerAst,
 };
 

--- a/demos/pet-demo/src/components/__isograph/AdItem/asAdItem/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/asAdItem/resolver_reader.ts
@@ -1,4 +1,4 @@
-import type { EagerReaderArtifact, ReaderAst } from '@isograph/react';
+import type { EagerReaderArtifact, ReaderAst, Link } from '@isograph/react';
 
 const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }> = [
   {
@@ -9,16 +9,16 @@ const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }
   },
   {
     kind: "Link",
-    alias: "__link",
+    alias: "link",
   },
 ];
 
 const artifact: EagerReaderArtifact<
   { data: any, parameters: Record<PropertyKey, never> },
-  boolean
+  Link | null
 > = {
   kind: "EagerReaderArtifact",
-  resolver: ({ data }) => data.__typename === "AdItem" ? data.__link : null,
+  resolver: ({ data }) => data.__typename === "AdItem" ? data.link : null,
   readerAst,
 };
 

--- a/demos/pet-demo/src/components/__isograph/BlogItem/asBlogItem/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/asBlogItem/resolver_reader.ts
@@ -7,6 +7,10 @@ const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }
     alias: null,
     arguments: null,
   },
+  {
+    kind: "Link",
+    alias: "__link",
+  },
 ];
 
 const artifact: EagerReaderArtifact<
@@ -14,7 +18,7 @@ const artifact: EagerReaderArtifact<
   boolean
 > = {
   kind: "EagerReaderArtifact",
-  resolver: ({ data }) => data.__typename === "BlogItem",
+  resolver: ({ data }) => data.__typename === "BlogItem" ? data.__link : null,
   readerAst,
 };
 

--- a/demos/pet-demo/src/components/__isograph/BlogItem/asBlogItem/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/asBlogItem/resolver_reader.ts
@@ -1,4 +1,4 @@
-import type { EagerReaderArtifact, ReaderAst } from '@isograph/react';
+import type { EagerReaderArtifact, ReaderAst, Link } from '@isograph/react';
 
 const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }> = [
   {
@@ -9,16 +9,16 @@ const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }
   },
   {
     kind: "Link",
-    alias: "__link",
+    alias: "link",
   },
 ];
 
 const artifact: EagerReaderArtifact<
   { data: any, parameters: Record<PropertyKey, never> },
-  boolean
+  Link | null
 > = {
   kind: "EagerReaderArtifact",
-  resolver: ({ data }) => data.__typename === "BlogItem" ? data.__link : null,
+  resolver: ({ data }) => data.__typename === "BlogItem" ? data.link : null,
   readerAst,
 };
 

--- a/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
+++ b/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
@@ -1,3 +1,4 @@
+import type { Link } from './IsographEnvironment';
 import type { ReaderAst, ReaderLinkedField, ReaderScalarField } from './reader';
 export function mergeUsingReaderAst(
   field: ReaderScalarField | ReaderLinkedField,
@@ -96,7 +97,24 @@ export function mergeObjectsUsingReaderAst(
         }
         break;
       }
-      case 'Link':
+      case 'Link': {
+        const key = field.alias;
+        // @ts-expect-error
+        const oldValue: Link = oldItemObject[key];
+        // @ts-expect-error
+        const newValue: Link = newItemObject[key];
+
+        if (
+          oldValue.__link !== newValue.__link ||
+          oldValue.__typename !== newValue.__typename
+        ) {
+          canRecycle = false;
+        } else {
+          // @ts-expect-error
+          newItemObject[key] = oldValue;
+        }
+        break;
+      }
       case 'ImperativelyLoadedField':
       case 'LoadablySelectedField':
         break;

--- a/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
+++ b/libs/isograph-react/src/core/areEqualWithDeepComparison.ts
@@ -96,6 +96,7 @@ export function mergeObjectsUsingReaderAst(
         }
         break;
       }
+      case 'Link':
       case 'ImperativelyLoadedField':
       case 'LoadablySelectedField':
         break;

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -163,6 +163,10 @@ function readData<TReadFromStore>(
         target[field.alias ?? field.fieldName] = value;
         break;
       }
+      case 'Link': {
+        target[field.alias] = root;
+        break;
+      }
       case 'Linked': {
         const storeRecordName = getParentRecordKey(field, variables);
         const value = storeRecord[storeRecordName];
@@ -605,6 +609,7 @@ function readData<TReadFromStore>(
         }
         break;
       }
+
       default: {
         // Ensure we have covered all variants
         let _: never = field;

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -79,7 +79,8 @@ export type ReaderAstNode =
   | ReaderLinkedField
   | ReaderNonLoadableResolverField
   | ReaderImperativelyLoadedField
-  | ReaderLoadableField;
+  | ReaderLoadableField
+  | ReaderLinkeField;
 
 // @ts-ignore
 export type ReaderAst<TReadFromStore> = ReadonlyArray<ReaderAstNode>;
@@ -90,6 +91,12 @@ export type ReaderScalarField = {
   readonly alias: string | null;
   readonly arguments: Arguments | null;
 };
+
+export type ReaderLinkeField = {
+  readonly kind: 'Link';
+  readonly alias: string;
+};
+
 export type ReaderLinkedField = {
   readonly kind: 'Linked';
   readonly fieldName: string;


### PR DESCRIPTION
This is a bit awkward at places because
- I didn't extended `Loadability`, should we do that? 
- I don't know what will happen when we select `__link` \@loadably, we should validate it as part of this PR
- `type Link` is not imported right know, but it's not an issue since client pointers are not implemented yet

other then that It seems to work 