### PR TITLE
Support emitting ESM imports from Babel transform

### DIFF
--- a/crates/isograph_config/src/compilation_options.rs
+++ b/crates/isograph_config/src/compilation_options.rs
@@ -44,6 +44,7 @@ pub struct ConfigOptions {
     pub on_invalid_id_type: OptionalValidationLevel,
     pub no_babel_transform: bool,
     pub generate_file_extensions: GenerateFileExtensionsOption,
+    pub module: JavascriptModule,
 }
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -93,6 +94,13 @@ impl Default for OptionalValidationLevel {
     fn default() -> Self {
         Self::Ignore
     }
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub enum JavascriptModule {
+    CommonJs,
+    #[default]
+    EsModule,
 }
 
 /// This struct is deserialized from an isograph.config.json file.
@@ -219,6 +227,7 @@ pub struct ConfigFileOptions {
     on_invalid_id_type: ConfigFileOptionalValidationLevel,
     no_babel_transform: bool,
     include_file_extensions_in_import_statements: bool,
+    module: ConfigFileJavascriptModule,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy, JsonSchema)]
@@ -238,6 +247,14 @@ impl Default for ConfigFileOptionalValidationLevel {
     }
 }
 
+#[derive(Deserialize, Default, Debug, Clone, Copy, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfigFileJavascriptModule {
+    CommonJs,
+    #[default]
+    EsModule,
+}
+
 fn create_options(options: ConfigFileOptions) -> ConfigOptions {
     ConfigOptions {
         on_invalid_id_type: create_optional_validation_level(options.on_invalid_id_type),
@@ -245,6 +262,7 @@ fn create_options(options: ConfigFileOptions) -> ConfigOptions {
         generate_file_extensions: create_generate_file_extensions(
             options.include_file_extensions_in_import_statements,
         ),
+        module: create_module(options.module),
     }
 }
 
@@ -264,6 +282,13 @@ fn create_generate_file_extensions(
     match optional_generate_file_extensions {
         true => GenerateFileExtensionsOption::IncludeExtensionsInFileImports,
         false => GenerateFileExtensionsOption::ExcludeExtensionsInFileImports,
+    }
+}
+
+fn create_module(module: ConfigFileJavascriptModule) -> JavascriptModule {
+    match module {
+        ConfigFileJavascriptModule::CommonJs => JavascriptModule::CommonJs,
+        ConfigFileJavascriptModule::EsModule => JavascriptModule::EsModule,
     }
 }
 

--- a/demos/vite-demo/isograph.config.json
+++ b/demos/vite-demo/isograph.config.json
@@ -1,5 +1,8 @@
 {
   "$schema": "../../libs/isograph-compiler/isograph-config-schema.json",
   "project_root": "./src/components",
-  "schema": "./schema.graphql"
+  "schema": "./schema.graphql",
+  "options": {
+    "module": "esmodule"
+  }
 }

--- a/demos/vite-demo/package.json
+++ b/demos/vite-demo/package.json
@@ -32,7 +32,6 @@
     "typescript": "5.6.3",
     "typescript-eslint": "^8.7.0",
     "vite": "^5.4.8",
-    "vite-plugin-babel": "^1.2.0",
-    "vite-plugin-commonjs": "^0.10.1"
+    "vite-plugin-babel": "^1.2.0"
   }
 }

--- a/demos/vite-demo/vite.config.ts
+++ b/demos/vite-demo/vite.config.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
-import commonjs from 'vite-plugin-commonjs';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,11 +8,6 @@ export default defineConfig({
     react({
       babel: {
         babelrc: true,
-      },
-    }),
-    commonjs({
-      advanced: {
-        importRules: 'merge',
       },
     }),
   ],

--- a/libs/isograph-babel-plugin/package.json
+++ b/libs/isograph-babel-plugin/package.json
@@ -19,6 +19,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
+    "@babel/helper-module-imports": "^7.0.0",
     "babel-plugin-macros": "^2.0.0",
     "cosmiconfig": "^5.0.5",
     "graphql": "15.3.0"
@@ -27,6 +28,7 @@
     "@babel/core": "^7.20.0",
     "@babel/types": "^7.25.6",
     "@types/babel__core": "^7.20.5",
+    "@types/babel__helper-module-imports": "^7.18.3",
     "@types/cosmiconfig": "^5.0.3",
     "prettier": "2.8.8",
     "prettier-plugin-hermes-parser": "0.16.0"

--- a/libs/isograph-compiler/isograph-config-schema.json
+++ b/libs/isograph-compiler/isograph-config-schema.json
@@ -49,6 +49,13 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "ConfigFileJavascriptModule": {
+      "type": "string",
+      "enum": [
+        "commonjs",
+        "esmodule"
+      ]
+    },
     "ConfigFileOptionalValidationLevel": {
       "oneOf": [
         {
@@ -80,6 +87,9 @@
         "include_file_extensions_in_import_statements": {
           "default": false,
           "type": "boolean"
+        },
+        "module": {
+          "$ref": "#/definitions/ConfigFileJavascriptModule"
         },
         "no_babel_transform": {
           "default": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,9 @@ importers:
 
   libs/isograph-babel-plugin:
     dependencies:
+      '@babel/helper-module-imports':
+        specifier: ^7.0.0
+        version: 7.24.7
       babel-plugin-macros:
         specifier: ^2.0.0
         version: 2.8.0
@@ -306,6 +309,9 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
+      '@types/babel__helper-module-imports':
+        specifier: ^7.18.3
+        version: 7.18.3
       '@types/cosmiconfig':
         specifier: ^5.0.3
         version: 5.0.3
@@ -2182,6 +2188,9 @@ packages:
 
   '@types/babel__generator@7.6.8':
     resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
+
+  '@types/babel__helper-module-imports@7.18.3':
+    resolution: {integrity: sha512-2pyr9Vlriessj2KI85SEF7qma8vA3vzquQMw3wn6kL5lsfjH/YxJ1Noytk4/FJElpYybUbyaC37CVfEgfyme9A==}
 
   '@types/babel__template@7.4.4':
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
@@ -10274,6 +10283,11 @@ snapshots:
   '@types/babel__generator@7.6.8':
     dependencies:
       '@babel/types': 7.25.6
+
+  '@types/babel__helper-module-imports@7.18.3':
+    dependencies:
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.20.6
 
   '@types/babel__template@7.4.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,9 +241,6 @@ importers:
       vite-plugin-babel:
         specifier: ^1.2.0
         version: 1.2.0(@babel/core@7.25.2)(vite@5.4.8(@types/node@22.7.5)(terser@5.32.0))
-      vite-plugin-commonjs:
-        specifier: ^0.10.1
-        version: 0.10.1
 
   docs-website:
     dependencies:


### PR DESCRIPTION
This PR adds support for emitting ESM imports instead of CJS `require()`s while running the Babel transform.