### PR TITLE
Add kind to normalization ast

### DIFF
--- a/crates/graphql_artifact_generation/src/entrypoint_artifact.rs
+++ b/crates/graphql_artifact_generation/src/entrypoint_artifact.rs
@@ -147,7 +147,7 @@ pub(crate) fn generate_entrypoint_artifacts_with_client_field_traversal_result<'
         generate_refetch_query_artifact_import(&refetch_paths_with_variables, file_extensions);
 
     let normalization_ast_text =
-        generate_normalization_ast_text(schema, merged_selection_map.values(), 0);
+        generate_normalization_ast_text(schema, merged_selection_map.values(), 1);
 
     let concrete_type = schema.server_field_data.object(
         if schema
@@ -294,7 +294,10 @@ impl EntrypointArtifactInfo<'_> {
             import readerResolver from './{resolver_reader_file_name}{ts_file_extension}';\n\
             {refetch_query_artifact_import}\n\n\
             const queryText = '{query_text}';\n\n\
-            const normalizationAst: NormalizationAst = {normalization_ast_text};\n\
+            const normalizationAst: NormalizationAst = {{\n\
+            {}kind: \"NormalizationAst\",\n\
+            {}normalizationAst: {normalization_ast_text},\n\
+            }};\n\
             const artifact: IsographEntrypoint<\n\
             {}{entrypoint_params_typename},\n\
             {}{entrypoint_output_type_name}\n\
@@ -313,7 +316,7 @@ impl EntrypointArtifactInfo<'_> {
             {}}},\n\
             }};\n\n\
             export default artifact;\n",
-            "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ",
+            "  ","  ","  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ",
         )
     }
 }

