### PR TITLE
Type check variables

### DIFF
--- a/crates/graphql_artifact_generation/src/generate_artifacts.rs
+++ b/crates/graphql_artifact_generation/src/generate_artifacts.rs
@@ -185,7 +185,9 @@ pub fn get_artifact_path_and_content(
                                 type_: GraphQLTypeAnnotation::NonNull(Box::new(
                                     GraphQLNonNullTypeAnnotation::Named(
                                         GraphQLNamedTypeAnnotation(WithSpan::new(
-                                            SelectableServerFieldId::Scalar(schema.id_type_id),
+                                            SelectableServerFieldId::Scalar(
+                                                schema.server_field_data.id_type_id,
+                                            ),
                                             Span::todo_generated(),
                                         )),
                                     ),

--- a/crates/graphql_lang_types/src/graphql_type_annotation.rs
+++ b/crates/graphql_lang_types/src/graphql_type_annotation.rs
@@ -9,6 +9,25 @@ pub enum GraphQLTypeAnnotation<TValue> {
     NonNull(Box<GraphQLNonNullTypeAnnotation<TValue>>),
 }
 
+impl<TValue> From<GraphQLTypeAnnotation<TValue>> for GraphQLNonNullTypeAnnotation<TValue> {
+    fn from(value: GraphQLTypeAnnotation<TValue>) -> Self {
+        match value {
+            GraphQLTypeAnnotation::Named(named) => GraphQLNonNullTypeAnnotation::Named(named),
+            GraphQLTypeAnnotation::List(list) => GraphQLNonNullTypeAnnotation::List(*list),
+            GraphQLTypeAnnotation::NonNull(non_null) => *non_null,
+        }
+    }
+}
+
+impl<TValue> From<GraphQLNonNullTypeAnnotation<TValue>> for GraphQLTypeAnnotation<TValue> {
+    fn from(value: GraphQLNonNullTypeAnnotation<TValue>) -> Self {
+        match value {
+            GraphQLNonNullTypeAnnotation::Named(named) => GraphQLTypeAnnotation::Named(named),
+            GraphQLNonNullTypeAnnotation::List(list) => GraphQLTypeAnnotation::List(Box::new(list)),
+        }
+    }
+}
+
 impl<TValue> GraphQLTypeAnnotation<TValue> {
     pub fn inner(&self) -> &TValue {
         match self {

--- a/crates/isograph_schema/src/isograph_schema.rs
+++ b/crates/isograph_schema/src/isograph_schema.rs
@@ -89,16 +89,6 @@ pub struct Schema<TSchemaValidationState: SchemaValidationState> {
     pub entrypoints: TSchemaValidationState::Entrypoint,
     pub server_field_data: ServerFieldData,
 
-    // Well known types
-    pub id_type_id: ServerScalarId,
-    pub string_type_id: ServerScalarId,
-    pub float_type_id: ServerScalarId,
-    pub boolean_type_id: ServerScalarId,
-    pub int_type_id: ServerScalarId,
-    // TODO restructure UnionTypeAnnotation to not have a nullable field, but to instead
-    // include null in its variants.
-    pub null_type_id: ServerScalarId,
-
     /// These are root types like Query, Mutation, Subscription
     pub fetchable_types: BTreeMap<ServerObjectId, RootOperationName>,
 }
@@ -185,6 +175,16 @@ pub struct ServerFieldData {
     pub server_objects: Vec<SchemaObject>,
     pub server_scalars: Vec<SchemaScalar>,
     pub defined_types: HashMap<UnvalidatedTypeName, SelectableServerFieldId>,
+
+    // Well known types
+    pub id_type_id: ServerScalarId,
+    pub string_type_id: ServerScalarId,
+    pub float_type_id: ServerScalarId,
+    pub boolean_type_id: ServerScalarId,
+    pub int_type_id: ServerScalarId,
+    // TODO restructure UnionTypeAnnotation to not have a nullable field, but to instead
+    // include null in its variants.
+    pub null_type_id: ServerScalarId,
 }
 
 impl<TSchemaValidationState: SchemaValidationState> Schema<TSchemaValidationState> {

--- a/crates/isograph_schema/src/process_type_definition.rs
+++ b/crates/isograph_schema/src/process_type_definition.rs
@@ -371,7 +371,7 @@ impl UnvalidatedSchema {
             ..
         } = self;
         let next_object_id = schema_data.server_objects.len().into();
-        let string_type_for_typename = schema_data.scalar(self.string_type_id).name;
+        let string_type_for_typename = schema_data.scalar(schema_data.string_type_id).name;
         let type_names = &mut schema_data.defined_types;
         let objects = &mut schema_data.server_objects;
         let encountered_root_kind = match type_names.entry(object_type_definition.name.item.into())

--- a/crates/isograph_schema/src/unvalidated_schema.rs
+++ b/crates/isograph_schema/src/unvalidated_schema.rs
@@ -150,15 +150,14 @@ impl UnvalidatedSchema {
                 server_objects: objects,
                 server_scalars: scalars,
                 defined_types,
+
+                id_type_id,
+                string_type_id,
+                int_type_id,
+                float_type_id,
+                boolean_type_id,
+                null_type_id,
             },
-
-            id_type_id,
-            string_type_id,
-            int_type_id,
-            float_type_id,
-            boolean_type_id,
-            null_type_id,
-
             fetchable_types: BTreeMap::new(),
         }
     }

--- a/demos/github-demo/src/isograph-components/PullRequestDetail.tsx
+++ b/demos/github-demo/src/isograph-components/PullRequestDetail.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from '@mui/material';
 import { RepoGitHubLink } from './RepoGitHubLink';
 
 export const PullRequestDetail = iso(`
-  field Query.PullRequestDetail($repositoryOwner: String, $repositoryName: String, $pullRequestNumber: Int) @component {
+  field Query.PullRequestDetail($repositoryOwner: String!, $repositoryName: String!, $pullRequestNumber: Int!) @component {
     repository(owner: $repositoryOwner, name: $repositoryName) {
       pullRequest(number: $pullRequestNumber) {
         title

--- a/demos/github-demo/src/isograph-components/RepositoryDetail.tsx
+++ b/demos/github-demo/src/isograph-components/RepositoryDetail.tsx
@@ -17,7 +17,7 @@ export const IsStarred = iso(`
 });
 
 export const RepositoryDetail = iso(`
-  field Query.RepositoryDetail($first: Int, $repositoryName: String, $repositoryOwner: String) @component {
+  field Query.RepositoryDetail($first: Int, $repositoryName: String!, $repositoryOwner: String!) @component {
     repository(name: $repositoryName, owner: $repositoryOwner) {
       IsStarred
       nameWithOwner

--- a/demos/github-demo/src/isograph-components/UserDetail.tsx
+++ b/demos/github-demo/src/isograph-components/UserDetail.tsx
@@ -3,7 +3,7 @@ import { RepoGitHubLink } from './RepoGitHubLink';
 import { Route } from './GithubDemo';
 
 export const UserDetail = iso(`
-  field Query.UserDetail($userLogin: String) @component {
+  field Query.UserDetail($userLogin: String!) @component {
     user(login: $userLogin) {
       name
       RepositoryList

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/parameters_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/parameters_type.ts
@@ -1,5 +1,5 @@
 export type Query__PullRequestDetail__parameters = {
-  readonly repositoryOwner?: string | null | void,
-  readonly repositoryName?: string | null | void,
-  readonly pullRequestNumber?: number | null | void,
+  readonly repositoryOwner: string,
+  readonly repositoryName: string,
+  readonly pullRequestNumber: number,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/parameters_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/parameters_type.ts
@@ -1,5 +1,5 @@
 export type Query__RepositoryDetail__parameters = {
   readonly first?: number | null | void,
-  readonly repositoryName?: string | null | void,
-  readonly repositoryOwner?: string | null | void,
+  readonly repositoryName: string,
+  readonly repositoryOwner: string,
 };

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/parameters_type.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/parameters_type.ts
@@ -1,3 +1,3 @@
 export type Query__UserDetail__parameters = {
-  readonly userLogin?: string | null | void,
+  readonly userLogin: string,
 };


### PR DESCRIPTION
I've used `GraphQLTypeAnnotation` instead of `TypeAnnotation` suggested in #181

I am not checking `enums` and `object literals` yet.

Object literals require checking `extraneous` and `missing` `fields` just like the `arguments` maybe it's possible to make a single function that can be used for both of these. 