### PR TITLE
Get closer(?) to a fix for the TypeScript caching(?) + overloads issue

### DIFF
--- a/demos/pet-demo/src/components/__isograph/Query/HomeRoute/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/HomeRoute/entrypoint.ts
@@ -1,4 +1,4 @@
-import type {IsographEntrypoint, NormalizationAst, RefetchQueryNormalizationArtifactWrapper} from '@isograph/react';
+import type {IsographEntrypoint, NormalizationAst, NormalizationAstLoader, RefetchQueryNormalizationArtifactWrapper} from '@isograph/react';
 import {Query__HomeRoute__param} from './param_type';
 import {Query__HomeRoute__output_type} from './output_type';
 import readerResolver from './resolver_reader';

--- a/demos/pet-demo/src/components/__isograph/Query/HomeRoute/entrypoint.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/HomeRoute/entrypoint.ts
@@ -1,7 +1,8 @@
-import type {IsographEntrypoint, NormalizationAst, NormalizationAstLoader, RefetchQueryNormalizationArtifactWrapper} from '@isograph/react';
+import type {FetchOptions, IsographEntrypoint, NormalizationAst, NormalizationAstLoader, RefetchQueryNormalizationArtifactWrapper} from '@isograph/react';
 import {Query__HomeRoute__param} from './param_type';
 import {Query__HomeRoute__output_type} from './output_type';
 import readerResolver from './resolver_reader';
+import { RequiredFetchOptions } from '@isograph/react/dist/core/check';
 const nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[] = [];
 
 const queryText = 'query HomeRoute  {\
@@ -49,7 +50,7 @@ const normalizationAst: NormalizationAst = {
 const artifact: IsographEntrypoint<
   Query__HomeRoute__param,
   Query__HomeRoute__output_type,
-  NormalizationAst
+  NormalizationAst | NormalizationAstLoader
 > = {
   kind: "Entrypoint",
   networkRequestInfo: {


### PR DESCRIPTION
On this commit, I can change the entrypoint's normalization ast type to NormalizationAst <-> NormalizationAstLoader, and everything behaves correctly, i.e. it fails to typecheck then passes typechecking, instead of being stuck in a "fails to typecheck" state.

Unfortunately, one ts test does not behave as we would hope:
```
  // if the type is unknown there can be no ast so we should use the same rules
  // @ts-expect-error if the type is unknown, require `shouldFetch` to be specified
  useLazyReference(withAstOrLoader, {});
  useLazyReference(withAstOrLoader, {}, { shouldFetch: 'Yes' });
  // @ts-expect-error if the type is unknown, `shouldFetch` can't be `IfNecessary`
  useLazyReference(withAstOrLoader, {}, { shouldFetch: 'IfNecessary' });
```

Both `ts-expect-error`'s fail to be triggered.

This can be understood based on the `type Blah`, which has type `"They are equal?" | "Of course theyre not"`.

Which, I guess, is fair.

Anyway, still trying to figure this out. I've looked into this before, and I don't remember if I ever came up with a good solution for this.