### PR TITLE
Print combined schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Make artifact executable
         run: chmod +x ./artifacts/linux-x64/isograph_cli
       - name: 'Build project'
-        run: ./artifacts/linux-x64/isograph_cli --config ./demos/${{ matrix.target.folder }}/isograph.config.json
+        run: cd ./demos/${{ matrix.target.folder }} && ../../artifacts/linux-x64/isograph_cli --config ./isograph.config.json
       - name: 'Check working directory status'
         run: './scripts/check-git-status.sh'
 

--- a/crates/graphql_artifact_generation/src/build_combined_graphql_schema.rs
+++ b/crates/graphql_artifact_generation/src/build_combined_graphql_schema.rs
@@ -1,20 +1,204 @@
-use common_lang_types::ArtifactPathAndContent;
-use isograph_schema::{SchemaObject, ValidatedSchema};
+use common_lang_types::{ArtifactPathAndContent, DescriptionValue, SelectableFieldName};
+use intern::{string_key::Intern, Lookup};
+use isograph_lang_types::{SelectionType, ServerFieldId};
+use isograph_schema::{
+    ClientFieldVariant, ClientType, FieldType, SchemaObject, SchemaScalar,
+    UserWrittenComponentVariant, ValidatedSchema,
+};
+use std::fmt::Write;
+
+use crate::generate_artifacts::COMBINED_GRAPHQL_SCHEMA_FILE_NAME;
 
 pub(crate) fn build_combined_graphql_schema(schema: &ValidatedSchema) -> ArtifactPathAndContent {
-    let mut schema_content = String::new();
+    let mut schema_content = initial_schema_content();
 
     for object in schema.server_field_data.server_objects.iter() {
-        write_object(&mut schema_content, &object)
+        write_object(schema, &mut schema_content, &object).expect("Expected writing to work");
+    }
+
+    for scalar in schema.server_field_data.server_scalars.iter() {
+        // TODO avoid doing this
+        if scalar.name.item == "NullDoesNotExistIfThisIsPrintedThisIsABug".intern().into() {
+            continue;
+        }
+        write_scalar(&mut schema_content, scalar).expect("Expected writing scalar to work");
     }
 
     ArtifactPathAndContent {
         type_and_field: None,
-        file_name_prefix: todo!(),
-        file_content: todo!(),
+        file_content: schema_content,
+        file_name: *COMBINED_GRAPHQL_SCHEMA_FILE_NAME,
     }
 }
 
