### PR TITLE
replace std::Error with String

### DIFF
--- a/crates/isograph_compiler/src/batch_compile.rs
+++ b/crates/isograph_compiler/src/batch_compile.rs
@@ -59,10 +59,7 @@ pub fn print_result(
 #[derive(Error, Debug)]
 pub enum BatchCompileError {
     #[error("Unable to load schema file at path {path:?}.\nReason: {message}")]
-    UnableToLoadSchema {
-        path: PathBuf,
-        message: std::io::Error,
-    },
+    UnableToLoadSchema { path: PathBuf, message: String },
 
     #[error("Attempted to load the graphql schema at the following path: {path:?}, but that is not a file.")]
     SchemaNotAFile { path: PathBuf },
@@ -74,13 +71,10 @@ pub enum BatchCompileError {
     ProjectRootNotADirectory { path: PathBuf },
 
     #[error("Unable to read the file at the following path: {path:?}.\nReason: {message}")]
-    UnableToReadFile {
-        path: PathBuf,
-        message: std::io::Error,
-    },
+    UnableToReadFile { path: PathBuf, message: String },
 
-    #[error("Unable to traverse directory.\nReason: {0}")]
-    UnableToTraverseDirectory(#[from] std::io::Error),
+    #[error("Unable to traverse directory.\nReason: {message}")]
+    UnableToTraverseDirectory { message: String },
 
     #[error("Unable to parse schema.\n\n{0}")]
     UnableToParseSchema(#[from] WithLocation<SchemaParseError>),

--- a/crates/isograph_compiler/src/isograph_literals.rs
+++ b/crates/isograph_compiler/src/isograph_literals.rs
@@ -56,9 +56,9 @@ pub fn read_file(
     let path_2 = path.clone();
 
     // N.B. we have previously ensured that path is a file
-    let contents = std::fs::read(&path).map_err(|message| BatchCompileError::UnableToReadFile {
+    let contents = std::fs::read(&path).map_err(|e| BatchCompileError::UnableToReadFile {
         path: path_2,
-        message,
+        message: e.to_string(),
     })?;
 
     let contents = std::str::from_utf8(&contents)
@@ -80,7 +80,9 @@ fn read_dir_recursive(root_js_path: &Path) -> Result<Vec<PathBuf>, BatchCompileE
     visit_dirs_skipping_isograph(root_js_path, &mut |dir_entry| {
         paths.push(dir_entry.path());
     })
-    .map_err(BatchCompileError::from)?;
+    .map_err(|e| BatchCompileError::UnableToTraverseDirectory {
+        message: e.to_string(),
+    })?;
 
     Ok(paths)
 }

--- a/crates/isograph_compiler/src/schema.rs
+++ b/crates/isograph_compiler/src/schema.rs
@@ -9,9 +9,9 @@ pub(crate) fn read_schema_file(path: &PathBuf) -> Result<String, BatchCompileErr
     let canonicalized_existing_path =
         joined
             .canonicalize()
-            .map_err(|message| BatchCompileError::UnableToLoadSchema {
+            .map_err(|e| BatchCompileError::UnableToLoadSchema {
                 path: joined,
-                message,
+                message: e.to_string(),
             })?;
 
     if !canonicalized_existing_path.is_file() {
@@ -20,10 +20,10 @@ pub(crate) fn read_schema_file(path: &PathBuf) -> Result<String, BatchCompileErr
         });
     }
 
-    let contents = std::fs::read(canonicalized_existing_path.clone()).map_err(|message| {
+    let contents = std::fs::read(canonicalized_existing_path.clone()).map_err(|e| {
         BatchCompileError::UnableToReadFile {
             path: canonicalized_existing_path.clone(),
-            message,
+            message: e.to_string(),
         }
     })?;
 

--- a/crates/isograph_compiler/src/source_files.rs
+++ b/crates/isograph_compiler/src/source_files.rs
@@ -303,9 +303,9 @@ fn get_canonicalized_root_path(project_root: &PathBuf) -> Result<PathBuf, BatchC
     let joined = current_dir.join(project_root);
     joined
         .canonicalize()
-        .map_err(|message| BatchCompileError::UnableToLoadSchema {
+        .map_err(|e| BatchCompileError::UnableToLoadSchema {
             path: joined.clone(),
-            message,
+            message: e.to_string(),
         })
 }
 

--- a/crates/isograph_compiler/src/write_artifacts.rs
+++ b/crates/isograph_compiler/src/write_artifacts.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{self, File},
-    io::{self, Write},
+    io::Write,
     path::PathBuf,
 };
 
@@ -15,14 +15,14 @@ pub(crate) fn write_artifacts_to_disk(
         fs::remove_dir_all(artifact_directory).map_err(|e| {
             GenerateArtifactsError::UnableToDeleteDirectory {
                 path: artifact_directory.clone(),
-                message: e,
+                message: e.to_string(),
             }
         })?;
     }
     fs::create_dir_all(artifact_directory).map_err(|e| {
         GenerateArtifactsError::UnableToCreateDirectory {
             path: artifact_directory.clone(),
-            message: e,
+            message: e.to_string(),
         }
     })?;
 
@@ -35,7 +35,7 @@ pub(crate) fn write_artifacts_to_disk(
         fs::create_dir_all(&absolute_directory).map_err(|e| {
             GenerateArtifactsError::UnableToCreateDirectory {
                 path: absolute_directory.clone(),
-                message: e,
+                message: e.to_string(),
             }
         })?;
 
@@ -44,14 +44,14 @@ pub(crate) fn write_artifacts_to_disk(
         let mut file = File::create(&absolute_file_path).map_err(|e| {
             GenerateArtifactsError::UnableToWriteToArtifactFile {
                 path: absolute_file_path.clone(),
-                message: e,
+                message: e.to_string(),
             }
         })?;
 
         file.write(path_and_content.file_content.as_bytes())
             .map_err(|e| GenerateArtifactsError::UnableToWriteToArtifactFile {
                 path: absolute_file_path.clone(),
-                message: e,
+                message: e.to_string(),
             })?;
     }
     Ok(count)
@@ -65,19 +65,19 @@ pub enum GenerateArtifactsError {
         Is there another instance of the Isograph compiler running?\
         \nReason: {message:?}"
     )]
-    UnableToWriteToArtifactFile { path: PathBuf, message: io::Error },
+    UnableToWriteToArtifactFile { path: PathBuf, message: String },
 
     #[error(
         "Unable to create directory at path {path:?}. \
         Is there another instance of the Isograph compiler running?\
         \nReason: {message:?}"
     )]
-    UnableToCreateDirectory { path: PathBuf, message: io::Error },
+    UnableToCreateDirectory { path: PathBuf, message: String },
 
     #[error(
         "Unable to delete directory at path {path:?}. \
         Is there another instance of the Isograph compiler running?\
         \nReason: {message:?}"
     )]
-    UnableToDeleteDirectory { path: PathBuf, message: io::Error },
+    UnableToDeleteDirectory { path: PathBuf, message: String },
 }


### PR DESCRIPTION
For incremental compiler we need errors to implement Clone, so we have to replace `std::io::Error` with `String`