### PR TITLE
Export all public nested types in `@isograph/react`

### DIFF
--- a/libs/isograph-react/src/core/IsographEnvironment.ts
+++ b/libs/isograph-react/src/core/IsographEnvironment.ts
@@ -9,7 +9,7 @@ import type { ReaderAst, StartUpdate } from './reader';
 
 export type ComponentOrFieldName = string;
 export type StringifiedArgs = string;
-type ComponentCache = {
+export type ComponentCache = {
   [key: DataId]: {
     [key: ComponentOrFieldName]: { [key: StringifiedArgs]: React.FC<any> };
   };
@@ -32,24 +32,24 @@ export type FragmentSubscription<
   readonly readerAst: ReaderAst<TReadFromStore>;
 };
 
-type AnyChangesToRecordSubscription = {
+export type AnyChangesToRecordSubscription = {
   readonly kind: 'AnyChangesToRecord';
   readonly callback: () => void;
   readonly recordLink: Link;
 };
 
-type AnyRecordSubscription = {
+export type AnyRecordSubscription = {
   readonly kind: 'AnyRecords';
   readonly callback: () => void;
 };
 
-type Subscription =
+export type Subscription =
   | FragmentSubscription<any>
   | AnyChangesToRecordSubscription
   | AnyRecordSubscription;
-type Subscriptions = Set<Subscription>;
+export type Subscriptions = Set<Subscription>;
 // Should this be a map?
-type CacheMap<T> = { [index: string]: ParentCache<T> };
+export type CacheMap<T> = { [index: string]: ParentCache<T> };
 
 export type IsographEnvironment = {
   readonly store: IsographStore;

--- a/libs/isograph-react/src/core/PromiseWrapper.ts
+++ b/libs/isograph-react/src/core/PromiseWrapper.ts
@@ -1,7 +1,7 @@
 export type AnyError = any;
 
-const NOT_SET: Symbol = Symbol('NOT_SET');
-type NotSet = typeof NOT_SET;
+export const NOT_SET: Symbol = Symbol('NOT_SET');
+export type NotSet = typeof NOT_SET;
 
 export type Result<T, E> =
   | {

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -144,8 +144,8 @@ export function getOrCreateCacheForArtifact<
   return getOrCreateItemInSuspenseCache(environment, cacheKey, factory);
 }
 
-type NetworkResponseScalarValue = string | number | boolean;
-type NetworkResponseValue =
+export type NetworkResponseScalarValue = string | number | boolean;
+export type NetworkResponseValue =
   | NetworkResponseScalarValue
   | null
   | NetworkResponseObject

--- a/libs/isograph-react/src/core/garbageCollection.ts
+++ b/libs/isograph-react/src/core/garbageCollection.ts
@@ -17,7 +17,7 @@ export type RetainedQuery = {
   readonly root: Link;
 };
 
-type DidUnretainSomeQuery = boolean;
+export type DidUnretainSomeQuery = boolean;
 export function unretainQuery(
   environment: IsographEnvironment,
   retainedQuery: RetainedQuery,

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -167,7 +167,7 @@ export type ReaderLoadableField = {
     | IsographEntrypointLoader<any, any>;
 };
 
-type StableId = string;
+export type StableId = string;
 /// Why is LoadableField the way it is? Let's work backwards.
 ///
 /// We ultimately need a stable id (for deduplication) and a way to produce a

--- a/libs/isograph-react/src/index.ts
+++ b/libs/isograph-react/src/index.ts
@@ -3,6 +3,7 @@ export {
   unretainQuery,
   type RetainedQuery,
   garbageCollectEnvironment,
+  type DidUnretainSomeQuery,
 } from './core/garbageCollection';
 export {
   type PromiseWrapper,
@@ -10,8 +11,20 @@ export {
   getPromiseState,
   wrapResolvedValue,
   wrapPromise,
+  type PromiseState,
+  type Result,
+  type AnyError,
+  type NotSet,
+  NOT_SET,
 } from './core/PromiseWrapper';
-export { subscribe, normalizeData } from './core/cache';
+export {
+  subscribe,
+  normalizeData,
+  type NetworkResponseObject,
+  type NetworkResponseValue,
+  type NetworkResponseScalarValue,
+  type EncounteredIds,
+} from './core/cache';
 export { makeNetworkRequest } from './core/makeNetworkRequest';
 export {
   ROOT_ID,
@@ -20,10 +33,21 @@ export {
   type IsographEnvironment,
   type IsographNetworkFunction,
   type IsographStore,
+  type MissingFieldHandler,
   type Link,
   type StoreRecord,
+  type CacheMap,
   createIsographEnvironment,
   createIsographStore,
+  type ComponentCache,
+  type Subscriptions,
+  type Subscription,
+  type TypeName,
+  type FragmentSubscription,
+  type AnyChangesToRecordSubscription,
+  type AnyRecordSubscription,
+  type ComponentOrFieldName,
+  type StringifiedArgs,
 } from './core/IsographEnvironment';
 export {
   type EagerReaderArtifact,
@@ -36,11 +60,17 @@ export {
   type ReaderScalarField,
   type TopLevelReaderArtifact,
   type LoadableField,
+  type StableId,
   type ResolverFirstParameter,
+  type ReaderImperativelyLoadedField,
+  type ReaderLoadableField,
+  type ReaderLinkeField,
+  type StartUpdate,
 } from './core/reader';
 export {
   type NormalizationAst,
   type NormalizationAstNode,
+  type NormalizationAstNodes,
   type NormalizationAstLoader,
   type NormalizationLinkedField,
   type NormalizationScalarField,
@@ -52,8 +82,16 @@ export {
   type ExtractReadFromStore,
   type ExtractResolverResult,
   type NetworkRequestInfo,
+  type NormalizationInlineFragment,
+  type ReaderWithRefetchQueries,
+  type IsographEntrypointLoader,
 } from './core/entrypoint';
-export { readButDoNotEvaluate } from './core/read';
+export {
+  readButDoNotEvaluate,
+  type WithEncounteredRecords,
+  type NetworkRequestReaderOptions,
+  type ReadDataResult,
+} from './core/read';
 export {
   type ExtractSecondParam,
   type CombineWithIntrinsicAttributes,
@@ -68,22 +106,38 @@ export {
   type ExtractParameters,
   type ExtractData,
   stableIdForFragmentReference,
+  type ExtractStartUpdate,
+  type VariableValue,
 } from './core/FragmentReference';
 export {
   type LogMessage,
   type LogFunction,
+  type WrappedLogFunction,
   logMessage,
   registerLogger,
 } from './core/logging';
-export { check, CheckResult, FetchOptions, ShouldFetch } from './core/check';
+export {
+  check,
+  type CheckResult,
+  type FetchOptions,
+  type RequiredFetchOptions,
+  type ShouldFetch,
+  type RequiredShouldFetch,
+} from './core/check';
 
 export {
   IsographEnvironmentProvider,
   useIsographEnvironment,
   type IsographEnvironmentProviderProps,
 } from './react/IsographEnvironmentProvider';
-export { useImperativeReference } from './react/useImperativeReference';
-export { FragmentReader } from './react/FragmentReader';
+export {
+  useImperativeReference,
+  type UseImperativeReferenceResult,
+} from './react/useImperativeReference';
+export {
+  FragmentReader,
+  type IsExactlyIntrinsicAttributes,
+} from './react/FragmentReader';
 export { useResult } from './react/useResult';
 export {
   useReadAndSubscribe,
@@ -94,7 +148,23 @@ export { useRerenderOnChange } from './react/useRerenderOnChange';
 export { RenderAfterCommit__DO_NOT_USE } from './react/RenderAfterCommit__DO_NOT_USE';
 
 export { useClientSideDefer } from './loadable-hooks/useClientSideDefer';
-export { useImperativeExposedMutationField } from './loadable-hooks/useImperativeExposedMutationField';
-export { useSkipLimitPagination } from './loadable-hooks/useSkipLimitPagination';
-export { useConnectionSpecPagination } from './loadable-hooks/useConnectionSpecPagination';
-export { useImperativeLoadableField } from './loadable-hooks/useImperativeLoadableField';
+export {
+  useImperativeExposedMutationField,
+  type UseImperativeLoadableFieldReturn as UseImperativeExposedMutationFieldReturn,
+} from './loadable-hooks/useImperativeExposedMutationField';
+export {
+  useSkipLimitPagination,
+  type UseSkipLimitPaginationArgs,
+  type UseSkipLimitReturnValue,
+} from './loadable-hooks/useSkipLimitPagination';
+export {
+  useConnectionSpecPagination,
+  type Connection,
+  type PageInfo,
+  type UseConnectionSpecPaginationArgs,
+  type UsePaginationReturnValue,
+} from './loadable-hooks/useConnectionSpecPagination';
+export {
+  useImperativeLoadableField,
+  type UseImperativeLoadableFieldReturn,
+} from './loadable-hooks/useImperativeLoadableField';

--- a/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
@@ -26,7 +26,7 @@ import { useIsographEnvironment } from '../react/IsographEnvironmentProvider';
 import { useSubscribeToMultiple } from '../react/useReadAndSubscribe';
 import { maybeUnwrapNetworkRequest } from '../react/useResult';
 
-type UsePaginationReturnValue<
+export type UsePaginationReturnValue<
   TReadFromStore extends {
     parameters: object;
     data: object;
@@ -71,12 +71,12 @@ function flatten<T>(arr: ReadonlyArray<ReadonlyArray<T>>): ReadonlyArray<T> {
   return outArray;
 }
 
-type PageInfo = {
+export type PageInfo = {
   readonly hasNextPage: boolean;
   readonly endCursor: string | null;
 };
 
-type Connection<T> = {
+export type Connection<T> = {
   readonly edges: ReadonlyArray<T> | null;
   readonly pageInfo: PageInfo;
 };
@@ -86,7 +86,7 @@ type NonNullConnection<T> = {
   readonly pageInfo: PageInfo;
 };
 
-type UseConnectionSpecPaginationArgs = {
+export type UseConnectionSpecPaginationArgs = {
   first: number;
   after: string | null;
 };

--- a/libs/isograph-react/src/loadable-hooks/useImperativeExposedMutationField.ts
+++ b/libs/isograph-react/src/loadable-hooks/useImperativeExposedMutationField.ts
@@ -1,4 +1,4 @@
-type UseImperativeLoadableFieldReturn<TArgs> = {
+export type UseImperativeLoadableFieldReturn<TArgs> = {
   loadField: (args: TArgs) => void;
 };
 

--- a/libs/isograph-react/src/loadable-hooks/useImperativeLoadableField.ts
+++ b/libs/isograph-react/src/loadable-hooks/useImperativeLoadableField.ts
@@ -9,7 +9,7 @@ import {
 } from '../core/FragmentReference';
 import { LoadableField } from '../core/reader';
 
-type UseImperativeLoadableFieldReturn<
+export type UseImperativeLoadableFieldReturn<
   TReadFromStore extends { data: object; parameters: object },
   TResult,
   TProvidedArgs extends object,

--- a/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
@@ -26,7 +26,7 @@ import { useIsographEnvironment } from '../react/IsographEnvironmentProvider';
 import { useSubscribeToMultiple } from '../react/useReadAndSubscribe';
 import { maybeUnwrapNetworkRequest } from '../react/useResult';
 
-type UseSkipLimitReturnValue<
+export type UseSkipLimitReturnValue<
   TReadFromStore extends {
     data: object;
     parameters: object;
@@ -82,7 +82,7 @@ function flatten<T>(arr: ReadonlyArray<ReadonlyArray<T>>): ReadonlyArray<T> {
   return outArray;
 }
 
-type UseSkipLimitPaginationArgs = {
+export type UseSkipLimitPaginationArgs = {
   skip: number;
   limit: number;
 };

--- a/libs/isograph-react/src/react/FragmentReader.tsx
+++ b/libs/isograph-react/src/react/FragmentReader.tsx
@@ -4,7 +4,7 @@ import { FragmentReference } from '../core/FragmentReference';
 import { NetworkRequestReaderOptions } from '../core/read';
 import { useResult } from './useResult';
 
-type IsExactlyIntrinsicAttributes<T> = T extends JSX.IntrinsicAttributes
+export type IsExactlyIntrinsicAttributes<T> = T extends JSX.IntrinsicAttributes
   ? JSX.IntrinsicAttributes extends T
     ? true
     : false

--- a/libs/isograph-react/src/react/useImperativeReference.ts
+++ b/libs/isograph-react/src/react/useImperativeReference.ts
@@ -18,7 +18,7 @@ import { wrapResolvedValue } from '../core/PromiseWrapper';
 import type { StartUpdate } from '../core/reader';
 import { useIsographEnvironment } from './IsographEnvironmentProvider';
 
-type UseImperativeReferenceResult<
+export type UseImperativeReferenceResult<
   TReadFromStore extends {
     parameters: object;
     data: object;


### PR DESCRIPTION
Given our current imports in `isograph-react/index.ts` there are nested types that are not exported, users can see them in definitions but can't import them, they should be able to.

To do it I've used `@microsoft/api-extractor` it allows for marking stuff as `public/internal` and `alpha/beta` with comments, then report if these contracts are broken between releases (also has other cool functions like emitting bundles for alpha/beta).