-fn write_object(schema_content: &mut String, object: &SchemaObject) {
-    writeln!(schema_content, "type {} {{ }}", object.name)
+fn initial_schema_content() -> String {
+    String::from(
+        "\"\"\"\n\
+        A scalar representing an Isograph field defined with the \n\
+        iso function.\n\
+        \"\"\"\n\
+        scalar IsographClientField\n\n\
+        \"\"\"\n\
+        A scalar representing an Isograph field defined with the\n\
+        iso function and annotated with @component.\n\
+        \"\"\"\n\
+        scalar IsographClientComponentField\n\n\
+        \"\"\"\n\
+        A scalar representing an Isograph imperatively loaded field.\n\
+        This type is deprecated. Use @loadable fields instead.\n\
+        \"\"\"\n\
+        scalar IsographImperativelyLoadedField\n\n\
+        \"\"\"\n\
+        A scalar representing a pointer to an Isograph object (specifically,\n\
+        a pointer to the object on which the link field was selected.)\n\
+        \"\"\"\n\
+        scalar IsographLinkField\n\n\
+        ",
+    )
+}
+
+fn write_object(
+    schema: &ValidatedSchema,
+    schema_content: &mut String,
+    object: &SchemaObject,
+) -> std::fmt::Result {
+    let padding = "    ";
+    let object_description = formatted_description(object.description, "", None);
+    writeln!(
+        schema_content,
+        "{object_description}type {} {{",
+        object.name
+    )?;
+    let typename = "__typename".intern().into();
+    for (field_name, field_type) in object.encountered_fields.iter() {
+        // HACK: skip typenames
+        if field_name == &typename {
+            continue;
+        }
+        match field_type {
+            FieldType::ServerField(server_field_id) => {
+                write_server_field(schema, schema_content, padding, server_field_id, field_name)?;
+            }
+            FieldType::ClientField(client_type) => match client_type {
+                ClientType::ClientField(client_field_id) => {
+                    write_client_field(
+                        schema,
+                        schema_content,
+                        padding,
+                        client_field_id,
+                        field_name,
+                    )?;
+                }
+            },
+        }
+    }
+
+    writeln!(schema_content, "}}\n")?;
+
+    Ok(())
+}
+
+fn write_client_field(
+    schema: &isograph_schema::Schema<isograph_schema::ValidatedSchemaState>,
+    schema_content: &mut String,
+    padding: &str,
+    client_field_id: &isograph_lang_types::ClientFieldId,
+    field_name: &SelectableFieldName,
+) -> Result<(), std::fmt::Error> {
+    let field = schema.client_field(*client_field_id);
+    let (formatted_type, extra_content) = match field.variant {
+        ClientFieldVariant::UserWritten(user_written_client_field_info) => {
+            let extra_content = Some(format!(
+                "{padding}Defined as `export const {}` in `{}`",
+                user_written_client_field_info.const_export_name,
+                user_written_client_field_info.file_path
+            ));
+            match user_written_client_field_info.user_written_component_variant {
+                UserWrittenComponentVariant::Eager => ("IsographClientField", extra_content),
+                UserWrittenComponentVariant::Component => {
+                    ("IsographClientComponentField", extra_content)
+                }
+            }
+        }
+        ClientFieldVariant::ImperativelyLoadedField(_) => ("IsographImperativelyLoadedField", None),
+        ClientFieldVariant::Link => ("IsographLinkField", None),
+    };
+    let description = formatted_description(field.description, padding, extra_content);
+    writeln!(
+        schema_content,
+        "{description}{padding}{field_name}: {formatted_type}"
+    )?;
+    Ok(())
+}
+
+fn write_server_field(
+    schema: &ValidatedSchema,
+    schema_content: &mut String,
+    padding: &str,
+    server_field_id: &ServerFieldId,
+    field_name: &SelectableFieldName,
+) -> Result<(), std::fmt::Error> {
+    let server_field = schema.server_field(*server_field_id);
+    let (type_annotation, description) = match &server_field.associated_data {
+        SelectionType::Object(object) => {
+            let mut description = None;
+            let type_annotation = object.type_name.clone().map(&mut |target_object_id| {
+                let target_object = schema.server_field_data.object(target_object_id);
+                description = target_object.description;
+                target_object.name.lookup()
+            });
+            (type_annotation, description)
+        }
+        SelectionType::Scalar(scalar) => {
+            let mut description = None;
+            let type_annotation = scalar.clone().map(&mut |target_scalar_id| {
+                let target_scalar = schema.server_field_data.scalar(target_scalar_id);
+                description = target_scalar.description.map(|x| x.item);
+                target_scalar.name.item.lookup()
+            });
+            (type_annotation, description)
+        }
+    };
+    let formatted_type = type_annotation.print_graphql();
+    let description = formatted_description(description, padding, None);
+    writeln!(
+        schema_content,
+        "{description}{padding}{field_name}: {formatted_type}"
+    )?;
+    Ok(())
+}
+
+fn formatted_description(
+    description: Option<DescriptionValue>,
+    padding: &str,
+    extra_description_content: Option<String>,
+) -> String {
+    if description.is_none() && extra_description_content.is_none() {
+        return "".to_string();
+    }
+
+    let mut description_output = format!("{padding}\"\"\"\n");
+    if let Some(description) = description {
+        description_output.push_str(padding);
+        description_output.push_str(description.lookup());
+    }
+
+    let both_present = description.is_some() && extra_description_content.is_some();
+    if both_present {
+        description_output.push_str(&format!("\n{padding}-------\n"));
+    }
+
+    if let Some(extra_description_content) = extra_description_content {
+        description_output.push_str(&extra_description_content);
+    }
+
+    description_output.push_str(&format!("\n{padding}\"\"\"\n"));
+
+    description_output
+}
+
+fn write_scalar(schema_content: &mut String, scalar: &SchemaScalar) -> std::fmt::Result {
+    let description = formatted_description(scalar.description.map(|x| x.item), "", None);
+    let scalar_name = scalar.name.item;
+    writeln!(schema_content, "{description}scalar {scalar_name}")
 }

--- a/crates/graphql_artifact_generation/src/build_combined_graphql_schema.rs
+++ b/crates/graphql_artifact_generation/src/build_combined_graphql_schema.rs
@@ -1,0 +1,20 @@
+use common_lang_types::ArtifactPathAndContent;
+use isograph_schema::{SchemaObject, ValidatedSchema};
+
+pub(crate) fn build_combined_graphql_schema(schema: &ValidatedSchema) -> ArtifactPathAndContent {
+    let mut schema_content = String::new();
+
+    for object in schema.server_field_data.server_objects.iter() {
+        write_object(&mut schema_content, &object)
+    }
+
+    ArtifactPathAndContent {
+        type_and_field: None,
+        file_name_prefix: todo!(),
+        file_content: todo!(),
+    }
+}
+
+fn write_object(schema_content: &mut String, object: &SchemaObject) {
+    writeln!(schema_content, "type {} {{ }}", object.name)
+}

--- a/crates/graphql_artifact_generation/src/build_combined_graphql_schema.rs
+++ b/crates/graphql_artifact_generation/src/build_combined_graphql_schema.rs
@@ -13,7 +13,7 @@ pub(crate) fn build_combined_graphql_schema(schema: &ValidatedSchema) -> Artifac
     let mut schema_content = initial_schema_content();
 
     for object in schema.server_field_data.server_objects.iter() {
-        write_object(schema, &mut schema_content, &object).expect("Expected writing to work");
+        write_object(schema, &mut schema_content, object).expect("Expected writing to work");
     }
 
     for scalar in schema.server_field_data.server_scalars.iter() {

--- a/crates/graphql_artifact_generation/src/build_combined_graphql_schema.rs
+++ b/crates/graphql_artifact_generation/src/build_combined_graphql_schema.rs
@@ -71,8 +71,8 @@ fn write_object(
     )?;
     let typename = "__typename".intern().into();
     for (field_name, field_type) in object.encountered_fields.iter() {
-        // HACK: skip typenames
-        if field_name == &typename {
+        // HACK: skip typenames and fields starting with __
+        if field_name == &typename || field_name.lookup().starts_with("__") {
             continue;
         }
         match field_type {

--- a/crates/graphql_artifact_generation/src/generate_artifacts.rs
+++ b/crates/graphql_artifact_generation/src/generate_artifacts.rs
@@ -26,6 +26,7 @@ use std::{
 };
 
 use crate::{
+    build_combined_graphql_schema::build_combined_graphql_schema,
     eager_reader_artifact::{
         generate_eager_reader_artifacts, generate_eager_reader_condition_artifact,
         generate_eager_reader_output_type_artifact, generate_eager_reader_param_type_artifact,
@@ -61,6 +62,8 @@ lazy_static! {
     pub static ref RESOLVER_READER_FILE_NAME: ArtifactFileName =
         "resolver_reader.ts".intern().into();
     pub static ref RESOLVER_READER: ArtifactFilePrefix = "resolver_reader".intern().into();
+    pub static ref COMBINED_GRAPHQL_SCHEMA_FILE_NAME: ArtifactFileName =
+        "combined-graphql-schema.graphql".intern().into();
 }
 
 /// Get all artifacts according to the following scheme:
@@ -318,6 +321,10 @@ pub fn get_artifact_path_and_content(
         config.options.include_file_extensions_in_import_statements,
         config.options.no_babel_transform,
     ));
+
+    if config.options.generate_combined_schema {
+        path_and_contents.push(build_combined_graphql_schema(schema));
+    }
 
     path_and_contents
 }

--- a/crates/graphql_artifact_generation/src/lib.rs
+++ b/crates/graphql_artifact_generation/src/lib.rs
@@ -1,3 +1,4 @@
+mod build_combined_graphql_schema;
 mod eager_reader_artifact;
 mod entrypoint_artifact;
 mod format_parameter_type;

--- a/crates/isograph_config/src/compilation_options.rs
+++ b/crates/isograph_config/src/compilation_options.rs
@@ -45,6 +45,7 @@ pub struct CompilerConfigOptions {
     pub no_babel_transform: bool,
     pub include_file_extensions_in_import_statements: GenerateFileExtensionsOption,
     pub module: JavascriptModule,
+    pub generate_combined_schema: bool,
 }
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -236,6 +237,9 @@ pub struct ConfigFileOptions {
     /// into imports or requires of the generated entrypoint.ts file. Should
     /// it generate require calls or esmodule imports?
     module: ConfigFileJavascriptModule,
+    /// Whether to generate a GraphQL schema containing the original schema
+    /// plus all fields defined as client fields.
+    generate_combined_schema: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy, JsonSchema)]
@@ -271,6 +275,7 @@ fn create_options(options: ConfigFileOptions) -> CompilerConfigOptions {
             options.include_file_extensions_in_import_statements,
         ),
         module: create_module(options.module),
+        generate_combined_schema: options.generate_combined_schema,
     }
 }
 

--- a/crates/isograph_lang_types/src/isograph_type_annotation.rs
+++ b/crates/isograph_lang_types/src/isograph_type_annotation.rs
@@ -96,6 +96,40 @@ impl<TInner: Ord + Debug> TypeAnnotation<TInner> {
     }
 }
 
+impl<TInner: std::fmt::Display + Ord + Debug> TypeAnnotation<TInner> {
+    pub fn print_graphql(&self) -> String {
+        match self {
+            TypeAnnotation::Scalar(scalar) => format!("{}!", scalar),
+            TypeAnnotation::Union(union_type_annotation) => {
+                assert!(
+                    union_type_annotation.variants.len() == 1,
+                    "Unimplemented: union types with multiple variants"
+                );
+                let first = union_type_annotation
+                    .variants
+                    .first()
+                    .expect("Expected first variant to exist");
+
+                let maybe_exclamation = if union_type_annotation.nullable {
+                    ""
+                } else {
+                    "!"
+                };
+
+                match first {
+                    UnionVariant::Scalar(scalar) => format!("{}{maybe_exclamation}", scalar),
+                    UnionVariant::Plural(type_annotation) => {
+                        format!("[{}]{maybe_exclamation}", type_annotation.print_graphql())
+                    }
+                }
+            }
+            TypeAnnotation::Plural(type_annotation) => {
+                format!("[{}]", type_annotation.print_graphql())
+            }
+        }
+    }
+}
+
 #[derive(Default, Ord, PartialEq, PartialOrd, Eq, Clone, Debug)]
 pub struct UnionTypeAnnotation<TInner: Ord + Debug> {
     pub variants: BTreeSet<UnionVariant<TInner>>,

--- a/demos/pet-demo/isograph.config.json
+++ b/demos/pet-demo/isograph.config.json
@@ -4,6 +4,7 @@
   "schema": "./backend/schema.graphql",
   "schema_extensions": ["./backend/schema-extension.graphql"],
   "options": {
-    "on_invalid_id_type": "error"
+    "on_invalid_id_type": "error",
+    "generate_combined_schema": true
   }
 }

--- a/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
@@ -1,6 +1,6 @@
 import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
-  variables.input ??= {};
+  variables.input = variables.input ?? {};
   variables.input.id = readOutData.id;
   return variables;
 };

