### PR TITLE
fix collisions in component cache

### DIFF
--- a/libs/isograph-react/src/core/FragmentReference.ts
+++ b/libs/isograph-react/src/core/FragmentReference.ts
@@ -1,4 +1,5 @@
 import { ReaderWithRefetchQueries } from '../core/entrypoint';
+import { stableCopy } from './cache';
 import { type Link } from './IsographEnvironment';
 import { PromiseWrapper } from './PromiseWrapper';
 import type { StartUpdate } from './reader';
@@ -45,18 +46,10 @@ export type FragmentReference<
   readonly networkRequest: PromiseWrapper<void, any>;
 };
 
+export type StableIdForFragmentReference = string;
+
 export function stableIdForFragmentReference(
   fragmentReference: FragmentReference<any, any>,
-): string {
-  return `${fragmentReference.root.__typename}/${fragmentReference.root.__link}/TODO_FRAGMENT_NAME/${serializeVariables(fragmentReference.variables ?? {})}`;
-}
-
-function serializeVariables(variables: Variables) {
-  let s = '';
-  const keys = Object.keys(variables);
-  keys.sort();
-  for (const key of keys) {
-    s += `${key}:${variables[key]},`;
-  }
-  return s;
+): StableIdForFragmentReference {
+  return `${fragmentReference.root.__typename}/${fragmentReference.root.__link}/TODO_FRAGMENT_NAME/${JSON.stringify(stableCopy(fragmentReference.variables))}`;
 }

--- a/libs/isograph-react/src/core/IsographEnvironment.ts
+++ b/libs/isograph-react/src/core/IsographEnvironment.ts
@@ -3,6 +3,7 @@ import { IsographEntrypoint } from './entrypoint';
 import {
   FragmentReference,
   Variables,
+  type StableIdForFragmentReference,
   type UnknownTReadFromStore,
 } from './FragmentReference';
 import { RetainedQuery } from './garbageCollection';
@@ -14,8 +15,8 @@ import type { ReaderAst } from './reader';
 export type ComponentOrFieldName = string;
 export type StringifiedArgs = string;
 export type ComponentCache = {
-  [key: DataId]: {
-    [key: ComponentOrFieldName]: { [key: StringifiedArgs]: React.FC<any> };
+  [key: StableIdForFragmentReference]: {
+    [key: ComponentOrFieldName]: React.FC<any>;
   };
 };
 

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -15,12 +15,9 @@ export function getOrCreateCachedComponent(
   fragmentReference: FragmentReference<any, any>,
   networkRequestOptions: NetworkRequestReaderOptions,
 ): React.FC<any> {
-  // cachedComponentsById is a three layer cache: id, then component name, then
-  // stringified args. These three, together, uniquely identify a read at a given
-  // time.
-  const cachedComponentsById = environment.componentCache;
+  const cachedComponentsByStableFragmentReferenceId = environment.componentCache;
 
-  const componentsByName = (cachedComponentsById[
+  const componentsByName = (cachedComponentsByStableFragmentReferenceId[
     stableIdForFragmentReference(fragmentReference)
   ] ??= {});
 

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -1,6 +1,8 @@
 import { useReadAndSubscribe } from '../react/useReadAndSubscribe';
-import { stableCopy } from './cache';
-import { FragmentReference } from './FragmentReference';
+import {
+  FragmentReference,
+  stableIdForFragmentReference,
+} from './FragmentReference';
 import { IsographEnvironment } from './IsographEnvironment';
 import { logMessage } from './logging';
 import { readPromise } from './PromiseWrapper';
@@ -18,16 +20,11 @@ export function getOrCreateCachedComponent(
   // time.
   const cachedComponentsById = environment.componentCache;
 
-  const recordLink = fragmentReference.root.__link;
+  const componentsByName = (cachedComponentsById[
+    stableIdForFragmentReference(fragmentReference)
+  ] ??= {});
 
-  const componentsByName = (cachedComponentsById[recordLink] ??= {});
-
-  const byArgs = (componentsByName[componentName] ??= {});
-
-  const stringifiedArgs = JSON.stringify(
-    stableCopy(fragmentReference.variables),
-  );
-  return (byArgs[stringifiedArgs] ??= (() => {
+  return (componentsByName[componentName] ??= (() => {
     function Component(additionalRuntimeProps: { [key: string]: any }) {
       const readerWithRefetchQueries = readPromise(
         fragmentReference.readerWithRefetchQueries,

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -15,7 +15,8 @@ export function getOrCreateCachedComponent(
   fragmentReference: FragmentReference<any, any>,
   networkRequestOptions: NetworkRequestReaderOptions,
 ): React.FC<any> {
-  const cachedComponentsByStableFragmentReferenceId = environment.componentCache;
+  const cachedComponentsByStableFragmentReferenceId =
+    environment.componentCache;
 
   const componentsByName = (cachedComponentsByStableFragmentReferenceId[
     stableIdForFragmentReference(fragmentReference)

--- a/libs/isograph-react/src/index.ts
+++ b/libs/isograph-react/src/index.ts
@@ -109,6 +109,7 @@ export {
   stableIdForFragmentReference,
   type ExtractStartUpdate,
   type VariableValue,
+  type StableIdForFragmentReference,
 } from './core/FragmentReference';
 export {
   type LogMessage,


### PR DESCRIPTION
We use only `fragmentReference.root.__link` `id` instead of `id` + `__typename` in cache,
We don't see any errors, because second layer `componentName` includes `__typename` (e.g. `Pet.resolver`)

For resolvers defined on an abstract types we would encounter collisions