--- a/crates/graphql_artifact_generation/src/entrypoint_artifact.rs
+++ b/crates/graphql_artifact_generation/src/entrypoint_artifact.rs
@@ -296,7 +296,7 @@ impl EntrypointArtifactInfo<'_> {
             const queryText = '{query_text}';\n\n\
             const normalizationAst: NormalizationAst = {{\n\
             {}kind: \"NormalizationAst\",\n\
-            {}normalizationAst: {normalization_ast_text},\n\
+            {}selections: {normalization_ast_text},\n\
             }};\n\
             const artifact: IsographEntrypoint<\n\
             {}{entrypoint_params_typename},\n\

--- a/crates/graphql_artifact_generation/src/imperatively_loaded_fields.rs
+++ b/crates/graphql_artifact_generation/src/imperatively_loaded_fields.rs
@@ -54,7 +54,10 @@ impl ImperativelyLoadedEntrypointArtifactInfo {
         format!(
             "import type {{ IsographEntrypoint, ReaderAst, FragmentReference, NormalizationAst, RefetchQueryNormalizationArtifact }} from '@isograph/react';\n\
             const queryText = '{query_text}';\n\n\
-            const normalizationAst: NormalizationAst = {normalization_ast};\n\
+            const normalizationAst: NormalizationAst = {{\n\
+            {}kind: \"NormalizationAst\",\n\
+            {}normalizationAst: {normalization_ast},\n\
+            }};\n\
             const artifact: RefetchQueryNormalizationArtifact = {{\n\
             {}kind: \"RefetchQuery\",\n\
             {}networkRequestInfo: {{\n\
@@ -65,6 +68,8 @@ impl ImperativelyLoadedEntrypointArtifactInfo {
             {}concreteType: \"{concrete_type}\",\n\
             }};\n\n\
             export default artifact;\n",
+            "  ",
+            "  ",
             "  ",
             "  ",
             "  ",
@@ -103,7 +108,7 @@ pub(crate) fn get_artifact_for_imperatively_loaded_field(
     );
 
     let normalization_ast_text =
-        generate_normalization_ast_text(schema, merged_selection_set.values(), 0);
+        generate_normalization_ast_text(schema, merged_selection_set.values(), 1);
 
     ImperativelyLoadedEntrypointArtifactInfo {
         normalization_ast_text,

--- a/crates/graphql_artifact_generation/src/imperatively_loaded_fields.rs
+++ b/crates/graphql_artifact_generation/src/imperatively_loaded_fields.rs
@@ -56,7 +56,7 @@ impl ImperativelyLoadedEntrypointArtifactInfo {
             const queryText = '{query_text}';\n\n\
             const normalizationAst: NormalizationAst = {{\n\
             {}kind: \"NormalizationAst\",\n\
-            {}normalizationAst: {normalization_ast},\n\
+            {}selections: {normalization_ast},\n\
             }};\n\
             const artifact: RefetchQueryNormalizationArtifact = {{\n\
             {}kind: \"RefetchQuery\",\n\

--- a/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/__refetch__0.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/__refetch__0.ts
@@ -38,183 +38,186 @@ const queryText = 'query User__refetch ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "InlineFragment",
-        type: "User",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "avatarUrl",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "login",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "name",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "repositories",
-            arguments: [
-              [
-                "first",
-                { kind: "Literal", value: 10 },
-              ],
-
-              [
-                "after",
-                { kind: "Literal", value: null },
-              ],
-            ],
-            concreteType: "RepositoryConnection",
-            selections: [
-              {
-                kind: "Linked",
-                fieldName: "edges",
-                arguments: null,
-                concreteType: "RepositoryEdge",
-                selections: [
-                  {
-                    kind: "Linked",
-                    fieldName: "node",
-                    arguments: null,
-                    concreteType: "Repository",
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "id",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "description",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "forkCount",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "name",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "nameWithOwner",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Linked",
-                        fieldName: "owner",
-                        arguments: null,
-                        concreteType: null,
-                        selections: [
-                          {
-                            kind: "Scalar",
-                            fieldName: "__typename",
-                            arguments: null,
-                          },
-                          {
-                            kind: "Scalar",
-                            fieldName: "id",
-                            arguments: null,
-                          },
-                          {
-                            kind: "Scalar",
-                            fieldName: "login",
-                            arguments: null,
-                          },
-                        ],
-                      },
-                      {
-                        kind: "Linked",
-                        fieldName: "pullRequests",
-                        arguments: null,
-                        concreteType: "PullRequestConnection",
-                        selections: [
-                          {
-                            kind: "Scalar",
-                            fieldName: "totalCount",
-                            arguments: null,
-                          },
-                        ],
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "stargazerCount",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Linked",
-                        fieldName: "watchers",
-                        arguments: null,
-                        concreteType: "UserConnection",
-                        selections: [
-                          {
-                            kind: "Scalar",
-                            fieldName: "totalCount",
-                            arguments: null,
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                kind: "Linked",
-                fieldName: "pageInfo",
-                arguments: null,
-                concreteType: "PageInfo",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "endCursor",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "hasNextPage",
-                    arguments: null,
-                  },
-                ],
-              },
-            ],
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "InlineFragment",
+          type: "User",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "avatarUrl",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "login",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "name",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "repositories",
+              arguments: [
+                [
+                  "first",
+                  { kind: "Literal", value: 10 },
+                ],
+
+                [
+                  "after",
+                  { kind: "Literal", value: null },
+                ],
+              ],
+              concreteType: "RepositoryConnection",
+              selections: [
+                {
+                  kind: "Linked",
+                  fieldName: "edges",
+                  arguments: null,
+                  concreteType: "RepositoryEdge",
+                  selections: [
+                    {
+                      kind: "Linked",
+                      fieldName: "node",
+                      arguments: null,
+                      concreteType: "Repository",
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "id",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "description",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "forkCount",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "name",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "nameWithOwner",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Linked",
+                          fieldName: "owner",
+                          arguments: null,
+                          concreteType: null,
+                          selections: [
+                            {
+                              kind: "Scalar",
+                              fieldName: "__typename",
+                              arguments: null,
+                            },
+                            {
+                              kind: "Scalar",
+                              fieldName: "id",
+                              arguments: null,
+                            },
+                            {
+                              kind: "Scalar",
+                              fieldName: "login",
+                              arguments: null,
+                            },
+                          ],
+                        },
+                        {
+                          kind: "Linked",
+                          fieldName: "pullRequests",
+                          arguments: null,
+                          concreteType: "PullRequestConnection",
+                          selections: [
+                            {
+                              kind: "Scalar",
+                              fieldName: "totalCount",
+                              arguments: null,
+                            },
+                          ],
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "stargazerCount",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Linked",
+                          fieldName: "watchers",
+                          arguments: null,
+                          concreteType: "UserConnection",
+                          selections: [
+                            {
+                              kind: "Scalar",
+                              fieldName: "totalCount",
+                              arguments: null,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  kind: "Linked",
+                  fieldName: "pageInfo",
+                  arguments: null,
+                  concreteType: "PageInfo",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "endCursor",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "hasNextPage",
+                      arguments: null,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: RefetchQueryNormalizationArtifact = {
   kind: "RefetchQuery",
   networkRequestInfo: {

--- a/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/entrypoint.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/entrypoint.ts
@@ -43,167 +43,170 @@ const queryText = 'query HomePage  {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "viewer",
-    arguments: null,
-    concreteType: "User",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "avatarUrl",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "login",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-      {
-        kind: "Linked",
-        fieldName: "repositories",
-        arguments: [
-          [
-            "first",
-            { kind: "Literal", value: 10 },
-          ],
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "viewer",
+      arguments: null,
+      concreteType: "User",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "avatarUrl",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "login",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+        {
+          kind: "Linked",
+          fieldName: "repositories",
+          arguments: [
+            [
+              "first",
+              { kind: "Literal", value: 10 },
+            ],
 
-          [
-            "after",
-            { kind: "Literal", value: null },
+            [
+              "after",
+              { kind: "Literal", value: null },
+            ],
           ],
-        ],
-        concreteType: "RepositoryConnection",
-        selections: [
-          {
-            kind: "Linked",
-            fieldName: "edges",
-            arguments: null,
-            concreteType: "RepositoryEdge",
-            selections: [
-              {
-                kind: "Linked",
-                fieldName: "node",
-                arguments: null,
-                concreteType: "Repository",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "id",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "description",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "forkCount",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "name",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "nameWithOwner",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Linked",
-                    fieldName: "owner",
-                    arguments: null,
-                    concreteType: null,
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "__typename",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "id",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "login",
-                        arguments: null,
-                      },
-                    ],
-                  },
-                  {
-                    kind: "Linked",
-                    fieldName: "pullRequests",
-                    arguments: null,
-                    concreteType: "PullRequestConnection",
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "totalCount",
-                        arguments: null,
-                      },
-                    ],
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "stargazerCount",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Linked",
-                    fieldName: "watchers",
-                    arguments: null,
-                    concreteType: "UserConnection",
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "totalCount",
-                        arguments: null,
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            kind: "Linked",
-            fieldName: "pageInfo",
-            arguments: null,
-            concreteType: "PageInfo",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "endCursor",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "hasNextPage",
-                arguments: null,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-];
+          concreteType: "RepositoryConnection",
+          selections: [
+            {
+              kind: "Linked",
+              fieldName: "edges",
+              arguments: null,
+              concreteType: "RepositoryEdge",
+              selections: [
+                {
+                  kind: "Linked",
+                  fieldName: "node",
+                  arguments: null,
+                  concreteType: "Repository",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "id",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "description",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "forkCount",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "name",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "nameWithOwner",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Linked",
+                      fieldName: "owner",
+                      arguments: null,
+                      concreteType: null,
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "__typename",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "id",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "login",
+                          arguments: null,
+                        },
+                      ],
+                    },
+                    {
+                      kind: "Linked",
+                      fieldName: "pullRequests",
+                      arguments: null,
+                      concreteType: "PullRequestConnection",
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "totalCount",
+                          arguments: null,
+                        },
+                      ],
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "stargazerCount",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Linked",
+                      fieldName: "watchers",
+                      arguments: null,
+                      concreteType: "UserConnection",
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "totalCount",
+                          arguments: null,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "pageInfo",
+              arguments: null,
+              concreteType: "PageInfo",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "endCursor",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "hasNextPage",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__HomePage__param,
   Query__HomePage__output_type

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/entrypoint.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/entrypoint.ts
@@ -33,144 +33,147 @@ const queryText = 'query PullRequest ($repositoryOwner: String!, $repositoryName
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "repository",
-    arguments: [
-      [
-        "owner",
-        { kind: "Variable", name: "repositoryOwner" },
-      ],
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "repository",
+      arguments: [
+        [
+          "owner",
+          { kind: "Variable", name: "repositoryOwner" },
+        ],
 
-      [
-        "name",
-        { kind: "Variable", name: "repositoryName" },
+        [
+          "name",
+          { kind: "Variable", name: "repositoryName" },
+        ],
       ],
-    ],
-    concreteType: "Repository",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Linked",
-        fieldName: "pullRequest",
-        arguments: [
-          [
-            "number",
-            { kind: "Variable", name: "pullRequestNumber" },
+      concreteType: "Repository",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Linked",
+          fieldName: "pullRequest",
+          arguments: [
+            [
+              "number",
+              { kind: "Variable", name: "pullRequestNumber" },
+            ],
           ],
-        ],
-        concreteType: "PullRequest",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "bodyHTML",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "comments",
-            arguments: [
-              [
-                "last",
-                { kind: "Literal", value: 10 },
-              ],
-            ],
-            concreteType: "IssueCommentConnection",
-            selections: [
-              {
-                kind: "Linked",
-                fieldName: "edges",
-                arguments: null,
-                concreteType: "IssueCommentEdge",
-                selections: [
-                  {
-                    kind: "Linked",
-                    fieldName: "node",
-                    arguments: null,
-                    concreteType: "IssueComment",
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "id",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Linked",
-                        fieldName: "author",
-                        arguments: null,
-                        concreteType: null,
-                        selections: [
-                          {
-                            kind: "Scalar",
-                            fieldName: "__typename",
-                            arguments: null,
-                          },
-                          {
-                            kind: "Scalar",
-                            fieldName: "login",
-                            arguments: null,
-                          },
-                        ],
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "bodyText",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "createdAt",
-                        arguments: null,
-                      },
-                    ],
-                  },
+          concreteType: "PullRequest",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "bodyHTML",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "comments",
+              arguments: [
+                [
+                  "last",
+                  { kind: "Literal", value: 10 },
                 ],
-              },
-            ],
-          },
-          {
-            kind: "Scalar",
-            fieldName: "title",
-            arguments: null,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    kind: "Linked",
-    fieldName: "viewer",
-    arguments: null,
-    concreteType: "User",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "avatarUrl",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-    ],
-  },
-];
+              ],
+              concreteType: "IssueCommentConnection",
+              selections: [
+                {
+                  kind: "Linked",
+                  fieldName: "edges",
+                  arguments: null,
+                  concreteType: "IssueCommentEdge",
+                  selections: [
+                    {
+                      kind: "Linked",
+                      fieldName: "node",
+                      arguments: null,
+                      concreteType: "IssueComment",
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "id",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Linked",
+                          fieldName: "author",
+                          arguments: null,
+                          concreteType: null,
+                          selections: [
+                            {
+                              kind: "Scalar",
+                              fieldName: "__typename",
+                              arguments: null,
+                            },
+                            {
+                              kind: "Scalar",
+                              fieldName: "login",
+                              arguments: null,
+                            },
+                          ],
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "bodyText",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "createdAt",
+                          arguments: null,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              kind: "Scalar",
+              fieldName: "title",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      kind: "Linked",
+      fieldName: "viewer",
+      arguments: null,
+      concreteType: "User",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "avatarUrl",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__PullRequest__param,
   Query__PullRequest__output_type

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/entrypoint.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/entrypoint.ts
@@ -58,254 +58,257 @@ const queryText = 'query RepositoryPage ($repositoryName: String!, $repositoryOw
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "repository",
-    arguments: [
-      [
-        "name",
-        { kind: "Variable", name: "repositoryName" },
-      ],
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "repository",
+      arguments: [
+        [
+          "name",
+          { kind: "Variable", name: "repositoryName" },
+        ],
 
-      [
-        "owner",
-        { kind: "Variable", name: "repositoryOwner" },
+        [
+          "owner",
+          { kind: "Variable", name: "repositoryOwner" },
+        ],
       ],
-    ],
-    concreteType: "Repository",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "nameWithOwner",
-        arguments: null,
-      },
-      {
-        kind: "Linked",
-        fieldName: "parent",
-        arguments: null,
-        concreteType: "Repository",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "name",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "nameWithOwner",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "owner",
-            arguments: null,
-            concreteType: null,
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "__typename",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "login",
-                arguments: null,
-              },
-            ],
-          },
-        ],
-      },
-      {
-        kind: "Linked",
-        fieldName: "pullRequests",
-        arguments: [
-          [
-            "last",
-            { kind: "Variable", name: "first" },
+      concreteType: "Repository",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "nameWithOwner",
+          arguments: null,
+        },
+        {
+          kind: "Linked",
+          fieldName: "parent",
+          arguments: null,
+          concreteType: "Repository",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "name",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "nameWithOwner",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "owner",
+              arguments: null,
+              concreteType: null,
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "__typename",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "login",
+                  arguments: null,
+                },
+              ],
+            },
           ],
-        ],
-        concreteType: "PullRequestConnection",
-        selections: [
-          {
-            kind: "Linked",
-            fieldName: "edges",
-            arguments: null,
-            concreteType: "PullRequestEdge",
-            selections: [
-              {
-                kind: "Linked",
-                fieldName: "node",
-                arguments: null,
-                concreteType: "PullRequest",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "id",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Linked",
-                    fieldName: "author",
-                    arguments: null,
-                    concreteType: null,
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "__typename",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "login",
-                        arguments: null,
-                      },
-                      {
-                        kind: "InlineFragment",
-                        type: "User",
-                        selections: [
-                          {
-                            kind: "Scalar",
-                            fieldName: "id",
-                            arguments: null,
-                          },
-                          {
-                            kind: "Scalar",
-                            fieldName: "__typename",
-                            arguments: null,
-                          },
-                          {
-                            kind: "Scalar",
-                            fieldName: "twitterUsername",
-                            arguments: null,
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "closed",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "createdAt",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "number",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Linked",
-                    fieldName: "repository",
-                    arguments: null,
-                    concreteType: "Repository",
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "id",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "name",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Linked",
-                        fieldName: "owner",
-                        arguments: null,
-                        concreteType: null,
-                        selections: [
-                          {
-                            kind: "Scalar",
-                            fieldName: "__typename",
-                            arguments: null,
-                          },
-                          {
-                            kind: "Scalar",
-                            fieldName: "id",
-                            arguments: null,
-                          },
-                          {
-                            kind: "Scalar",
-                            fieldName: "login",
-                            arguments: null,
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "title",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "totalCommentsCount",
-                    arguments: null,
-                  },
-                ],
-              },
+        },
+        {
+          kind: "Linked",
+          fieldName: "pullRequests",
+          arguments: [
+            [
+              "last",
+              { kind: "Variable", name: "first" },
             ],
-          },
-        ],
-      },
-      {
-        kind: "Scalar",
-        fieldName: "stargazerCount",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "viewerHasStarred",
-        arguments: null,
-      },
-    ],
-  },
-  {
-    kind: "Linked",
-    fieldName: "viewer",
-    arguments: null,
-    concreteType: "User",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "avatarUrl",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-    ],
-  },
-];
+          ],
+          concreteType: "PullRequestConnection",
+          selections: [
+            {
+              kind: "Linked",
+              fieldName: "edges",
+              arguments: null,
+              concreteType: "PullRequestEdge",
+              selections: [
+                {
+                  kind: "Linked",
+                  fieldName: "node",
+                  arguments: null,
+                  concreteType: "PullRequest",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "id",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Linked",
+                      fieldName: "author",
+                      arguments: null,
+                      concreteType: null,
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "__typename",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "login",
+                          arguments: null,
+                        },
+                        {
+                          kind: "InlineFragment",
+                          type: "User",
+                          selections: [
+                            {
+                              kind: "Scalar",
+                              fieldName: "id",
+                              arguments: null,
+                            },
+                            {
+                              kind: "Scalar",
+                              fieldName: "__typename",
+                              arguments: null,
+                            },
+                            {
+                              kind: "Scalar",
+                              fieldName: "twitterUsername",
+                              arguments: null,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "closed",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "createdAt",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "number",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Linked",
+                      fieldName: "repository",
+                      arguments: null,
+                      concreteType: "Repository",
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "id",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "name",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Linked",
+                          fieldName: "owner",
+                          arguments: null,
+                          concreteType: null,
+                          selections: [
+                            {
+                              kind: "Scalar",
+                              fieldName: "__typename",
+                              arguments: null,
+                            },
+                            {
+                              kind: "Scalar",
+                              fieldName: "id",
+                              arguments: null,
+                            },
+                            {
+                              kind: "Scalar",
+                              fieldName: "login",
+                              arguments: null,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "title",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "totalCommentsCount",
+                      arguments: null,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          kind: "Scalar",
+          fieldName: "stargazerCount",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "viewerHasStarred",
+          arguments: null,
+        },
+      ],
+    },
+    {
+      kind: "Linked",
+      fieldName: "viewer",
+      arguments: null,
+      concreteType: "User",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "avatarUrl",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__RepositoryPage__param,
   Query__RepositoryPage__output_type

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/entrypoint.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/entrypoint.ts
@@ -43,185 +43,188 @@ const queryText = 'query UserPage ($userLogin: String!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "user",
-    arguments: [
-      [
-        "login",
-        { kind: "Variable", name: "userLogin" },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "user",
+      arguments: [
+        [
+          "login",
+          { kind: "Variable", name: "userLogin" },
+        ],
       ],
-    ],
-    concreteType: "User",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-      {
-        kind: "Linked",
-        fieldName: "repositories",
-        arguments: [
-          [
-            "first",
-            { kind: "Literal", value: 10 },
-          ],
+      concreteType: "User",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+        {
+          kind: "Linked",
+          fieldName: "repositories",
+          arguments: [
+            [
+              "first",
+              { kind: "Literal", value: 10 },
+            ],
 
-          [
-            "after",
-            { kind: "Literal", value: null },
+            [
+              "after",
+              { kind: "Literal", value: null },
+            ],
           ],
-        ],
-        concreteType: "RepositoryConnection",
-        selections: [
-          {
-            kind: "Linked",
-            fieldName: "edges",
-            arguments: null,
-            concreteType: "RepositoryEdge",
-            selections: [
-              {
-                kind: "Linked",
-                fieldName: "node",
-                arguments: null,
-                concreteType: "Repository",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "id",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "description",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "forkCount",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "name",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "nameWithOwner",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Linked",
-                    fieldName: "owner",
-                    arguments: null,
-                    concreteType: null,
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "__typename",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "id",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "login",
-                        arguments: null,
-                      },
-                    ],
-                  },
-                  {
-                    kind: "Linked",
-                    fieldName: "pullRequests",
-                    arguments: null,
-                    concreteType: "PullRequestConnection",
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "totalCount",
-                        arguments: null,
-                      },
-                    ],
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "stargazerCount",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Linked",
-                    fieldName: "watchers",
-                    arguments: null,
-                    concreteType: "UserConnection",
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "totalCount",
-                        arguments: null,
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            kind: "Linked",
-            fieldName: "pageInfo",
-            arguments: null,
-            concreteType: "PageInfo",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "endCursor",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "hasNextPage",
-                arguments: null,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-  {
-    kind: "Linked",
-    fieldName: "viewer",
-    arguments: null,
-    concreteType: "User",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "avatarUrl",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-    ],
-  },
-];
+          concreteType: "RepositoryConnection",
+          selections: [
+            {
+              kind: "Linked",
+              fieldName: "edges",
+              arguments: null,
+              concreteType: "RepositoryEdge",
+              selections: [
+                {
+                  kind: "Linked",
+                  fieldName: "node",
+                  arguments: null,
+                  concreteType: "Repository",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "id",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "description",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "forkCount",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "name",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "nameWithOwner",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Linked",
+                      fieldName: "owner",
+                      arguments: null,
+                      concreteType: null,
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "__typename",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "id",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "login",
+                          arguments: null,
+                        },
+                      ],
+                    },
+                    {
+                      kind: "Linked",
+                      fieldName: "pullRequests",
+                      arguments: null,
+                      concreteType: "PullRequestConnection",
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "totalCount",
+                          arguments: null,
+                        },
+                      ],
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "stargazerCount",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Linked",
+                      fieldName: "watchers",
+                      arguments: null,
+                      concreteType: "UserConnection",
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "totalCount",
+                          arguments: null,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "pageInfo",
+              arguments: null,
+              concreteType: "PageInfo",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "endCursor",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "hasNextPage",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      kind: "Linked",
+      fieldName: "viewer",
+      arguments: null,
+      concreteType: "User",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "avatarUrl",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__UserPage__param,
   Query__UserPage__output_type

--- a/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/entrypoint.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/entrypoint.ts
@@ -40,168 +40,171 @@ const queryText = 'query RepositoryConnection ($first: Int, $after: String, $id:
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "InlineFragment",
-        type: "User",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "repositories",
-            arguments: [
-              [
-                "first",
-                { kind: "Variable", name: "first" },
-              ],
-
-              [
-                "after",
-                { kind: "Variable", name: "after" },
-              ],
-            ],
-            concreteType: "RepositoryConnection",
-            selections: [
-              {
-                kind: "Linked",
-                fieldName: "edges",
-                arguments: null,
-                concreteType: "RepositoryEdge",
-                selections: [
-                  {
-                    kind: "Linked",
-                    fieldName: "node",
-                    arguments: null,
-                    concreteType: "Repository",
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "id",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "description",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "forkCount",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "name",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "nameWithOwner",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Linked",
-                        fieldName: "owner",
-                        arguments: null,
-                        concreteType: null,
-                        selections: [
-                          {
-                            kind: "Scalar",
-                            fieldName: "__typename",
-                            arguments: null,
-                          },
-                          {
-                            kind: "Scalar",
-                            fieldName: "id",
-                            arguments: null,
-                          },
-                          {
-                            kind: "Scalar",
-                            fieldName: "login",
-                            arguments: null,
-                          },
-                        ],
-                      },
-                      {
-                        kind: "Linked",
-                        fieldName: "pullRequests",
-                        arguments: null,
-                        concreteType: "PullRequestConnection",
-                        selections: [
-                          {
-                            kind: "Scalar",
-                            fieldName: "totalCount",
-                            arguments: null,
-                          },
-                        ],
-                      },
-                      {
-                        kind: "Scalar",
-                        fieldName: "stargazerCount",
-                        arguments: null,
-                      },
-                      {
-                        kind: "Linked",
-                        fieldName: "watchers",
-                        arguments: null,
-                        concreteType: "UserConnection",
-                        selections: [
-                          {
-                            kind: "Scalar",
-                            fieldName: "totalCount",
-                            arguments: null,
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-              {
-                kind: "Linked",
-                fieldName: "pageInfo",
-                arguments: null,
-                concreteType: "PageInfo",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "endCursor",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "hasNextPage",
-                    arguments: null,
-                  },
-                ],
-              },
-            ],
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "InlineFragment",
+          type: "User",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "repositories",
+              arguments: [
+                [
+                  "first",
+                  { kind: "Variable", name: "first" },
+                ],
+
+                [
+                  "after",
+                  { kind: "Variable", name: "after" },
+                ],
+              ],
+              concreteType: "RepositoryConnection",
+              selections: [
+                {
+                  kind: "Linked",
+                  fieldName: "edges",
+                  arguments: null,
+                  concreteType: "RepositoryEdge",
+                  selections: [
+                    {
+                      kind: "Linked",
+                      fieldName: "node",
+                      arguments: null,
+                      concreteType: "Repository",
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "id",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "description",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "forkCount",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "name",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "nameWithOwner",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Linked",
+                          fieldName: "owner",
+                          arguments: null,
+                          concreteType: null,
+                          selections: [
+                            {
+                              kind: "Scalar",
+                              fieldName: "__typename",
+                              arguments: null,
+                            },
+                            {
+                              kind: "Scalar",
+                              fieldName: "id",
+                              arguments: null,
+                            },
+                            {
+                              kind: "Scalar",
+                              fieldName: "login",
+                              arguments: null,
+                            },
+                          ],
+                        },
+                        {
+                          kind: "Linked",
+                          fieldName: "pullRequests",
+                          arguments: null,
+                          concreteType: "PullRequestConnection",
+                          selections: [
+                            {
+                              kind: "Scalar",
+                              fieldName: "totalCount",
+                              arguments: null,
+                            },
+                          ],
+                        },
+                        {
+                          kind: "Scalar",
+                          fieldName: "stargazerCount",
+                          arguments: null,
+                        },
+                        {
+                          kind: "Linked",
+                          fieldName: "watchers",
+                          arguments: null,
+                          concreteType: "UserConnection",
+                          selections: [
+                            {
+                              kind: "Scalar",
+                              fieldName: "totalCount",
+                              arguments: null,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  kind: "Linked",
+                  fieldName: "pageInfo",
+                  arguments: null,
+                  concreteType: "PageInfo",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "endCursor",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "hasNextPage",
+                      arguments: null,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   User__RepositoryConnection__param,
   User__RepositoryConnection__output_type

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/entrypoint.ts
@@ -15,47 +15,50 @@ const queryText = 'query AdItemDisplay ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "InlineFragment",
-        type: "AdItem",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "advertiser",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "message",
-            arguments: null,
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "InlineFragment",
+          type: "AdItem",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "advertiser",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "message",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   AdItem__AdItemDisplay__param,
   AdItem__AdItemDisplay__output_type

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/entrypoint.ts
@@ -14,42 +14,45 @@ const queryText = 'query BlogItemMoreDetail ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "InlineFragment",
-        type: "BlogItem",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "moreContent",
-            arguments: null,
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "InlineFragment",
+          type: "BlogItem",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "moreContent",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   BlogItem__BlogItemMoreDetail__param,
   BlogItem__BlogItemMoreDetail__output_type

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/entrypoint.ts
@@ -14,42 +14,45 @@ const queryText = 'query ImageDisplay ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "InlineFragment",
-        type: "Image",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "url",
-            arguments: null,
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "InlineFragment",
+          type: "Image",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "url",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Image__ImageDisplay__param,
   Image__ImageDisplay__output_type

--- a/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/entrypoint.ts
@@ -13,39 +13,42 @@ const queryText = 'mutation SetTagline ($input: SetPetTaglineParams!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "set_pet_tagline",
-    arguments: [
-      [
-        "input",
-        { kind: "Variable", name: "input" },
-      ],
-    ],
-    concreteType: "SetPetTaglineResponse",
-    selections: [
-      {
-        kind: "Linked",
-        fieldName: "pet",
-        arguments: null,
-        concreteType: "Pet",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "tagline",
-            arguments: null,
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "set_pet_tagline",
+      arguments: [
+        [
+          "input",
+          { kind: "Variable", name: "input" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: "SetPetTaglineResponse",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "pet",
+          arguments: null,
+          concreteType: "Pet",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "tagline",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Mutation__SetTagline__param,
   Mutation__SetTagline__output_type

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/__refetch__0.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/__refetch__0.ts
@@ -12,55 +12,58 @@ const queryText = 'mutation Pet__make_super ($checkin_id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "make_checkin_super",
-    arguments: [
-      [
-        "checkin_id",
-        { kind: "Variable", name: "checkin_id" },
-      ],
-    ],
-    concreteType: "MakeCheckinSuperResponse",
-    selections: [
-      {
-        kind: "Linked",
-        fieldName: "checkin",
-        arguments: null,
-        concreteType: null,
-        selections: [
-          {
-            kind: "InlineFragment",
-            type: "Checkin",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "__typename",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "location",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "time",
-                arguments: null,
-              },
-            ],
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "make_checkin_super",
+      arguments: [
+        [
+          "checkin_id",
+          { kind: "Variable", name: "checkin_id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: "MakeCheckinSuperResponse",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "checkin",
+          arguments: null,
+          concreteType: null,
+          selections: [
+            {
+              kind: "InlineFragment",
+              type: "Checkin",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "__typename",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "location",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "time",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: RefetchQueryNormalizationArtifact = {
   kind: "RefetchQuery",
   networkRequestInfo: {

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/entrypoint.ts
@@ -21,70 +21,73 @@ const queryText = 'query PetCheckinsCard ($skip: Int, $limit: Int, $id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "InlineFragment",
-        type: "Pet",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "checkins",
-            arguments: [
-              [
-                "skip",
-                { kind: "Variable", name: "skip" },
-              ],
-
-              [
-                "limit",
-                { kind: "Variable", name: "limit" },
-              ],
-            ],
-            concreteType: "Checkin",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "location",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "time",
-                arguments: null,
-              },
-            ],
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "InlineFragment",
+          type: "Pet",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "checkins",
+              arguments: [
+                [
+                  "skip",
+                  { kind: "Variable", name: "skip" },
+                ],
+
+                [
+                  "limit",
+                  { kind: "Variable", name: "limit" },
+                ],
+              ],
+              concreteType: "Checkin",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "location",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "time",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Pet__PetCheckinsCard__param,
   Pet__PetCheckinsCard__output_type

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/__refetch__0.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/__refetch__0.ts
@@ -12,55 +12,58 @@ const queryText = 'mutation Pet__make_super ($checkin_id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "make_checkin_super",
-    arguments: [
-      [
-        "checkin_id",
-        { kind: "Variable", name: "checkin_id" },
-      ],
-    ],
-    concreteType: "MakeCheckinSuperResponse",
-    selections: [
-      {
-        kind: "Linked",
-        fieldName: "checkin",
-        arguments: null,
-        concreteType: null,
-        selections: [
-          {
-            kind: "InlineFragment",
-            type: "Checkin",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "__typename",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "location",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "time",
-                arguments: null,
-              },
-            ],
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "make_checkin_super",
+      arguments: [
+        [
+          "checkin_id",
+          { kind: "Variable", name: "checkin_id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: "MakeCheckinSuperResponse",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "checkin",
+          arguments: null,
+          concreteType: null,
+          selections: [
+            {
+              kind: "InlineFragment",
+              type: "Checkin",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "__typename",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "location",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "time",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: RefetchQueryNormalizationArtifact = {
   kind: "RefetchQuery",
   networkRequestInfo: {

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/entrypoint.ts
@@ -21,70 +21,73 @@ const queryText = 'query PetCheckinsCardList ($skip: Int!, $limit: Int!, $id: ID
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "InlineFragment",
-        type: "Pet",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "checkins",
-            arguments: [
-              [
-                "skip",
-                { kind: "Variable", name: "skip" },
-              ],
-
-              [
-                "limit",
-                { kind: "Variable", name: "limit" },
-              ],
-            ],
-            concreteType: "Checkin",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "location",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "time",
-                arguments: null,
-              },
-            ],
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "InlineFragment",
+          type: "Pet",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "checkins",
+              arguments: [
+                [
+                  "skip",
+                  { kind: "Variable", name: "skip" },
+                ],
+
+                [
+                  "limit",
+                  { kind: "Variable", name: "limit" },
+                ],
+              ],
+              concreteType: "Checkin",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "location",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "time",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Pet__PetCheckinsCardList__param,
   Pet__PetCheckinsCardList__output_type

--- a/demos/pet-demo/src/components/__isograph/Query/HomeRoute/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/HomeRoute/entrypoint.ts
@@ -13,36 +13,39 @@ const queryText = 'query HomeRoute  {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "pets",
-    arguments: null,
-    concreteType: "Pet",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "picture",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "tagline",
-        arguments: null,
-      },
-    ],
-  },
-];
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "pets",
+      arguments: null,
+      concreteType: "Pet",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "picture",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "tagline",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__HomeRoute__param,
   Query__HomeRoute__output_type

--- a/demos/pet-demo/src/components/__isograph/Query/Newsfeed/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/Newsfeed/entrypoint.ts
@@ -27,104 +27,107 @@ const queryText = 'query Newsfeed  {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "viewer",
-    arguments: null,
-    concreteType: "Viewer",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Linked",
-        fieldName: "newsfeed",
-        arguments: [
-          [
-            "skip",
-            { kind: "Literal", value: 0 },
-          ],
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "viewer",
+      arguments: null,
+      concreteType: "Viewer",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Linked",
+          fieldName: "newsfeed",
+          arguments: [
+            [
+              "skip",
+              { kind: "Literal", value: 0 },
+            ],
 
-          [
-            "limit",
-            { kind: "Literal", value: 6 },
+            [
+              "limit",
+              { kind: "Literal", value: 6 },
+            ],
           ],
-        ],
-        concreteType: null,
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "InlineFragment",
-            type: "AdItem",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "__typename",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "InlineFragment",
-            type: "BlogItem",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "__typename",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "author",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "content",
-                arguments: null,
-              },
-              {
-                kind: "Linked",
-                fieldName: "image",
-                arguments: null,
-                concreteType: "Image",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "id",
-                    arguments: null,
-                  },
-                ],
-              },
-              {
-                kind: "Scalar",
-                fieldName: "title",
-                arguments: null,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-];
+          concreteType: null,
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "InlineFragment",
+              type: "AdItem",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "__typename",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "InlineFragment",
+              type: "BlogItem",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "__typename",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "author",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "content",
+                  arguments: null,
+                },
+                {
+                  kind: "Linked",
+                  fieldName: "image",
+                  arguments: null,
+                  concreteType: "Image",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "id",
+                      arguments: null,
+                    },
+                  ],
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "title",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__Newsfeed__param,
   Query__Newsfeed__output_type

--- a/demos/pet-demo/src/components/__isograph/Query/PetByName/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetByName/entrypoint.ts
@@ -11,31 +11,34 @@ const queryText = 'query PetByName ($name: String!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "petByName",
-    arguments: [
-      [
-        "name",
-        { kind: "Variable", name: "name" },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "petByName",
+      arguments: [
+        [
+          "name",
+          { kind: "Variable", name: "name" },
+        ],
       ],
-    ],
-    concreteType: "Pet",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-    ],
-  },
-];
+      concreteType: "Pet",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__PetByName__param,
   Query__PetByName__output_type

--- a/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/__refetch__0.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/__refetch__0.ts
@@ -11,50 +11,53 @@ const queryText = 'mutation Query__make_super ($checkin_id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "make_checkin_super",
-    arguments: [
-      [
-        "checkin_id",
-        { kind: "Variable", name: "checkin_id" },
-      ],
-    ],
-    concreteType: "MakeCheckinSuperResponse",
-    selections: [
-      {
-        kind: "Linked",
-        fieldName: "checkin",
-        arguments: null,
-        concreteType: null,
-        selections: [
-          {
-            kind: "InlineFragment",
-            type: "Checkin",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "__typename",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "location",
-                arguments: null,
-              },
-            ],
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "make_checkin_super",
+      arguments: [
+        [
+          "checkin_id",
+          { kind: "Variable", name: "checkin_id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: "MakeCheckinSuperResponse",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "checkin",
+          arguments: null,
+          concreteType: null,
+          selections: [
+            {
+              kind: "InlineFragment",
+              type: "Checkin",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "__typename",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "location",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: RefetchQueryNormalizationArtifact = {
   kind: "RefetchQuery",
   networkRequestInfo: {

--- a/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/entrypoint.ts
@@ -18,59 +18,62 @@ const queryText = 'query PetCheckinListRoute ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "pet",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "pet",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
+        ],
       ],
-    ],
-    concreteType: "Pet",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Linked",
-        fieldName: "checkins",
-        arguments: [
-          [
-            "skip",
-            { kind: "Literal", value: 0 },
-          ],
+      concreteType: "Pet",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Linked",
+          fieldName: "checkins",
+          arguments: [
+            [
+              "skip",
+              { kind: "Literal", value: 0 },
+            ],
 
-          [
-            "limit",
-            { kind: "Literal", value: 1 },
+            [
+              "limit",
+              { kind: "Literal", value: 1 },
+            ],
           ],
-        ],
-        concreteType: "Checkin",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "location",
-            arguments: null,
-          },
-        ],
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-    ],
-  },
-];
+          concreteType: "Checkin",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "location",
+              arguments: null,
+            },
+          ],
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__PetCheckinListRoute__param,
   Query__PetCheckinListRoute__output_type

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/entrypoint.ts
@@ -11,31 +11,34 @@ const queryText = 'query PetDetailDeferredRoute ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "pet",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "pet",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
+        ],
       ],
-    ],
-    concreteType: "Pet",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-    ],
-  },
-];
+      concreteType: "Pet",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__PetDetailDeferredRoute__param,
   Query__PetDetailDeferredRoute__output_type

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__0.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__0.ts
@@ -38,187 +38,190 @@ const queryText = 'query Pet__refetch ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "InlineFragment",
-        type: "Pet",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "age",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "best_friend_relationship",
-            arguments: null,
-            concreteType: "BestFriendRelationship",
-            selections: [
-              {
-                kind: "Linked",
-                fieldName: "best_friend",
-                arguments: null,
-                concreteType: "Pet",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "id",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "name",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "picture",
-                    arguments: null,
-                  },
-                ],
-              },
-              {
-                kind: "Scalar",
-                fieldName: "picture_together",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Linked",
-            fieldName: "checkins",
-            arguments: [
-              [
-                "skip",
-                { kind: "Literal", value: null },
-              ],
-
-              [
-                "limit",
-                { kind: "Literal", value: null },
-              ],
-            ],
-            concreteType: "Checkin",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "location",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "time",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Scalar",
-            fieldName: "favorite_phrase",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "name",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "nickname",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "potential_new_best_friends",
-            arguments: null,
-            concreteType: "Pet",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "name",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Linked",
-            fieldName: "stats",
-            arguments: null,
-            concreteType: "PetStats",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "cuteness",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "energy",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "hunger",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "intelligence",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "sociability",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "weight",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Scalar",
-            fieldName: "tagline",
-            arguments: null,
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "InlineFragment",
+          type: "Pet",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "age",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "best_friend_relationship",
+              arguments: null,
+              concreteType: "BestFriendRelationship",
+              selections: [
+                {
+                  kind: "Linked",
+                  fieldName: "best_friend",
+                  arguments: null,
+                  concreteType: "Pet",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "id",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "name",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "picture",
+                      arguments: null,
+                    },
+                  ],
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "picture_together",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "checkins",
+              arguments: [
+                [
+                  "skip",
+                  { kind: "Literal", value: null },
+                ],
+
+                [
+                  "limit",
+                  { kind: "Literal", value: null },
+                ],
+              ],
+              concreteType: "Checkin",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "location",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "time",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Scalar",
+              fieldName: "favorite_phrase",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "name",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "nickname",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "potential_new_best_friends",
+              arguments: null,
+              concreteType: "Pet",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "stats",
+              arguments: null,
+              concreteType: "PetStats",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "cuteness",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "energy",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "hunger",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "intelligence",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "sociability",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "weight",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Scalar",
+              fieldName: "tagline",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: RefetchQueryNormalizationArtifact = {
   kind: "RefetchQuery",
   networkRequestInfo: {

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__1.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__1.ts
@@ -37,189 +37,192 @@ const queryText = 'mutation Query__set_best_friend ($id: ID!, $new_best_friend_i
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "set_pet_best_friend",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-
-      [
-        "new_best_friend_id",
-        { kind: "Variable", name: "new_best_friend_id" },
-      ],
-    ],
-    concreteType: "SetBestFriendResponse",
-    selections: [
-      {
-        kind: "Linked",
-        fieldName: "pet",
-        arguments: null,
-        concreteType: "Pet",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "age",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "best_friend_relationship",
-            arguments: null,
-            concreteType: "BestFriendRelationship",
-            selections: [
-              {
-                kind: "Linked",
-                fieldName: "best_friend",
-                arguments: null,
-                concreteType: "Pet",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "id",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "name",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "picture",
-                    arguments: null,
-                  },
-                ],
-              },
-              {
-                kind: "Scalar",
-                fieldName: "picture_together",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Linked",
-            fieldName: "checkins",
-            arguments: [
-              [
-                "skip",
-                { kind: "Literal", value: null },
-              ],
-
-              [
-                "limit",
-                { kind: "Literal", value: null },
-              ],
-            ],
-            concreteType: "Checkin",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "location",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "time",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Scalar",
-            fieldName: "favorite_phrase",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "name",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "nickname",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "potential_new_best_friends",
-            arguments: null,
-            concreteType: "Pet",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "name",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Linked",
-            fieldName: "stats",
-            arguments: null,
-            concreteType: "PetStats",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "cuteness",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "energy",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "hunger",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "intelligence",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "sociability",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "weight",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Scalar",
-            fieldName: "tagline",
-            arguments: null,
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "set_pet_best_friend",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+
+        [
+          "new_best_friend_id",
+          { kind: "Variable", name: "new_best_friend_id" },
+        ],
+      ],
+      concreteType: "SetBestFriendResponse",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "pet",
+          arguments: null,
+          concreteType: "Pet",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "age",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "best_friend_relationship",
+              arguments: null,
+              concreteType: "BestFriendRelationship",
+              selections: [
+                {
+                  kind: "Linked",
+                  fieldName: "best_friend",
+                  arguments: null,
+                  concreteType: "Pet",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "id",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "name",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "picture",
+                      arguments: null,
+                    },
+                  ],
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "picture_together",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "checkins",
+              arguments: [
+                [
+                  "skip",
+                  { kind: "Literal", value: null },
+                ],
+
+                [
+                  "limit",
+                  { kind: "Literal", value: null },
+                ],
+              ],
+              concreteType: "Checkin",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "location",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "time",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Scalar",
+              fieldName: "favorite_phrase",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "name",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "nickname",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "potential_new_best_friends",
+              arguments: null,
+              concreteType: "Pet",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "stats",
+              arguments: null,
+              concreteType: "PetStats",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "cuteness",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "energy",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "hunger",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "intelligence",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "sociability",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "weight",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Scalar",
+              fieldName: "tagline",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: RefetchQueryNormalizationArtifact = {
   kind: "RefetchQuery",
   networkRequestInfo: {

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__2.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__2.ts
@@ -37,184 +37,187 @@ const queryText = 'mutation Query__set_pet_tagline ($input: SetPetTaglineParams!
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "set_pet_tagline",
-    arguments: [
-      [
-        "input",
-        { kind: "Variable", name: "input" },
-      ],
-    ],
-    concreteType: "SetPetTaglineResponse",
-    selections: [
-      {
-        kind: "Linked",
-        fieldName: "pet",
-        arguments: null,
-        concreteType: "Pet",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "age",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "best_friend_relationship",
-            arguments: null,
-            concreteType: "BestFriendRelationship",
-            selections: [
-              {
-                kind: "Linked",
-                fieldName: "best_friend",
-                arguments: null,
-                concreteType: "Pet",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "id",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "name",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "picture",
-                    arguments: null,
-                  },
-                ],
-              },
-              {
-                kind: "Scalar",
-                fieldName: "picture_together",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Linked",
-            fieldName: "checkins",
-            arguments: [
-              [
-                "skip",
-                { kind: "Literal", value: null },
-              ],
-
-              [
-                "limit",
-                { kind: "Literal", value: null },
-              ],
-            ],
-            concreteType: "Checkin",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "location",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "time",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Scalar",
-            fieldName: "favorite_phrase",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "name",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "nickname",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "potential_new_best_friends",
-            arguments: null,
-            concreteType: "Pet",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "name",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Linked",
-            fieldName: "stats",
-            arguments: null,
-            concreteType: "PetStats",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "cuteness",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "energy",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "hunger",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "intelligence",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "sociability",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "weight",
-                arguments: null,
-              },
-            ],
-          },
-          {
-            kind: "Scalar",
-            fieldName: "tagline",
-            arguments: null,
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "set_pet_tagline",
+      arguments: [
+        [
+          "input",
+          { kind: "Variable", name: "input" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: "SetPetTaglineResponse",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "pet",
+          arguments: null,
+          concreteType: "Pet",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "age",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "best_friend_relationship",
+              arguments: null,
+              concreteType: "BestFriendRelationship",
+              selections: [
+                {
+                  kind: "Linked",
+                  fieldName: "best_friend",
+                  arguments: null,
+                  concreteType: "Pet",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "id",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "name",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "picture",
+                      arguments: null,
+                    },
+                  ],
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "picture_together",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "checkins",
+              arguments: [
+                [
+                  "skip",
+                  { kind: "Literal", value: null },
+                ],
+
+                [
+                  "limit",
+                  { kind: "Literal", value: null },
+                ],
+              ],
+              concreteType: "Checkin",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "location",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "time",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Scalar",
+              fieldName: "favorite_phrase",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "name",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "nickname",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "potential_new_best_friends",
+              arguments: null,
+              concreteType: "Pet",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Linked",
+              fieldName: "stats",
+              arguments: null,
+              concreteType: "PetStats",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "cuteness",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "energy",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "hunger",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "intelligence",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "sociability",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "weight",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Scalar",
+              fieldName: "tagline",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: RefetchQueryNormalizationArtifact = {
   kind: "RefetchQuery",
   networkRequestInfo: {

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__3.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__3.ts
@@ -12,55 +12,58 @@ const queryText = 'mutation Query__make_super ($checkin_id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "make_checkin_super",
-    arguments: [
-      [
-        "checkin_id",
-        { kind: "Variable", name: "checkin_id" },
-      ],
-    ],
-    concreteType: "MakeCheckinSuperResponse",
-    selections: [
-      {
-        kind: "Linked",
-        fieldName: "checkin",
-        arguments: null,
-        concreteType: null,
-        selections: [
-          {
-            kind: "InlineFragment",
-            type: "Checkin",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "__typename",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "location",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "time",
-                arguments: null,
-              },
-            ],
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "make_checkin_super",
+      arguments: [
+        [
+          "checkin_id",
+          { kind: "Variable", name: "checkin_id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: "MakeCheckinSuperResponse",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "checkin",
+          arguments: null,
+          concreteType: null,
+          selections: [
+            {
+              kind: "InlineFragment",
+              type: "Checkin",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "__typename",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "location",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "time",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: RefetchQueryNormalizationArtifact = {
   kind: "RefetchQuery",
   networkRequestInfo: {

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__4.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/__refetch__4.ts
@@ -12,59 +12,62 @@ const queryText = 'query Query__refetch_pet_stats ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "pet",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: "Pet",
-    selections: [
-      {
-        kind: "Linked",
-        fieldName: "stats",
-        arguments: null,
-        concreteType: "PetStats",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "cuteness",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "energy",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "hunger",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "intelligence",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "sociability",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "weight",
-            arguments: null,
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "pet",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: "Pet",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "stats",
+          arguments: null,
+          concreteType: "PetStats",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "cuteness",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "energy",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "hunger",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "intelligence",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "sociability",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "weight",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: RefetchQueryNormalizationArtifact = {
   kind: "RefetchQuery",
   networkRequestInfo: {

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/entrypoint.ts
@@ -51,176 +51,179 @@ const queryText = 'query PetDetailRoute ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "pet",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "pet",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
+        ],
       ],
-    ],
-    concreteType: "Pet",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "age",
-        arguments: null,
-      },
-      {
-        kind: "Linked",
-        fieldName: "best_friend_relationship",
-        arguments: null,
-        concreteType: "BestFriendRelationship",
-        selections: [
-          {
-            kind: "Linked",
-            fieldName: "best_friend",
-            arguments: null,
-            concreteType: "Pet",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "name",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "picture",
-                arguments: null,
-              },
+      concreteType: "Pet",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "age",
+          arguments: null,
+        },
+        {
+          kind: "Linked",
+          fieldName: "best_friend_relationship",
+          arguments: null,
+          concreteType: "BestFriendRelationship",
+          selections: [
+            {
+              kind: "Linked",
+              fieldName: "best_friend",
+              arguments: null,
+              concreteType: "Pet",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "picture",
+                  arguments: null,
+                },
+              ],
+            },
+            {
+              kind: "Scalar",
+              fieldName: "picture_together",
+              arguments: null,
+            },
+          ],
+        },
+        {
+          kind: "Linked",
+          fieldName: "checkins",
+          arguments: [
+            [
+              "skip",
+              { kind: "Literal", value: null },
             ],
-          },
-          {
-            kind: "Scalar",
-            fieldName: "picture_together",
-            arguments: null,
-          },
-        ],
-      },
-      {
-        kind: "Linked",
-        fieldName: "checkins",
-        arguments: [
-          [
-            "skip",
-            { kind: "Literal", value: null },
-          ],
 
-          [
-            "limit",
-            { kind: "Literal", value: null },
+            [
+              "limit",
+              { kind: "Literal", value: null },
+            ],
           ],
-        ],
-        concreteType: "Checkin",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "location",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "time",
-            arguments: null,
-          },
-        ],
-      },
-      {
-        kind: "Scalar",
-        fieldName: "favorite_phrase",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "nickname",
-        arguments: null,
-      },
-      {
-        kind: "Linked",
-        fieldName: "potential_new_best_friends",
-        arguments: null,
-        concreteType: "Pet",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "name",
-            arguments: null,
-          },
-        ],
-      },
-      {
-        kind: "Linked",
-        fieldName: "stats",
-        arguments: null,
-        concreteType: "PetStats",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "cuteness",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "energy",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "hunger",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "intelligence",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "sociability",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "weight",
-            arguments: null,
-          },
-        ],
-      },
-      {
-        kind: "Scalar",
-        fieldName: "tagline",
-        arguments: null,
-      },
-    ],
-  },
-];
+          concreteType: "Checkin",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "location",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "time",
+              arguments: null,
+            },
+          ],
+        },
+        {
+          kind: "Scalar",
+          fieldName: "favorite_phrase",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "nickname",
+          arguments: null,
+        },
+        {
+          kind: "Linked",
+          fieldName: "potential_new_best_friends",
+          arguments: null,
+          concreteType: "Pet",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "name",
+              arguments: null,
+            },
+          ],
+        },
+        {
+          kind: "Linked",
+          fieldName: "stats",
+          arguments: null,
+          concreteType: "PetStats",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "cuteness",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "energy",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "hunger",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "intelligence",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "sociability",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "weight",
+              arguments: null,
+            },
+          ],
+        },
+        {
+          kind: "Scalar",
+          fieldName: "tagline",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__PetDetailRoute__param,
   Query__PetDetailRoute__output_type

--- a/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/entrypoint.ts
@@ -12,36 +12,39 @@ const queryText = 'query PetFavoritePhrase ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "pet",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "pet",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
+        ],
       ],
-    ],
-    concreteType: "Pet",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "favorite_phrase",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-    ],
-  },
-];
+      concreteType: "Pet",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "favorite_phrase",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__PetFavoritePhrase__param,
   Query__PetFavoritePhrase__output_type

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/entrypoint.ts
@@ -30,120 +30,123 @@ const queryText = 'query NewsfeedPaginationComponent ($skip: Int!, $limit: Int!,
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
-      ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "InlineFragment",
-        type: "Viewer",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "newsfeed",
-            arguments: [
-              [
-                "skip",
-                { kind: "Variable", name: "skip" },
-              ],
-
-              [
-                "limit",
-                { kind: "Variable", name: "limit" },
-              ],
-            ],
-            concreteType: null,
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "__typename",
-                arguments: null,
-              },
-              {
-                kind: "InlineFragment",
-                type: "AdItem",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "id",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "__typename",
-                    arguments: null,
-                  },
-                ],
-              },
-              {
-                kind: "InlineFragment",
-                type: "BlogItem",
-                selections: [
-                  {
-                    kind: "Scalar",
-                    fieldName: "id",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "__typename",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "author",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "content",
-                    arguments: null,
-                  },
-                  {
-                    kind: "Linked",
-                    fieldName: "image",
-                    arguments: null,
-                    concreteType: "Image",
-                    selections: [
-                      {
-                        kind: "Scalar",
-                        fieldName: "id",
-                        arguments: null,
-                      },
-                    ],
-                  },
-                  {
-                    kind: "Scalar",
-                    fieldName: "title",
-                    arguments: null,
-                  },
-                ],
-              },
-            ],
-          },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
         ],
-      },
-    ],
-  },
-];
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "InlineFragment",
+          type: "Viewer",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "newsfeed",
+              arguments: [
+                [
+                  "skip",
+                  { kind: "Variable", name: "skip" },
+                ],
+
+                [
+                  "limit",
+                  { kind: "Variable", name: "limit" },
+                ],
+              ],
+              concreteType: null,
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "__typename",
+                  arguments: null,
+                },
+                {
+                  kind: "InlineFragment",
+                  type: "AdItem",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "id",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "__typename",
+                      arguments: null,
+                    },
+                  ],
+                },
+                {
+                  kind: "InlineFragment",
+                  type: "BlogItem",
+                  selections: [
+                    {
+                      kind: "Scalar",
+                      fieldName: "id",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "__typename",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "author",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "content",
+                      arguments: null,
+                    },
+                    {
+                      kind: "Linked",
+                      fieldName: "image",
+                      arguments: null,
+                      concreteType: "Image",
+                      selections: [
+                        {
+                          kind: "Scalar",
+                          fieldName: "id",
+                          arguments: null,
+                        },
+                      ],
+                    },
+                    {
+                      kind: "Scalar",
+                      fieldName: "title",
+                      arguments: null,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Viewer__NewsfeedPaginationComponent__param,
   Viewer__NewsfeedPaginationComponent__output_type

--- a/demos/vite-demo/src/components/__isograph/Query/HomePage/entrypoint.ts
+++ b/demos/vite-demo/src/components/__isograph/Query/HomePage/entrypoint.ts
@@ -15,56 +15,59 @@ const queryText = 'query HomePage  {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "getAllPokemon",
-    arguments: [
-      [
-        "take",
-        { kind: "Literal", value: 232 },
-      ],
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "getAllPokemon",
+      arguments: [
+        [
+          "take",
+          { kind: "Literal", value: 232 },
+        ],
 
-      [
-        "offset",
-        { kind: "Literal", value: 93 },
+        [
+          "offset",
+          { kind: "Literal", value: 93 },
+        ],
       ],
-    ],
-    concreteType: "Pokemon",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "bulbapediaPage",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "forme",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "key",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "num",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "species",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "sprite",
-        arguments: null,
-      },
-    ],
-  },
-];
+      concreteType: "Pokemon",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "bulbapediaPage",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "forme",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "key",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "num",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "species",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "sprite",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__HomePage__param,
   Query__HomePage__output_type

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -16,7 +16,7 @@ import {
 } from './IsographEnvironment';
 import {
   IsographEntrypoint,
-  NormalizationAst,
+  type NormalizationAstNodes,
   NormalizationInlineFragment,
   NormalizationLinkedField,
   NormalizationScalarField,
@@ -142,7 +142,7 @@ export type NetworkResponseObject = {
 
 export function normalizeData(
   environment: IsographEnvironment,
-  normalizationAst: NormalizationAst,
+  normalizationAst: NormalizationAstNodes,
   networkResponse: NetworkResponseObject,
   variables: Variables,
   nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[],
@@ -376,7 +376,7 @@ export type EncounteredIds = Map<TypeName, Set<DataId>>;
  */
 function normalizeDataIntoRecord(
   environment: IsographEnvironment,
-  normalizationAst: NormalizationAst,
+  normalizationAst: NormalizationAstNodes,
   networkResponseParentRecord: NetworkResponseObject,
   targetParentRecord: StoreRecord,
   targetParentRecordLink: Link,

--- a/libs/isograph-react/src/core/check.ts
+++ b/libs/isograph-react/src/core/check.ts
@@ -1,5 +1,5 @@
 import { getParentRecordKey } from './cache';
-import { NormalizationAst } from './entrypoint';
+import { NormalizationAstNodes } from './entrypoint';
 import { Variables } from './FragmentReference';
 import {
   getLink,
@@ -30,7 +30,7 @@ export type CheckResult =
 
 export function check(
   environment: IsographEnvironment,
-  normalizationAst: NormalizationAst,
+  normalizationAst: NormalizationAstNodes,
   variables: Variables,
   root: Link,
 ): CheckResult {
@@ -53,7 +53,7 @@ export function check(
 
 function checkFromRecord(
   environment: IsographEnvironment,
-  normalizationAst: NormalizationAst,
+  normalizationAst: NormalizationAstNodes,
   variables: Variables,
   record: StoreRecord,
   recordLink: Link,

--- a/libs/isograph-react/src/core/entrypoint.ts
+++ b/libs/isograph-react/src/core/entrypoint.ts
@@ -16,18 +16,19 @@ export type ReaderWithRefetchQueries<
   readonly nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[];
 };
 
-export type NetworkRequestInfo = {
+export type NetworkRequestInfo<TNormalizationAst> = {
   readonly kind: 'NetworkRequestInfo';
   readonly queryText: string;
-  readonly normalizationAst: NormalizationAst;
+  readonly normalizationAst: TNormalizationAst;
 };
 // This type should be treated as an opaque type.
 export type IsographEntrypoint<
   TReadFromStore extends { parameters: object; data: object },
   TClientFieldValue,
+  TNormalizationAst = NormalizationAst
 > = {
   readonly kind: 'Entrypoint';
-  readonly networkRequestInfo: NetworkRequestInfo;
+  readonly networkRequestInfo: NetworkRequestInfo<TNormalizationAst>;
   readonly readerWithRefetchQueries: ReaderWithRefetchQueries<
     TReadFromStore,
     TClientFieldValue
@@ -50,7 +51,13 @@ export type NormalizationAstNode =
   | NormalizationScalarField
   | NormalizationLinkedField
   | NormalizationInlineFragment;
-export type NormalizationAst = ReadonlyArray<NormalizationAstNode>;
+
+export type NormalizationAstNodes = ReadonlyArray<NormalizationAstNode>;
+
+export type NormalizationAst = {
+  kind: 'NormalizationAst';
+  normalizationAst: NormalizationAstNodes;
+};
 
 export type NormalizationScalarField = {
   readonly kind: 'Scalar';
@@ -62,20 +69,20 @@ export type NormalizationLinkedField = {
   readonly kind: 'Linked';
   readonly fieldName: string;
   readonly arguments: Arguments | null;
-  readonly selections: NormalizationAst;
+  readonly selections: NormalizationAstNodes;
   readonly concreteType: TypeName | null;
 };
 
 export type NormalizationInlineFragment = {
   readonly kind: 'InlineFragment';
   readonly type: string;
-  readonly selections: NormalizationAst;
+  readonly selections: NormalizationAstNodes;
 };
 
 // This is more like an entrypoint, but one specifically for a refetch query/mutation
 export type RefetchQueryNormalizationArtifact = {
   readonly kind: 'RefetchQuery';
-  readonly networkRequestInfo: NetworkRequestInfo;
+  readonly networkRequestInfo: NetworkRequestInfo<NormalizationAst>;
   readonly concreteType: TypeName;
 };
 

--- a/libs/isograph-react/src/core/entrypoint.ts
+++ b/libs/isograph-react/src/core/entrypoint.ts
@@ -25,7 +25,7 @@ export type NetworkRequestInfo<TNormalizationAst> = {
 export type IsographEntrypoint<
   TReadFromStore extends { parameters: object; data: object },
   TClientFieldValue,
-  TNormalizationAst = NormalizationAst
+  TNormalizationAst = NormalizationAst,
 > = {
   readonly kind: 'Entrypoint';
   readonly networkRequestInfo: NetworkRequestInfo<TNormalizationAst>;

--- a/libs/isograph-react/src/core/entrypoint.ts
+++ b/libs/isograph-react/src/core/entrypoint.ts
@@ -56,7 +56,7 @@ export type NormalizationAstNodes = ReadonlyArray<NormalizationAstNode>;
 
 export type NormalizationAst = {
   kind: 'NormalizationAst';
-  normalizationAst: NormalizationAstNodes;
+  selections: NormalizationAstNodes;
 };
 
 export type NormalizationScalarField = {

--- a/libs/isograph-react/src/core/garbageCollection.ts
+++ b/libs/isograph-react/src/core/garbageCollection.ts
@@ -9,10 +9,10 @@ import {
   type TypeName,
 } from './IsographEnvironment';
 import { getParentRecordKey } from './cache';
-import { NormalizationAst } from './entrypoint';
+import { NormalizationAstNodes } from './entrypoint';
 
 export type RetainedQuery = {
-  readonly normalizationAst: NormalizationAst;
+  readonly normalizationAst: NormalizationAstNodes;
   readonly variables: {};
   readonly root: Link;
 };
@@ -108,7 +108,7 @@ function recordReachableIdsFromRecord(
   store: IsographStore,
   currentRecord: StoreRecord,
   mutableRetainedIds: RetainedIds,
-  selections: NormalizationAst,
+  selections: NormalizationAstNodes,
   variables: Variables | null,
 ) {
   for (const selection of selections) {

--- a/libs/isograph-react/src/core/logging.ts
+++ b/libs/isograph-react/src/core/logging.ts
@@ -7,7 +7,7 @@ import {
 } from './IsographEnvironment';
 import {
   IsographEntrypoint,
-  NormalizationAst,
+  type NormalizationAstNodes,
   RefetchQueryNormalizationArtifact,
 } from './entrypoint';
 import { FragmentReference, Variables } from './FragmentReference';
@@ -25,7 +25,7 @@ export type LogMessage =
     }
   | {
       kind: 'AboutToNormalize';
-      normalizationAst: NormalizationAst;
+      normalizationAst: NormalizationAstNodes;
       networkResponse: NetworkResponseObject;
       variables: Variables;
     }

--- a/libs/isograph-react/src/core/makeNetworkRequest.ts
+++ b/libs/isograph-react/src/core/makeNetworkRequest.ts
@@ -46,7 +46,7 @@ export function maybeMakeNetworkRequest<
     case 'IfNecessary': {
       const result = check(
         environment,
-        artifact.networkRequestInfo.normalizationAst,
+        artifact.networkRequestInfo.normalizationAst.normalizationAst,
         variables,
         {
           __link: ROOT_ID,
@@ -116,7 +116,7 @@ export function makeNetworkRequest<
       if (status.kind === 'UndisposedIncomplete') {
         normalizeData(
           environment,
-          artifact.networkRequestInfo.normalizationAst,
+          artifact.networkRequestInfo.normalizationAst.normalizationAst,
           networkResponse.data ?? {},
           variables,
           artifact.kind === 'Entrypoint'
@@ -125,7 +125,7 @@ export function makeNetworkRequest<
           root,
         );
         const retainedQuery = {
-          normalizationAst: artifact.networkRequestInfo.normalizationAst,
+          normalizationAst: artifact.networkRequestInfo.normalizationAst.normalizationAst,
           variables,
           root,
         };

--- a/libs/isograph-react/src/core/makeNetworkRequest.ts
+++ b/libs/isograph-react/src/core/makeNetworkRequest.ts
@@ -125,7 +125,8 @@ export function makeNetworkRequest<
           root,
         );
         const retainedQuery = {
-          normalizationAst: artifact.networkRequestInfo.normalizationAst.selections,
+          normalizationAst:
+            artifact.networkRequestInfo.normalizationAst.selections,
           variables,
           root,
         };

--- a/libs/isograph-react/src/core/makeNetworkRequest.ts
+++ b/libs/isograph-react/src/core/makeNetworkRequest.ts
@@ -46,7 +46,7 @@ export function maybeMakeNetworkRequest<
     case 'IfNecessary': {
       const result = check(
         environment,
-        artifact.networkRequestInfo.normalizationAst.normalizationAst,
+        artifact.networkRequestInfo.normalizationAst.selections,
         variables,
         {
           __link: ROOT_ID,
@@ -116,7 +116,7 @@ export function makeNetworkRequest<
       if (status.kind === 'UndisposedIncomplete') {
         normalizeData(
           environment,
-          artifact.networkRequestInfo.normalizationAst.normalizationAst,
+          artifact.networkRequestInfo.normalizationAst.selections,
           networkResponse.data ?? {},
           variables,
           artifact.kind === 'Entrypoint'
@@ -125,7 +125,7 @@ export function makeNetworkRequest<
           root,
         );
         const retainedQuery = {
-          normalizationAst: artifact.networkRequestInfo.normalizationAst.normalizationAst,
+          normalizationAst: artifact.networkRequestInfo.normalizationAst.selections,
           variables,
           root,
         };

--- a/libs/isograph-react/src/tests/__isograph/Query/meName/entrypoint.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/meName/entrypoint.ts
@@ -11,26 +11,29 @@ const queryText = 'query meName  {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "me",
-    arguments: null,
-    concreteType: "Economist",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-    ],
-  },
-];
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "me",
+      arguments: null,
+      concreteType: "Economist",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__meName__param,
   Query__meName__output_type

--- a/libs/isograph-react/src/tests/__isograph/Query/meNameSuccessor/entrypoint.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/meNameSuccessor/entrypoint.ts
@@ -18,57 +18,60 @@ const queryText = 'query meNameSuccessor  {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "me",
-    arguments: null,
-    concreteType: "Economist",
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "name",
-        arguments: null,
-      },
-      {
-        kind: "Linked",
-        fieldName: "successor",
-        arguments: null,
-        concreteType: "Economist",
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-          {
-            kind: "Linked",
-            fieldName: "successor",
-            arguments: null,
-            concreteType: "Economist",
-            selections: [
-              {
-                kind: "Scalar",
-                fieldName: "id",
-                arguments: null,
-              },
-              {
-                kind: "Scalar",
-                fieldName: "name",
-                arguments: null,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-];
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "me",
+      arguments: null,
+      concreteType: "Economist",
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "name",
+          arguments: null,
+        },
+        {
+          kind: "Linked",
+          fieldName: "successor",
+          arguments: null,
+          concreteType: "Economist",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Linked",
+              fieldName: "successor",
+              arguments: null,
+              concreteType: "Economist",
+              selections: [
+                {
+                  kind: "Scalar",
+                  fieldName: "id",
+                  arguments: null,
+                },
+                {
+                  kind: "Scalar",
+                  fieldName: "name",
+                  arguments: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__meNameSuccessor__param,
   Query__meNameSuccessor__output_type

--- a/libs/isograph-react/src/tests/__isograph/Query/nodeField/entrypoint.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/nodeField/entrypoint.ts
@@ -11,31 +11,34 @@ const queryText = 'query nodeField ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "node",
-    arguments: [
-      [
-        "id",
-        { kind: "Variable", name: "id" },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
+        ],
       ],
-    ],
-    concreteType: null,
-    selections: [
-      {
-        kind: "Scalar",
-        fieldName: "__typename",
-        arguments: null,
-      },
-      {
-        kind: "Scalar",
-        fieldName: "id",
-        arguments: null,
-      },
-    ],
-  },
-];
+      concreteType: null,
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "__typename",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__nodeField__param,
   Query__nodeField__output_type

--- a/libs/isograph-react/src/tests/__isograph/Query/subquery/entrypoint.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/subquery/entrypoint.ts
@@ -13,39 +13,42 @@ const queryText = 'query subquery ($id: ID!) {\
   },\
 }';
 
-const normalizationAst: NormalizationAst = [
-  {
-    kind: "Linked",
-    fieldName: "query",
-    arguments: null,
-    concreteType: "Query",
-    selections: [
-      {
-        kind: "Linked",
-        fieldName: "node",
-        arguments: [
-          [
-            "id",
-            { kind: "Variable", name: "id" },
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "query",
+      arguments: null,
+      concreteType: "Query",
+      selections: [
+        {
+          kind: "Linked",
+          fieldName: "node",
+          arguments: [
+            [
+              "id",
+              { kind: "Variable", name: "id" },
+            ],
           ],
-        ],
-        concreteType: null,
-        selections: [
-          {
-            kind: "Scalar",
-            fieldName: "__typename",
-            arguments: null,
-          },
-          {
-            kind: "Scalar",
-            fieldName: "id",
-            arguments: null,
-          },
-        ],
-      },
-    ],
-  },
-];
+          concreteType: null,
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const artifact: IsographEntrypoint<
   Query__subquery__param,
   Query__subquery__output_type

--- a/libs/isograph-react/src/tests/garbageCollection.test.ts
+++ b/libs/isograph-react/src/tests/garbageCollection.test.ts
@@ -55,7 +55,8 @@ export const meNameField = iso(`
 import { meNameSuccessorRetainedQuery } from './meNameSuccessor';
 const meNameEntrypoint = iso(`entrypoint Query.meName`);
 const meNameRetainedQuery = {
-  normalizationAst: meNameEntrypoint.networkRequestInfo.normalizationAst,
+  normalizationAst:
+    meNameEntrypoint.networkRequestInfo.normalizationAst.selections,
   variables: {},
   root: { __link: ROOT_ID, __typename: 'Query' },
 };

--- a/libs/isograph-react/src/tests/meNameSuccessor.ts
+++ b/libs/isograph-react/src/tests/meNameSuccessor.ts
@@ -16,7 +16,7 @@ export const meNameField = iso(`
 const meNameSuccessorEntrypoint = iso(`entrypoint Query.meNameSuccessor`);
 export const meNameSuccessorRetainedQuery = {
   normalizationAst:
-    meNameSuccessorEntrypoint.networkRequestInfo.normalizationAst,
+    meNameSuccessorEntrypoint.networkRequestInfo.normalizationAst.selections,
   variables: {},
   root: {
     __link: ROOT_ID,

--- a/libs/isograph-react/src/tests/nodeQuery.ts
+++ b/libs/isograph-react/src/tests/nodeQuery.ts
@@ -13,7 +13,8 @@ export const nodeField = iso(`
 `)(() => {});
 const nodeFieldEntrypoint = iso(`entrypoint Query.nodeField`);
 export const nodeFieldRetainedQuery: RetainedQuery = {
-  normalizationAst: nodeFieldEntrypoint.networkRequestInfo.normalizationAst,
+  normalizationAst:
+    nodeFieldEntrypoint.networkRequestInfo.normalizationAst.selections,
   variables: { id: 0 },
   root: { __link: ROOT_ID, __typename: 'Query' },
 };

--- a/libs/isograph-react/src/tests/normalizeData.test.ts
+++ b/libs/isograph-react/src/tests/normalizeData.test.ts
@@ -35,7 +35,7 @@ describe('normalizeData', () => {
 
     normalizeData(
       environment,
-      entrypoint.networkRequestInfo.normalizationAst,
+      entrypoint.networkRequestInfo.normalizationAst.selections,
       {
         query: { node____id___v_id: { __typename: 'Economist', id: '1' } },
       },


### PR DESCRIPTION
This converts `NormalizationAst` from `NormalizationAstNode[]` to object with `kind: "NormalizationAst"` so we can make it a union of `NormalizationAstLoader` and `NormalizationAst` in #271 

Part of #33, #43