--- a/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/set_pet_tagline/refetch_reader.ts
@@ -1,6 +1,6 @@
 import type { RefetchReaderArtifact, ReaderAst, RefetchQueryNormalizationArtifact } from '@isograph/react';
 const includeReadOutData = (variables: any, readOutData: any) => {
-  variables.input = variables.input ?? {};
+  variables.input ??= {};
   variables.input.id = readOutData.id;
   return variables;
 };

--- a/demos/pet-demo/src/components/__isograph/combined-graphql-schema.graphql
+++ b/demos/pet-demo/src/components/__isograph/combined-graphql-schema.graphql
@@ -1,0 +1,389 @@
+"""
+A scalar representing an Isograph field defined with the 
+iso function.
+"""
+scalar IsographClientField
+
+"""
+A scalar representing an Isograph field defined with the
+iso function and annotated with @component.
+"""
+scalar IsographClientComponentField
+
+"""
+A scalar representing an Isograph imperatively loaded field.
+This type is deprecated. Use @loadable fields instead.
+"""
+scalar IsographImperativelyLoadedField
+
+"""
+A scalar representing a pointer to an Isograph object (specifically,
+a pointer to the object on which the link field was selected.)
+"""
+scalar IsographLinkField
+
+type Query {
+    """
+    Defined as `export const HomeRoute` in `src/components/HomeRoute.tsx`
+    """
+    HomeRoute: IsographClientComponentField
+    """
+    Defined as `export const Newsfeed` in `src/components/Newsfeed/NewsfeedRoute.tsx`
+    """
+    Newsfeed: IsographClientComponentField
+    """
+    Defined as `export const PetByNameRouteComponent` in `src/components/PetByName.tsx`
+    """
+    PetByName: IsographClientComponentField
+    """
+    Defined as `export const PetDetailDeferredRouteComponent` in `src/components/PetCheckinListRoute.tsx`
+    """
+    PetCheckinListRoute: IsographClientComponentField
+    """
+    Defined as `export const PetDetailDeferredRouteComponent` in `src/components/PetDetailDeferredRoute.tsx`
+    """
+    PetDetailDeferredRoute: IsographClientComponentField
+    """
+    Defined as `export const PetDetailRouteComponent` in `src/components/PetDetailRoute.tsx`
+    """
+    PetDetailRoute: IsographClientComponentField
+    """
+    Defined as `export const PetFavoritePhrase` in `src/components/FavoritePhrase.tsx`
+    """
+    PetFavoritePhrase: IsographClientComponentField
+    """
+    A store Link for the Query type.
+    """
+    link: IsographLinkField
+    node: Node
+    pet: Pet
+    petByName: Pet
+    pets: [Pet!]
+    viewer: Viewer!
+}
+
+type Viewer {
+    """
+    Defined as `export const NewsfeedPaginationComponent` in `src/components/Newsfeed/NewsfeedPagination.tsx`
+    """
+    NewsfeedPaginationComponent: IsographClientField
+    """
+    A refetch field for the Viewer type.
+    """
+    __refetch: IsographImperativelyLoadedField
+    id: ID!
+    """
+    A store Link for the Viewer type.
+    """
+    link: IsographLinkField
+    newsfeed: [NewsfeedItem!]
+}
+
+type Mutation {
+    """
+    Defined as `export const setTagline` in `src/components/PetTaglineCard.tsx`
+    """
+    SetTagline: IsographClientComponentField
+    """
+    A store Link for the Mutation type.
+    """
+    link: IsographLinkField
+    make_checkin_super: MakeCheckinSuperResponse!
+    set_pet_best_friend: SetBestFriendResponse!
+    set_pet_tagline: SetPetTaglineResponse!
+}
+
+type Node {
+    """
+    A refetch field for the Node type.
+    """
+    __refetch: IsographImperativelyLoadedField
+    asAdItem: AdItem
+    asBlogItem: BlogItem
+    asImage: Image
+    asPet: Pet
+    asViewer: Viewer
+    id: ID!
+    """
+    A store Link for the Node type.
+    """
+    link: IsographLinkField
+}
+
+type MakeCheckinSuperResponse {
+    """
+    This interface exists solely allow make_checkin_super to
+return an interface
+    """
+    checkin: ICheckin
+    """
+    A store Link for the MakeCheckinSuperResponse type.
+    """
+    link: IsographLinkField
+}
+
+type SetBestFriendResponse {
+    """
+    A store Link for the SetBestFriendResponse type.
+    """
+    link: IsographLinkField
+    pet: Pet!
+}
+
+type SetPetTaglineParams {
+    id: ID!
+    """
+    A store Link for the SetPetTaglineParams type.
+    """
+    link: IsographLinkField
+    tagline: String!
+}
+
+type SetPetTaglineResponse {
+    """
+    A store Link for the SetPetTaglineResponse type.
+    """
+    link: IsographLinkField
+    pet: Pet!
+}
+
+type Pet {
+    """
+    Defined as `export const FavoritePhraseLoader` in `src/components/FavoritePhrase.tsx`
+    """
+    FavoritePhraseLoader: IsographClientComponentField
+    """
+    Defined as `export const FirstCheckinMakeSuperButton` in `src/components/PetMakeFirstCheckinSuperButton.tsx`
+    """
+    FirstCheckinMakeSuperButton: IsographClientComponentField
+    """
+    Defined as `export const PetBestFriendCard` in `src/components/PetBestFriendCard.tsx`
+    """
+    PetBestFriendCard: IsographClientComponentField
+    """
+    Defined as `export const PetCheckinsCard` in `src/components/PetCheckinsCard.tsx`
+    """
+    PetCheckinsCard: IsographClientComponentField
+    """
+    Defined as `export const PetCheckinsCardList` in `src/components/PetCheckinsCard.tsx`
+    """
+    PetCheckinsCardList: IsographClientField
+    """
+    Defined as `export const PetDetailDeferredRouteInnerComponent` in `src/components/PetDetailDeferredRoute.tsx`
+    """
+    PetDetailDeferredRouteInnerComponent: IsographClientComponentField
+    """
+    Defined as `export const PetPhraseCard` in `src/components/PetPhraseCard.tsx`
+    """
+    PetPhraseCard: IsographClientComponentField
+    """
+    Defined as `export const PetStatsCard` in `src/components/PetStatsCard.tsx`
+    """
+    PetStatsCard: IsographClientComponentField
+    """
+    Defined as `export const PetSummaryCard` in `src/components/PetSummaryCard.tsx`
+    """
+    PetSummaryCard: IsographClientComponentField
+    """
+    Defined as `export const PetTaglineCard` in `src/components/PetTaglineCard.tsx`
+    """
+    PetTaglineCard: IsographClientComponentField
+    """
+    # Pet.PetUpdater
+A component to test behavior with respect to mutations.
+You can update the best friend and the tagline.
+    -------
+    Defined as `export const PetUpdater` in `src/components/PetUpdater.tsx`
+    """
+    PetUpdater: IsographClientComponentField
+    """
+    Defined as `export const Unreachable2` in `src/components/UnreachableFromEntrypoint.tsx`
+    """
+    Unreachable2: IsographClientField
+    """
+    Defined as `export const unreachableFromEntrypoint` in `src/components/UnreachableFromEntrypoint.tsx`
+    """
+    UnreachableFromEntrypoint: IsographClientField
+    """
+    A refetch field for the Pet type.
+    """
+    __refetch: IsographImperativelyLoadedField
+    age: Int!
+    alt_tagline: String!
+    best_friend_relationship: BestFriendRelationship
+    checkins: [Checkin!]
+    favorite_phrase: String
+    id: ID!
+    """
+    A store Link for the Pet type.
+    """
+    link: IsographLinkField
+    name: String!
+    nickname: String
+    picture: Url!
+    potential_new_best_friends: [Pet!]
+    set_best_friend: IsographImperativelyLoadedField
+    set_best_friend_do_not_use: IsographImperativelyLoadedField
+    set_best_friend_do_not_use_2: IsographImperativelyLoadedField
+    set_pet_tagline: IsographImperativelyLoadedField
+    stats: PetStats
+    tagline: String!
+}
+
+type BestFriendRelationship {
+    best_friend: Pet!
+    """
+    A store Link for the BestFriendRelationship type.
+    """
+    link: IsographLinkField
+    picture_together: Url
+}
+
+type PetStats {
+    cuteness: Int
+    energy: Int
+    hunger: Int
+    intelligence: Int
+    """
+    A store Link for the PetStats type.
+    """
+    link: IsographLinkField
+    refetch_pet_stats: IsographImperativelyLoadedField
+    sociability: Int
+    weight: Int
+}
+
+type Checkin {
+    """
+    Defined as `export const CheckinDisplay` in `src/components/PetCheckinsCard.tsx`
+    """
+    CheckinDisplay: IsographClientComponentField
+    """
+    A refetch field for the Checkin type.
+    """
+    __refetch: IsographImperativelyLoadedField
+    id: ID!
+    """
+    A store Link for the Checkin type.
+    """
+    link: IsographLinkField
+    location: String!
+    make_super: IsographImperativelyLoadedField
+    time: String!
+}
+
+"""
+This interface exists solely allow make_checkin_super to
+return an interface
+"""
+type ICheckin {
+    """
+    A refetch field for the ICheckin type.
+    """
+    __refetch: IsographImperativelyLoadedField
+    asCheckin: Checkin
+    id: ID!
+    """
+    A store Link for the ICheckin type.
+    """
+    link: IsographLinkField
+    location: String!
+    make_super: IsographImperativelyLoadedField
+    time: String!
+}
+
+type NewsfeedItem {
+    """
+    Defined as `export const NewsfeedAdOrBlog` in `src/components/Newsfeed/NewsfeedRoute.tsx`
+    """
+    NewsfeedAdOrBlog: IsographClientComponentField
+    asAdItem: AdItem
+    asBlogItem: BlogItem
+    """
+    A store Link for the NewsfeedItem type.
+    """
+    link: IsographLinkField
+}
+
+type BlogItem {
+    """
+    Defined as `export const BlogItem` in `src/components/Newsfeed/BlogItem.tsx`
+    """
+    BlogItemDisplay: IsographClientComponentField
+    """
+    Defined as `export const BlogItemMoreDetail` in `src/components/Newsfeed/BlogItemMoreDetail.tsx`
+    """
+    BlogItemMoreDetail: IsographClientComponentField
+    """
+    Defined as `export const NewsfeedAdOrBlog` in `src/components/Newsfeed/NewsfeedRoute.tsx`
+    """
+    NewsfeedAdOrBlog: IsographClientComponentField
+    """
+    A refetch field for the BlogItem type.
+    """
+    __refetch: IsographImperativelyLoadedField
+    author: String!
+    content: String!
+    id: ID!
+    image: Image
+    """
+    A store Link for the BlogItem type.
+    """
+    link: IsographLinkField
+    moreContent: String!
+    title: String!
+}
+
+type Image {
+    """
+    Defined as `export const ImageDisplay` in `src/components/Newsfeed/ImageDisplay.tsx`
+    """
+    ImageDisplay: IsographClientComponentField
+    """
+    Defined as `export const ImageDisplayWrapper` in `src/components/Newsfeed/BlogItem.tsx`
+    """
+    ImageDisplayWrapper: IsographClientComponentField
+    """
+    A refetch field for the Image type.
+    """
+    __refetch: IsographImperativelyLoadedField
+    id: ID!
+    """
+    A store Link for the Image type.
+    """
+    link: IsographLinkField
+    url: String!
+}
+
+type AdItem {
+    """
+    Defined as `export const BlogItem` in `src/components/Newsfeed/AdItem.tsx`
+    """
+    AdItemDisplay: IsographClientComponentField
+    """
+    Defined as `export const AdItemDisplayWrapper` in `src/components/Newsfeed/AdItemDisplayWrapper.tsx`
+    """
+    AdItemDisplayWrapper: IsographClientComponentField
+    """
+    Defined as `export const NewsfeedAdOrBlog` in `src/components/Newsfeed/NewsfeedRoute.tsx`
+    """
+    NewsfeedAdOrBlog: IsographClientComponentField
+    """
+    A refetch field for the AdItem type.
+    """
+    __refetch: IsographImperativelyLoadedField
+    advertiser: String!
+    id: ID!
+    """
+    A store Link for the AdItem type.
+    """
+    link: IsographLinkField
+    message: String!
+}
+
+scalar ID
+scalar String
+scalar Boolean
+scalar Float
+scalar Int
+scalar Url

