### PR TITLE
draft

### DIFF
--- a/libs/isograph-react/src/react/useResult.ts
+++ b/libs/isograph-react/src/react/useResult.ts
@@ -14,6 +14,11 @@ import { startUpdate } from '../core/startUpdate';
 import { useIsographEnvironment } from '../react/IsographEnvironmentProvider';
 import { useReadAndSubscribe } from './useReadAndSubscribe';
 
+export function useResult(
+  fragmentReference: null | undefined,
+  partialNetworkRequestOptions?: Partial<NetworkRequestReaderOptions> | void,
+): null;
+
 export function useResult<
   TReadFromStore extends {
     parameters: object;
@@ -24,7 +29,41 @@ export function useResult<
 >(
   fragmentReference: FragmentReference<TReadFromStore, TClientFieldValue>,
   partialNetworkRequestOptions?: Partial<NetworkRequestReaderOptions> | void,
-): TClientFieldValue {
+): TClientFieldValue;
+
+export function useResult<
+  TReadFromStore extends {
+    parameters: object;
+    data: object;
+    startUpdate?: StartUpdate<object>;
+  },
+  TClientFieldValue,
+>(
+  fragmentReference:
+    | FragmentReference<TReadFromStore, TClientFieldValue>
+    | null
+    | undefined,
+  partialNetworkRequestOptions?: Partial<NetworkRequestReaderOptions> | void,
+): TClientFieldValue | null;
+
+export function useResult<
+  TReadFromStore extends {
+    parameters: object;
+    data: object;
+    startUpdate?: StartUpdate<object>;
+  },
+  TClientFieldValue,
+>(
+  fragmentReference:
+    | FragmentReference<TReadFromStore, TClientFieldValue>
+    | null
+    | undefined,
+  partialNetworkRequestOptions?: Partial<NetworkRequestReaderOptions> | void,
+): TClientFieldValue | null {
+  if (fragmentReference == null) {
+    return null;
+  }
+
   const environment = useIsographEnvironment();
   const networkRequestOptions = getNetworkRequestOptionsWithDefaults(
     partialNetworkRequestOptions,
@@ -34,6 +73,7 @@ export function useResult<
     fragmentReference.networkRequest,
     networkRequestOptions,
   );
+
   const readerWithRefetchQueries = readPromise(
     fragmentReference.readerWithRefetchQueries,
   );


### PR DESCRIPTION
addresses #338

@rbalicki2 `useLazyReference` hook never returns a nullish fragment reference. And even if was nullish I cannot see how handling a nullish fragment reference in the `useResult` hook is useful in any way other than what I've implemented in this pull request.

>- We should add an overload (at the type level) such that if it receives null, it returns null

Unless you meant something internal to the fragment reference here.