### PR TITLE
reuse interned value in fn args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,9 @@ dependencies = [
  "once_map",
  "pico_macros",
  "serde",
+ "serde_derive",
  "thiserror",
+ "tinyvec",
  "tracing",
  "u64_newtypes",
 ]
@@ -1838,10 +1840,11 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
+ "serde",
  "tinyvec_macros",
 ]
 

--- a/crates/pico/Cargo.toml
+++ b/crates/pico/Cargo.toml
@@ -14,3 +14,5 @@ once_map = { workspace = true }
 serde = { workspace = true } 
 thiserror = { workspace = true }
 tracing = { workspace = true }
+serde_derive = { workspace = true }
+tinyvec = { version = "1.8.1", features = ["serde"] }

--- a/crates/pico/src/database.rs
+++ b/crates/pico/src/database.rs
@@ -5,8 +5,8 @@ use crate::{
     dyn_eq::DynEq,
     epoch::Epoch,
     index::Index,
+    intern::{Key, ParamId},
     source::{Source, SourceId, SourceNode},
-    u64_types::{Key, ParamId},
 };
 use dashmap::{DashMap, Entry};
 use once_map::OnceMap;

--- a/crates/pico/src/dependency.rs
+++ b/crates/pico/src/dependency.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use crate::{derived_node::DerivedNodeId, epoch::Epoch, u64_types::Key};
+use crate::{derived_node::DerivedNodeId, epoch::Epoch, intern::Key};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Dependency {

--- a/crates/pico/src/derived_node.rs
+++ b/crates/pico/src/derived_node.rs
@@ -1,29 +1,43 @@
-use std::{fmt, hash::Hash};
+use std::{fmt, hash::Hash, marker::PhantomData, ops::Deref};
+
+use intern::{intern_struct, InternId};
+use serde::{Deserialize, Serialize};
+use tinyvec::ArrayVec;
 
 use crate::{
     dependency::Dependency,
     dyn_eq::DynEq,
     epoch::Epoch,
-    u64_types::{Key, ParamId},
+    intern::{Key, ParamId},
     Database,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct DerivedNodeId {
+#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct DerivedNodeDescriptor {
     pub key: Key,
-    pub param_id: ParamId,
+    pub params: ArrayVec<[ParamId; 8]>,
+}
+
+intern_struct! {
+    pub struct DerivedNodeId = Intern<DerivedNodeDescriptor> {}
 }
 
 impl DerivedNodeId {
-    pub fn new(key: Key, param_id: ParamId) -> Self {
-        Self { key, param_id }
+    pub fn new(key: Key, params: ArrayVec<[ParamId; 8]>) -> Self {
+        Self::intern(DerivedNodeDescriptor { key, params })
+    }
+}
+
+impl From<ParamId> for DerivedNodeId {
+    fn from(value: ParamId) -> Self {
+        DerivedNodeId::from_index_checked(**value.inner() as u32).unwrap()
     }
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct InnerFn(pub fn(&Database, ParamId) -> Box<dyn DynEq>);
+pub struct InnerFn(pub fn(&Database, DerivedNodeId) -> Box<dyn DynEq>);
 impl InnerFn {
-    pub fn new(inner_fn: fn(&Database, ParamId) -> Box<dyn DynEq>) -> Self {
+    pub fn new(inner_fn: fn(&Database, DerivedNodeId) -> Box<dyn DynEq>) -> Self {
         InnerFn(inner_fn)
     }
 }
@@ -47,4 +61,41 @@ impl fmt::Debug for DerivedNode {
 pub struct DerivedNodeRevision {
     pub time_updated: Epoch,
     pub time_verified: Epoch,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MemoRef<'db, T> {
+    db: &'db Database,
+    derived_node_id: DerivedNodeId,
+    phantom: PhantomData<T>,
+}
+
+impl<'db, T> MemoRef<'db, T> {
+    pub fn new(db: &'db Database, derived_node_id: DerivedNodeId) -> Self {
+        Self {
+            db,
+            derived_node_id,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: 'static + Clone> MemoRef<'_, T> {
+    pub fn to_owned(&self) -> T {
+        self.deref().clone()
+    }
+}
+
+impl<T: 'static> Deref for MemoRef<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.db
+            .get_derived_node(self.derived_node_id)
+            .unwrap()
+            .value
+            .as_any()
+            .downcast_ref::<T>()
+            .unwrap()
+    }
 }

--- a/crates/pico/src/intern.rs
+++ b/crates/pico/src/intern.rs
@@ -1,0 +1,76 @@
+use intern::InternSerdes;
+use intern::{intern_struct, InternId};
+use serde::{Deserialize, Serialize};
+use u64_newtypes::u64_newtype;
+
+use crate::{DerivedNodeId, SourceId};
+
+u64_newtype!(HashKey);
+
+intern_struct! {
+    pub struct HashId = Intern<HashKey> {
+      serdes("InternSerdes<HashId>");
+      const EMPTY = HashKey(0);
+    }
+}
+
+impl Default for HashId {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct ParamId(HashId);
+
+impl ParamId {
+    pub fn inner(&self) -> HashId {
+        self.0
+    }
+}
+
+impl From<u64> for ParamId {
+    fn from(value: u64) -> Self {
+        Self(HashId::intern(HashKey(value)))
+    }
+}
+
+impl<T> From<SourceId<T>> for ParamId {
+    fn from(value: SourceId<T>) -> Self {
+        Self(value.key.0)
+    }
+}
+
+impl<T> From<&SourceId<T>> for ParamId {
+    fn from(value: &SourceId<T>) -> Self {
+        Self(value.key.0)
+    }
+}
+
+impl From<DerivedNodeId> for ParamId {
+    fn from(value: DerivedNodeId) -> Self {
+        let idx: u64 = value.index().into();
+        Self::from(idx)
+    }
+}
+
+impl From<&DerivedNodeId> for ParamId {
+    fn from(value: &DerivedNodeId) -> Self {
+        Self::from(value.index() as u64)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct Key(HashId);
+
+impl From<u64> for Key {
+    fn from(value: u64) -> Self {
+        Self(HashId::intern(HashKey(value)))
+    }
+}
+
+impl From<HashId> for Key {
+    fn from(value: HashId) -> Self {
+        Self(value)
+    }
+}

--- a/crates/pico/src/lib.rs
+++ b/crates/pico/src/lib.rs
@@ -6,13 +6,13 @@ mod dyn_eq;
 mod epoch;
 mod generation;
 mod index;
+mod intern;
 pub mod macro_fns;
 mod memo;
 mod source;
-mod u64_types;
 
 pub use database::*;
 pub use derived_node::*;
+pub use intern::*;
 pub use memo::*;
 pub use source::*;
-pub use u64_types::*;

--- a/crates/pico/src/macro_fns.rs
+++ b/crates/pico/src/macro_fns.rs
@@ -1,22 +1,28 @@
 use std::{
-    any::Any,
+    any::{Any, TypeId},
     hash::{DefaultHasher, Hash, Hasher},
 };
 
+use tinyvec::ArrayVec;
+
 use crate::{index::Index, Database, DerivedNode, DerivedNodeId, ParamId};
 
-pub fn intern_param<T: Hash + Clone + 'static>(db: &Database, param: T) -> ParamId {
-    let param_id = hash(&param).into();
-    if !db.contains_param(param_id) {
-        let idx = db
-            .epoch_to_generation_map
-            .get(&db.current_epoch)
-            .unwrap()
-            .insert_param(Box::new(param));
-        db.param_id_to_index
-            .insert(param_id, Index::new(db.current_epoch, idx));
-    }
-    param_id
+pub fn init_param_vec() -> ArrayVec<[ParamId; 8]> {
+    ArrayVec::<[ParamId; 8]>::default()
+}
+
+pub fn intern_param<T: 'static>(db: &Database, param_id: ParamId, param: T) {
+    let idx = db
+        .epoch_to_generation_map
+        .get(&db.current_epoch)
+        .unwrap()
+        .insert_param(Box::new(param));
+    db.param_id_to_index
+        .insert(param_id, Index::new(db.current_epoch, idx));
+}
+
+pub fn param_exists(db: &Database, param_id: ParamId) -> bool {
+    db.contains_param(param_id)
 }
 
 pub fn get_derived_node(db: &Database, derived_node_id: DerivedNodeId) -> Option<&DerivedNode> {
@@ -27,8 +33,10 @@ pub fn get_param(db: &Database, param_id: ParamId) -> Option<&Box<dyn Any>> {
     db.get_param(param_id)
 }
 
-pub fn hash<T: Hash>(value: &T) -> u64 {
+pub fn hash<T: Hash + 'static>(value: &T) -> u64 {
     let mut s = DefaultHasher::new();
+    // hash `TypeId` to prevent collisions for new types
+    TypeId::of::<T>().hash(&mut s);
     value.hash(&mut s);
     s.finish()
 }

--- a/crates/pico/src/source.rs
+++ b/crates/pico/src/source.rs
@@ -3,7 +3,7 @@ use std::{
     marker::PhantomData,
 };
 
-use crate::{dyn_eq::DynEq, epoch::Epoch, u64_types::Key};
+use crate::{dyn_eq::DynEq, epoch::Epoch, intern::Key, ParamId};
 
 pub trait Source {
     fn get_key(&self) -> Key;
@@ -33,6 +33,15 @@ impl<T> SourceId<T> {
     pub fn new(source: &impl Source) -> Self {
         Self {
             key: source.get_key(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> From<ParamId> for SourceId<T> {
+    fn from(value: ParamId) -> Self {
+        Self {
+            key: value.inner().into(),
             phantom: PhantomData,
         }
     }

--- a/crates/pico/src/u64_types.rs
+++ b/crates/pico/src/u64_types.rs
@@ -1,4 +1,0 @@
-use u64_newtypes::u64_newtype;
-
-u64_newtype!(Key);
-u64_newtype!(ParamId);

--- a/crates/pico/tests/arg_reference.rs
+++ b/crates/pico/tests/arg_reference.rs
@@ -23,7 +23,7 @@ fn arg_reference() {
     assert_eq!(VALUE.load(Ordering::SeqCst), 0);
 
     let expected = Expected(6);
-    assert_result(&db, value, expected);
+    assert_result(&db, &value, expected);
     // assert that the argument of type `&Value` was cloned only once, when it was
     // inserted into the params store, and then internally used by reference
     assert_eq!(VALUE.load(Ordering::SeqCst), 1);
@@ -66,9 +66,9 @@ fn parse_ast(db: &Database, id: SourceId<Input>) -> Result<Program> {
     parser.parse_program()
 }
 
-#[memo(reference)]
+#[memo]
 fn evaluate_input(db: &Database, id: SourceId<Input>) -> Value {
-    let ast = parse_ast(db, id).expect("ast must be correct");
+    let ast = parse_ast(db, id).to_owned().expect("ast must be correct");
     let result = eval(ast.expression).expect("value must be evaluated");
     Value(result)
 }

--- a/crates/pico/tests/memoization.rs
+++ b/crates/pico/tests/memoization.rs
@@ -31,7 +31,7 @@ fn memoization() {
     });
 
     let result = sum(&db, left, right);
-    assert_eq!(result, 14);
+    assert_eq!(*result, 14);
 
     // every functions has been called once on the first run
     assert_eq!(*EVAL_COUNTER.lock().unwrap().get(&left).unwrap(), 1);
@@ -50,7 +50,7 @@ fn memoization() {
     assert_eq!(SUM_COUNTER.load(Ordering::SeqCst), 1);
 
     let result = sum(&db, left, right);
-    assert_eq!(result, 14);
+    assert_eq!(*result, 14);
 
     // "left" must be called again because the input value has been changed
     assert_eq!(*EVAL_COUNTER.lock().unwrap().get(&left).unwrap(), 2);
@@ -65,7 +65,7 @@ fn memoization() {
         value: "3 * 3".to_string(),
     });
     let result = sum(&db, left, right);
-    assert_eq!(result, 17);
+    assert_eq!(*result, 17);
 
     // "left" must be called again because the input value has been changed
     assert_eq!(*EVAL_COUNTER.lock().unwrap().get(&left).unwrap(), 3);
@@ -83,8 +83,8 @@ struct Input {
 }
 
 #[memo]
-fn parse_ast(db: &Database, id: SourceId<Input>) -> Result<Program> {
-    let source_text = db.get(id);
+fn parse_ast(db: &Database, id: &SourceId<Input>) -> Result<Program> {
+    let source_text = db.get(*id);
     let mut lexer = Lexer::new(source_text.value);
     let mut parser = Parser::new(&mut lexer)?;
     parser.parse_program()
@@ -93,7 +93,7 @@ fn parse_ast(db: &Database, id: SourceId<Input>) -> Result<Program> {
 #[memo]
 fn evaluate_input(db: &Database, id: SourceId<Input>) -> i64 {
     *EVAL_COUNTER.lock().unwrap().entry(id).or_insert(0) += 1;
-    let ast = parse_ast(db, id).expect("ast must be correct");
+    let ast = parse_ast(db, &id).to_owned().expect("ast must be correct");
     eval(ast.expression).expect("value must be evaluated")
 }
 
@@ -103,5 +103,5 @@ fn sum(db: &Database, left: SourceId<Input>, right: SourceId<Input>) -> i64 {
     let left = evaluate_input(db, left);
     let right = evaluate_input(db, right);
 
-    left + right
+    *left + *right
 }

--- a/crates/pico/tests/return_reference.rs
+++ b/crates/pico/tests/return_reference.rs
@@ -17,15 +17,10 @@ fn return_reference() {
         value: "2 + 2 * 2".to_string(),
     });
 
-    let value_ref = evaluate_input_ref(&db, input);
-    assert_eq!(*value_ref, Value(6));
+    let value = evaluate_input(&db, input);
+    assert_eq!(*value, Value(6));
     // assert that the value was not cloned
     assert_eq!(COUNTER.load(Ordering::SeqCst), 0);
-
-    let value = evaluate_input(&db, input);
-    assert_eq!(value, Value(6));
-    // assert that the value was cloned this time
-    assert_eq!(COUNTER.load(Ordering::SeqCst), 1);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Source)]
@@ -55,14 +50,7 @@ fn parse_ast(db: &Database, id: SourceId<Input>) -> Result<Program> {
 
 #[memo]
 fn evaluate_input(db: &Database, id: SourceId<Input>) -> Value {
-    let ast = parse_ast(db, id).expect("ast must be correct");
-    let result = eval(ast.expression).expect("value must be evaluated");
-    Value(result)
-}
-
-#[memo(reference)]
-fn evaluate_input_ref(db: &Database, id: SourceId<Input>) -> Value {
-    let ast = parse_ast(db, id).expect("ast must be correct");
+    let ast = parse_ast(db, id).to_owned().expect("ast must be correct");
     let result = eval(ast.expression).expect("value must be evaluated");
     Value(result)
 }

--- a/crates/pico/tests/shared_dependency.rs
+++ b/crates/pico/tests/shared_dependency.rs
@@ -16,9 +16,9 @@ fn shared_dependency() {
     });
 
     let result = evaluate(&db, input);
-    assert_eq!(result, 6);
+    assert_eq!(*result, 6);
     let result_exp = evaluate_exp(&db, input, 2);
-    assert_eq!(result_exp, 36);
+    assert_eq!(*result_exp, 36);
 
     let input = db.set(Input {
         key: "input",
@@ -26,9 +26,9 @@ fn shared_dependency() {
     });
 
     let result = evaluate(&db, input);
-    assert_eq!(result, 9);
+    assert_eq!(*result, 9);
     let result_exp = evaluate_exp(&db, input, 2);
-    assert_eq!(result_exp, 81);
+    assert_eq!(*result_exp, 81);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Source)]
@@ -48,13 +48,13 @@ fn parse_ast(db: &Database, id: SourceId<Input>) -> Result<Program> {
 
 #[memo]
 fn evaluate(db: &Database, id: SourceId<Input>) -> i64 {
-    let ast = parse_ast(db, id).expect("ast must be correct");
+    let ast = parse_ast(db, id).to_owned().expect("ast must be correct");
     eval(ast.expression).expect("value must be evaluated")
 }
 
 #[memo]
 fn evaluate_exp(db: &Database, id: SourceId<Input>, exp: u32) -> i64 {
-    let ast = parse_ast(db, id).expect("ast must be correct");
+    let ast = parse_ast(db, id).to_owned().expect("ast must be correct");
     eval(ast.expression)
         .expect("value must be evaluated")
         .pow(exp)

--- a/crates/pico_macros/src/memo.rs
+++ b/crates/pico_macros/src/memo.rs
@@ -14,7 +14,9 @@ use syn::{
 #[derive(Debug, FromMeta)]
 struct MemoArgs {
     #[darling(default)]
-    reference: bool,
+    inner: bool,
+    #[darling(default)]
+    inner_ref: bool,
 }
 
 pub(crate) fn memo(args: TokenStream, item: TokenStream) -> TokenStream {
@@ -51,23 +53,27 @@ pub(crate) fn memo(args: TokenStream, item: TokenStream) -> TokenStream {
         _ => unreachable!(),
     });
 
-    let unpacked_args = sig.inputs.iter().skip(1).map(|arg| match arg {
-        FnArg::Typed(PatType { pat, .. }) => pat.clone(),
-        _ => unreachable!(),
-    });
-
-    let get_ref_types = argument_types.clone().map(|ty| match **ty {
-        syn::Type::Reference(ref ref_type) => ref_type.elem.clone(),
-        _ => ty.clone(),
-    });
-
-    let reconstructed_args = argument_types
+    let param_ids_blocks = other_args
         .clone()
-        .zip(unpacked_args.clone())
-        .map(|(ty, arg)| {
-            match **ty {
-                syn::Type::Reference(_) => quote!(#arg),
-                _ => quote!(#arg.clone()), // Clone
+        .zip(argument_types.clone())
+        .map(|(arg, ty)| match ArgType::parse(ty) {
+            ArgType::Source | ArgType::MemoRef => {
+                quote! {
+                    param_ids.push(#arg.into());
+                }
+            }
+            ArgType::Other => {
+                let param_arg = match **ty {
+                    syn::Type::Reference(_) => quote!(#arg),
+                    _ => quote!(&#arg),
+                };
+                quote! {
+                    let param_id: ::pico::ParamId = ::pico::macro_fns::hash(#param_arg).into();
+                    if !::pico::macro_fns::param_exists(#db_arg, param_id) {
+                        ::pico::macro_fns::intern_param(#db_arg, param_id, #arg.clone());
+                    }
+                    param_ids.push(param_id);
+                }
             }
         });
 
@@ -97,7 +103,9 @@ pub(crate) fn memo(args: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut new_sig = sig.clone();
 
-    if args_.reference {
+    if args_.inner {
+        return_expr = quote! { #return_expr.clone() };
+    } else if args_.inner_ref {
         let lifetime = new_sig.generics.params.iter().find_map(|param| {
             if let GenericParam::Lifetime(lt) = param {
                 Some(&lt.lifetime)
@@ -124,27 +132,77 @@ pub(crate) fn memo(args: TokenStream, item: TokenStream) -> TokenStream {
                 ReturnType::Type(parse_quote!(->), Box::new(parse_quote!(&'db #return_type)));
         }
     } else {
-        return_expr = quote! { #return_expr.clone() };
+        new_sig.generics.params.push(parse_quote!('db));
+        if let FnArg::Typed(PatType { ty, .. }) = &mut new_sig.inputs[0] {
+            if let syn::Type::Reference(ref mut reference) = **ty {
+                reference.lifetime = Some(parse_quote!('db));
+            } else {
+                return Error::new_spanned(ty, "Expected a mutable reference type")
+                    .to_compile_error()
+                    .into();
+            }
+        }
+        new_sig.output = ReturnType::Type(
+            parse_quote!(->),
+            Box::new(parse_quote!(::pico::MemoRef<'db, #return_type>)),
+        );
+        return_expr = quote! {
+            ::pico::MemoRef::new(#db_arg, derived_node_id)
+        };
     }
 
-    let unpacked_args = other_args.clone();
-    let inner_args = other_args.clone();
+    let extract_parameters = other_args.clone().zip(argument_types.clone())
+        .enumerate()
+        .map(|(i, (arg, ty))| {
+            match ArgType::parse(ty) {
+                ArgType::Source | ArgType::MemoRef => {
+                    let maybe_ref = if matches!(**ty, syn::Type::Reference(_)) {
+                        quote! { &param_id.into() }
+                    } else {
+                        quote! { param_id.into() }
+                    };
+                    quote! {
+                        let #arg: #ty = {
+                            let param_id = derived_node_id.params[#i];
+                            #maybe_ref
+                        };
+                    }
+                }
+                ArgType::Other => {
+                    let target_type = if let syn::Type::Reference(ref reference) = **ty {
+                        &reference.elem
+                    } else {
+                        ty
+                    };
+                    let binding_expr = match **ty {
+                        syn::Type::Reference(_) => quote!(inner),
+                        _ => quote!(inner.clone()),
+                    };
+                    quote! {
+                        let #arg = {
+                            let param_ref = ::pico::macro_fns::get_param(#db_arg, derived_node_id.params[#i])
+                                .expect("param should exist. This is indicative of a bug in Pico.");
+                            let inner = param_ref.downcast_ref::<#target_type>()
+                                .expect("param type must be correct. This is indicative of a bug in Pico.");
+                            #binding_expr
+                        };
+                    }
+                }
+            }
+        });
+
     let output = quote! {
         #(#attrs)*
         #vis #new_sig {
-            let param_id = ::pico::macro_fns::intern_param(#db_arg, (#(#other_args.clone(),)*));
-            let derived_node_id = ::pico::DerivedNodeId::new(#fn_hash.into(), param_id);
-            ::pico::memo(#db_arg, derived_node_id, ::pico::InnerFn::new(|#db_arg, param_id| {
-                let param_ref = ::pico::macro_fns::get_param(#db_arg, param_id)
-                    .expect("param should exist. This is indicative of a bug in Pico.");
-                let (#(#unpacked_args,)*) = {
-                    let (#(#inner_args,)*) = param_ref
-                        .downcast_ref::<(#(#get_ref_types,)*)>()
-                        .expect("param type must to be correct. This is indicative of a bug in Pico.");
-                    (
-                        #(#reconstructed_args,)*
-                    )
-                };
+            let mut param_ids = ::pico::macro_fns::init_param_vec();
+            #(
+                #param_ids_blocks
+            )*
+            let derived_node_id = ::pico::DerivedNodeId::new(#fn_hash.into(), param_ids);
+            ::pico::memo(#db_arg, derived_node_id, ::pico::InnerFn::new(|#db_arg, derived_node_id| {
+                #(
+                    #extract_parameters
+                )*
                 let value: #return_type = (|| #block)();
                 Box::new(value)
             }));
@@ -159,4 +217,37 @@ fn hash(input: &Signature) -> u64 {
     let mut s = DefaultHasher::new();
     input.to_token_stream().to_string().hash(&mut s);
     s.finish()
+}
+
+enum ArgType {
+    Source,
+    MemoRef,
+    Other,
+}
+
+impl ArgType {
+    pub fn parse(ty: &syn::Type) -> Self {
+        if type_is(ty, "SourceId") {
+            return ArgType::Source;
+        }
+        if type_is(ty, "MemoRef") {
+            return ArgType::MemoRef;
+        }
+        ArgType::Other
+    }
+}
+
+fn type_is(ty: &syn::Type, target: &'static str) -> bool {
+    let inner = if let syn::Type::Reference(r) = ty {
+        &*r.elem
+    } else {
+        ty
+    };
+
+    if let syn::Type::Path(type_path) = inner {
+        if let Some(segment) = type_path.path.segments.last() {
+            return segment.ident == target;
+        }
+    }
+    false
 }

--- a/crates/u64_newtypes/src/lib.rs
+++ b/crates/u64_newtypes/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! u64_newtype {
     ($named:ident) => {
-        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Default)]
         pub struct $named(u64);
 
         impl std::fmt::Display for $named {
@@ -33,6 +33,25 @@ macro_rules! u64_newtype {
         impl $named {
             pub fn as_usize(&self) -> usize {
                 self.0 as usize
+            }
+        }
+
+        impl serde::Serialize for $named {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_u64(**self)
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $named {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let v: u64 = serde::Deserialize::deserialize(deserializer)?;
+                Ok($named::from(v))
             }
         }
     };


### PR DESCRIPTION
### The Problem

The current implementation of Pico interns memoized function parameters as a tuple, which has the following disadvantages:
- Possible data duplication in the database if the same argument is used in different memoized functions—it's cloned as many times as it is used.
- Unable to reuse a memoized function result. Even though it is already present in the database, it gets cloned and put in the params storage anyway. `SourceId` is `copy`, but it is better to reuse it and not intern it as a param.

To fix this, we need to intern parameters independently and find a way to detect arguments of types `SourceId` and arguments that are results of another memoized function.

### The Solution

Instead of interning a tuple, we intern each param individually. First, we generate a `ParamId` by hashing an argument. Then, we check if it is already present in the database to avoid unnecessary cloning. If not, we clone the argument and insert it into the params storage in the database.

If an argument is of the `SourceId` type, we simply convert `SourceId` to `ParamId` (internally they are just new types over a `u64` hash) before the `memo` call and convert it back inside `innerFn`.

To support reusing a memoized function result, we introduce a new struct:
```rs
pub struct MemoRef<'db, T> {
    db: &'db Database,
    derived_node_id: DerivedNodeId,
    phantom: PhantomData<T>,
}
```

The `reference` parameter has been removed from the macro, and the memoized function now always returns `MemoRef<'_, T>`. It implements `Deref` to get `&T` from the database and includes a `to_owned` method to clone a value from the database.

The `memo` macro now has `#[memo(inner)]` and `#[memo(inner_ref)]` parameters to support the previous implementation, which returned `&T` and `T` directly. These parameters can be used for a root query or inside a memoized function that consumes the result without passing it further (but this may be redundant).

`DerivedNodeId` now has a different implementation because we need to store all `ParamId`s:
```rs
#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
pub struct DerivedNodeDescriptor {
    pub key: Key,
    pub params: ArrayVec<[ParamId; 8]>,
}

intern_struct! {
    pub struct DerivedNodeId = Intern<DerivedNodeDescriptor> {}
}
```

Conversion between `DerivedNodeId` and `ParamId` is done using the interned index:
```rs
impl From<&DerivedNodeId> for ParamId {
    fn from(value: &DerivedNodeId) -> Self {
        Self::from(value.index() as u64)
    }
}

impl From<ParamId> for DerivedNodeId {
    fn from(value: ParamId) -> Self {
        DerivedNodeId::from_index_checked(**value.inner() as u32).unwrap()
    }
}
```

This is safe because the conversion is handled by generated code that knows the argument position and can extract the argument type from the corresponding `DerivedNodeId`.

**Note:** Arguments are analyzed by their type names, so `SourceId` and `MemoRef` should not be aliased.

---

**To Discuss:**  
I removed the `param_id` check in the `derived_node_changed_since` function. I think we should return `Option<Box<dyn DynEq>>` or `Result` from `inner_fn` and force re-evaluation of the parent `inner_fn` upon receiving `None` during the dependency check step. This may occur only if some `ParamId` is garbage collected. We can safely `unwrap` it when calling `inner_fn` in the new node creation step because parameters are interned right before the `inner_fn` call and cannot yet be garbage collected.

---

### TODO:
- [ ] Add new tests to cover the new implementations.  
- [ ] Restore the `ParamId` check before calling `inner_fn`.