--- a/demos/pet-demo/src/components/__isograph/combined-graphql-schema.graphql
+++ b/demos/pet-demo/src/components/__isograph/combined-graphql-schema.graphql
@@ -67,10 +67,6 @@ type Viewer {
     Defined as `export const NewsfeedPaginationComponent` in `src/components/Newsfeed/NewsfeedPagination.tsx`
     """
     NewsfeedPaginationComponent: IsographClientField
-    """
-    A refetch field for the Viewer type.
-    """
-    __refetch: IsographImperativelyLoadedField
     id: ID!
     """
     A store Link for the Viewer type.
@@ -94,10 +90,6 @@ type Mutation {
 }
 
 type Node {
-    """
-    A refetch field for the Node type.
-    """
-    __refetch: IsographImperativelyLoadedField
     asAdItem: AdItem
     asBlogItem: BlogItem
     asImage: Image
@@ -189,7 +181,7 @@ type Pet {
     """
     PetTaglineCard: IsographClientComponentField
     """
-    # Pet.PetUpdater
+    Pet.PetUpdater
 A component to test behavior with respect to mutations.
 You can update the best friend and the tagline.
     -------
@@ -204,10 +196,6 @@ You can update the best friend and the tagline.
     Defined as `export const unreachableFromEntrypoint` in `src/components/UnreachableFromEntrypoint.tsx`
     """
     UnreachableFromEntrypoint: IsographClientField
-    """
-    A refetch field for the Pet type.
-    """
-    __refetch: IsographImperativelyLoadedField
     age: Int!
     alt_tagline: String!
     best_friend_relationship: BestFriendRelationship
@@ -258,10 +246,6 @@ type Checkin {
     Defined as `export const CheckinDisplay` in `src/components/PetCheckinsCard.tsx`
     """
     CheckinDisplay: IsographClientComponentField
-    """
-    A refetch field for the Checkin type.
-    """
-    __refetch: IsographImperativelyLoadedField
     id: ID!
     """
     A store Link for the Checkin type.
@@ -277,10 +261,6 @@ This interface exists solely allow make_checkin_super to
 return an interface
 """
 type ICheckin {
-    """
-    A refetch field for the ICheckin type.
-    """
-    __refetch: IsographImperativelyLoadedField
     asCheckin: Checkin
     id: ID!
     """
@@ -318,10 +298,6 @@ type BlogItem {
     Defined as `export const NewsfeedAdOrBlog` in `src/components/Newsfeed/NewsfeedRoute.tsx`
     """
     NewsfeedAdOrBlog: IsographClientComponentField
-    """
-    A refetch field for the BlogItem type.
-    """
-    __refetch: IsographImperativelyLoadedField
     author: String!
     content: String!
     id: ID!
@@ -343,10 +319,6 @@ type Image {
     Defined as `export const ImageDisplayWrapper` in `src/components/Newsfeed/BlogItem.tsx`
     """
     ImageDisplayWrapper: IsographClientComponentField
-    """
-    A refetch field for the Image type.
-    """
-    __refetch: IsographImperativelyLoadedField
     id: ID!
     """
     A store Link for the Image type.
@@ -368,10 +340,6 @@ type AdItem {
     Defined as `export const NewsfeedAdOrBlog` in `src/components/Newsfeed/NewsfeedRoute.tsx`
     """
     NewsfeedAdOrBlog: IsographClientComponentField
-    """
-    A refetch field for the AdItem type.
-    """
-    __refetch: IsographImperativelyLoadedField
     advertiser: String!
     id: ID!
     """

--- a/libs/isograph-compiler/isograph-config-schema.json
+++ b/libs/isograph-compiler/isograph-config-schema.json
@@ -85,6 +85,7 @@
       "type": "object",
       "properties": {
         "generate_combined_schema": {
+          "description": "Whether to generate a GraphQL schema containing the original schema plus all fields defined as client fields.",
           "default": false,
           "type": "boolean"
         },

--- a/libs/isograph-compiler/isograph-config-schema.json
+++ b/libs/isograph-compiler/isograph-config-schema.json
@@ -84,6 +84,10 @@
     "ConfigFileOptions": {
       "type": "object",
       "properties": {
+        "generate_combined_schema": {
+          "default": false,
+          "type": "boolean"
+        },
         "include_file_extensions_in_import_statements": {
           "description": "Should the compiler include file extensions in import statements in generated files? e.g. should it import ./param_type or ./param_type.ts?",
           "default": false,


### PR DESCRIPTION
## Summary

As part of generating artifacts, also generate a graphql schema that contains all of the objects + fields, and scalars, that exist in the schema object, and write it to `/combined-graphql-schema.graphql`.

I'm not in love with the name.

## Why is this so badly written??

I would love a set of eyes on this. I don't think this is my finest work, but I'm (unless convinced otherwise) okay with this being not super good, because (in the long run) there is work that is required to do this "right", and that work is not the highest priority at the moment.

## Ways in which this is necessarily bad:

- we don't keep track of whether objects are input objects or output objects, because that doesn't matter to Isograph
- we also don't keep track of whether something is an interface, or union, or what.
- so, everything is "type"

## I would like to (as a follow up):

- Include in client fields' descriptions a link to the file and line number, and perhaps the text of the isograph literal

## In the end, doing this right will entail:

- Adding a type parameter to IsographSchema, which varies based on whether we are in GraphQL-land, SQL-land, etc. This parameter will include info on whether the item was an Input, or an Interface, whether to skip printing the field (for typename) etc