### PR TITLE
create upadtable proxy and apply updates

### DIFF
--- a/demos/pet-demo/src/components/PetTaglineCard.tsx
+++ b/demos/pet-demo/src/components/PetTaglineCard.tsx
@@ -22,7 +22,7 @@ export const PetTaglineCard = iso(`
       <CardContent>
         <h2>Tagline</h2>
         <p>&quot;{pet.tagline}&quot;</p>
-        {mutationRef === null ? (
+        {mutationRef === null || pet.tagline !== 'SUPER DOG' ? (
           <Button
             onClick={() => {
               loadMutation({

--- a/demos/pet-demo/src/components/PetUpdater.tsx
+++ b/demos/pet-demo/src/components/PetUpdater.tsx
@@ -29,9 +29,6 @@ export const PetUpdater = iso(`
   // We should find a way to work around this.
 
   const updateTagline = () => {
-    startUpdate((updatableData) => {
-      updatableData.tagline = tagline;
-    });
     pet.set_pet_tagline({ input: { tagline } })[1]();
   };
 
@@ -75,6 +72,16 @@ export const PetUpdater = iso(`
         />
         <Button variant="contained" onClick={updateTagline}>
           Set tagline
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            startUpdate((updatableData) => {
+              updatableData.tagline = tagline;
+            });
+          }}
+        >
+          Update cache
         </Button>
         <Button variant="contained" onClick={() => pet.__refetch()[1]()}>
           Refetch pet

--- a/demos/pet-demo/src/components/__isograph/Pet/PetUpdater/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetUpdater/resolver_reader.ts
@@ -46,6 +46,7 @@ const readerAst: ReaderAst<Pet__PetUpdater__param> = [
     fieldName: "tagline",
     alias: null,
     arguments: null,
+    isUpdatable: true,
   },
   {
     kind: "ImperativelyLoadedField",

--- a/libs/isograph-react/src/core/FragmentReference.ts
+++ b/libs/isograph-react/src/core/FragmentReference.ts
@@ -33,6 +33,9 @@ export type ExtractStartUpdate<
   },
 > = T['startUpdate'];
 
+export type ExtractStartUpdateUpdatableData<T> =
+  T extends StartUpdate<infer D> ? D : never;
+
 export type FragmentReference<
   TReadFromStore extends UnknownTReadFromStore,
   TClientFieldValue,

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -265,7 +265,7 @@ function withErrorHandling<T>(f: (t: T) => void): (t: T) => void {
   };
 }
 
-function callSubscriptions(
+export function callSubscriptions(
   environment: IsographEnvironment,
   recordsEncounteredWhenNormalizing: EncounteredIds,
 ) {

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -16,7 +16,11 @@ export function getOrCreateCachedComponent(
   networkRequestOptions: NetworkRequestReaderOptions,
 ): React.FC<any> {
   // We create startUpdate outside of component to make it stable
-  const startUpdate = createStartUpdate(environment, fragmentReference);
+  const startUpdate = createStartUpdate(
+    environment,
+    fragmentReference,
+    networkRequestOptions,
+  );
 
   return (environment.componentCache[
     stableIdForFragmentReference(fragmentReference, componentName)

--- a/libs/isograph-react/src/core/logging.ts
+++ b/libs/isograph-react/src/core/logging.ts
@@ -14,6 +14,7 @@ import {
   type Link,
 } from './IsographEnvironment';
 import { ReadDataResult } from './read';
+import type { Update } from './startUpdate';
 import { Arguments } from './util';
 
 export type LogMessage =
@@ -87,6 +88,10 @@ export type LogMessage =
     }
   | {
       kind: 'EnvironmentCreated';
+    }
+  | {
+      kind: 'AppliedUpdate';
+      update: Update;
     };
 
 export type LogFunction = (logMessage: LogMessage) => void;

--- a/libs/isograph-react/src/core/logging.ts
+++ b/libs/isograph-react/src/core/logging.ts
@@ -14,7 +14,7 @@ import {
   type Link,
 } from './IsographEnvironment';
 import { ReadDataResult } from './read';
-import type { Update } from './startUpdate';
+import type { StorePatch } from './startUpdate';
 import { Arguments } from './util';
 
 export type LogMessage =
@@ -91,7 +91,8 @@ export type LogMessage =
     }
   | {
       kind: 'AppliedUpdate';
-      update: Update;
+      store: IsographStore;
+      revert: StorePatch;
     };
 
 export type LogFunction = (logMessage: LogMessage) => void;

--- a/libs/isograph-react/src/core/makeNetworkRequest.ts
+++ b/libs/isograph-react/src/core/makeNetworkRequest.ts
@@ -312,6 +312,7 @@ function readDataForOnComplete<
                   environment,
                   fragment,
                   artifact.readerWithRefetchQueries.readerArtifact.fieldName,
+                  fakeNetworkRequestOptions,
                 ),
               }
             : undefined),

--- a/libs/isograph-react/src/core/optimisitcUpdate.ts
+++ b/libs/isograph-react/src/core/optimisitcUpdate.ts
@@ -1,0 +1,89 @@
+import { insertIfNotExists, type EncounteredIds } from './cache';
+import type {
+  DataId,
+  IsographEnvironment,
+  IsographStore,
+  StoreRecord,
+  TypeName,
+} from './IsographEnvironment';
+import { logMessage } from './logging';
+import { type StorePatch } from './startUpdate';
+
+export function applyAndQueueStartUpdate(
+  environment: IsographEnvironment,
+  apply: () => StorePatch,
+  mutableEncounteredIds: EncounteredIds,
+) {
+  let revert = applyPatch(environment.store, apply(), mutableEncounteredIds);
+
+  logMessage(environment, {
+    kind: 'AppliedUpdate',
+    store: environment.store,
+    revert,
+  });
+}
+
+function patchRecord(mutableRecord: StoreRecord, patch: StoreRecord) {
+  let revertRecord: StoreRecord = {};
+  for (const key in patch) {
+    revertRecord[key] = mutableRecord[key];
+    mutableRecord[key] = patch[key];
+  }
+  return revertRecord;
+}
+
+export type MutableStorePatch = {
+  [index: TypeName]:
+    | {
+        [index: DataId]: StoreRecord | null | undefined;
+      }
+    | null
+    | undefined;
+};
+
+function applyPatch(
+  mutableStore: IsographStore,
+  storePatch: StorePatch,
+  mutableEncounteredIds: EncounteredIds,
+): StorePatch {
+  let mutableRevert: MutableStorePatch = {};
+
+  for (const typeName in storePatch) {
+    let encounteredRecordsIds = insertIfNotExists(
+      mutableEncounteredIds,
+      typeName,
+    );
+
+    let patchById = storePatch[typeName];
+    let recordById = mutableStore[typeName];
+
+    if (patchById === null) {
+      mutableRevert[typeName] = recordById;
+      mutableStore[typeName] = null;
+      continue;
+    } else if (patchById === undefined) {
+      mutableRevert[typeName] = recordById;
+      delete mutableStore[typeName];
+      continue;
+    }
+    recordById = mutableStore[typeName] ??= {};
+    let revertById = (mutableRevert[typeName] ??= {});
+
+    for (const [recordId, patch] of Object.entries(patchById)) {
+      const data = recordById[recordId];
+
+      if (patch === undefined) {
+        revertById[recordId] = data;
+        delete recordById[recordId];
+      } else if (patch == null || data == null) {
+        revertById[recordId] = data;
+        recordById[recordId] = patch;
+      } else {
+        revertById[recordId] = patchRecord(data, patch);
+      }
+
+      encounteredRecordsIds.add(recordId);
+    }
+  }
+  return mutableRevert;
+}

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -36,7 +36,7 @@ import {
   wrapResolvedValue,
 } from './PromiseWrapper';
 import { ReaderAst } from './reader';
-import { getOrCreateCachedStartUpdate } from './startUpdate';
+import { getOrCreateCachedStartUpdate, LINK } from './startUpdate';
 import { Arguments } from './util';
 
 export type WithEncounteredRecords<T> = {
@@ -162,7 +162,7 @@ function readData<TReadFromStore>(
     };
   }
 
-  let target: { [index: string]: any } = {};
+  let target: { [index: PropertyKey]: any } = { [LINK]: root };
 
   for (const field of ast) {
     switch (field.kind) {

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -299,6 +299,7 @@ function readData<TReadFromStore>(
                     environment,
                     fragment,
                     readerWithRefetchQueries.readerArtifact.fieldName,
+                    networkRequestOptions,
                   ),
                 }
               : undefined),
@@ -484,6 +485,7 @@ function readData<TReadFromStore>(
                       environment,
                       fragment,
                       readerWithRefetchQueries.readerArtifact.fieldName,
+                      networkRequestOptions,
                     )
                   : undefined,
               };

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -94,6 +94,7 @@ export type ReaderScalarField = {
   readonly fieldName: string;
   readonly alias: string | null;
   readonly arguments: Arguments | null;
+  readonly isUpdatable: boolean;
 };
 
 export type ReaderLinkField = {

--- a/libs/isograph-react/src/core/startUpdate.ts
+++ b/libs/isograph-react/src/core/startUpdate.ts
@@ -1,10 +1,28 @@
 import {
+  callSubscriptions,
+  getParentRecordKey,
+  insertIfNotExists,
+  type EncounteredIds,
+} from './cache';
+import {
   stableIdForFragmentReference,
+  type ExtractParameters,
   type ExtractStartUpdate,
+  type ExtractStartUpdateUpdatableData,
   type FragmentReference,
   type UnknownTReadFromStore,
+  type Variables,
 } from './FragmentReference';
-import type { IsographEnvironment } from './IsographEnvironment';
+import {
+  assertLink,
+  type DataTypeValue,
+  type IsographEnvironment,
+  type Link,
+} from './IsographEnvironment';
+import { logMessage } from './logging';
+import { readPromise } from './PromiseWrapper';
+import { readButDoNotEvaluate, type NetworkRequestReaderOptions } from './read';
+import type { ReaderAst } from './reader';
 
 export function getOrCreateCachedStartUpdate<
   TReadFromStore extends UnknownTReadFromStore,
@@ -12,17 +30,233 @@ export function getOrCreateCachedStartUpdate<
   environment: IsographEnvironment,
   fragmentReference: FragmentReference<TReadFromStore, any>,
   eagerResolverName: string,
+  networkRequestOptions: NetworkRequestReaderOptions,
 ): ExtractStartUpdate<TReadFromStore> {
   return (environment.eagerReaderCache[
     stableIdForFragmentReference(fragmentReference, eagerResolverName)
-  ] ??= createStartUpdate(environment, fragmentReference));
+  ] ??= createStartUpdate(
+    environment,
+    fragmentReference,
+    networkRequestOptions,
+  ));
 }
 
+export type Update = {
+  root: Link;
+  variables: Variables;
+  storeRecordName: string;
+  newValue: DataTypeValue;
+  oldValue: DataTypeValue;
+};
+
 export function createStartUpdate<TReadFromStore extends UnknownTReadFromStore>(
-  _environment: IsographEnvironment,
-  _fragmentReference: FragmentReference<TReadFromStore, any>,
+  environment: IsographEnvironment,
+  fragmentReference: FragmentReference<TReadFromStore, any>,
+  networkRequestOptions: NetworkRequestReaderOptions,
 ): ExtractStartUpdate<TReadFromStore> {
-  return (_updater) => {
-    // TODO start update
+  return (updater) => {
+    const mutableUpdates: Update[] = [];
+    const readerWithRefetchQueries = readPromise(
+      fragmentReference.readerWithRefetchQueries,
+    );
+
+    const data = proxyUpdatableData(
+      environment,
+      readerWithRefetchQueries.readerArtifact.readerAst,
+      fragmentReference.root,
+      fragmentReference.variables ?? {},
+      readButDoNotEvaluate(
+        environment,
+        fragmentReference,
+        networkRequestOptions,
+      ).item,
+      mutableUpdates,
+    ) as ExtractStartUpdateUpdatableData<ExtractStartUpdate<TReadFromStore>>;
+
+    updater(data);
+
+    let mutableEncounteredIds: EncounteredIds = new Map();
+    applyUpdates(environment, mutableUpdates, mutableEncounteredIds);
+    callSubscriptions(environment, mutableEncounteredIds);
   };
+}
+
+function applyUpdates(
+  environment: IsographEnvironment,
+  updates: Update[],
+  mutableEncounteredIds: EncounteredIds,
+) {
+  for (const update of updates) {
+    const storeRecord = ((environment.store[update.root.__typename] ??= {})[
+      update.root.__link
+    ] ??= {});
+
+    storeRecord[update.storeRecordName] = update.newValue;
+    logMessage(environment, {
+      kind: 'AppliedUpdate',
+      update,
+    });
+
+    let encounteredRecordsIds = insertIfNotExists(
+      mutableEncounteredIds,
+      update.root.__typename,
+    );
+    encounteredRecordsIds.add(update.root.__link);
+  }
+}
+
+function proxyUpdatableData<TReadFromStore extends UnknownTReadFromStore>(
+  environment: IsographEnvironment,
+  ast: ReaderAst<TReadFromStore>,
+  root: Link,
+  variables: ExtractParameters<TReadFromStore>,
+  readData: object,
+  mutableUpdates: Update[],
+) {
+  let updatableData: Record<PropertyKey, typeof Reflect.set> = {};
+
+  let storeRecord = environment.store[root.__typename]?.[root.__link];
+  if (storeRecord === undefined) {
+    throw new Error('Expected record for root ' + root.__link);
+  }
+
+  if (storeRecord === null) {
+    return null;
+  }
+
+  for (const field of ast) {
+    switch (field.kind) {
+      case 'Scalar': {
+        if (field.isUpdatable) {
+          const storeRecordName = getParentRecordKey(field, variables);
+          const key = field.alias ?? field.fieldName;
+          updatableData[key] = (
+            target: object,
+            propertyKey: PropertyKey,
+            value: DataTypeValue,
+            receiver?: unknown,
+          ) => {
+            mutableUpdates.push({
+              storeRecordName,
+              newValue: value,
+              oldValue: Reflect.get(target, propertyKey, receiver),
+              root,
+              variables,
+            });
+            return Reflect.set(target, propertyKey, value, receiver);
+          };
+        }
+        break;
+      }
+      case 'Linked': {
+        const key = field.alias ?? field.fieldName;
+        const storeRecordName = getParentRecordKey(field, variables);
+        const storeValue = storeRecord[storeRecordName];
+        if (Array.isArray(storeValue)) {
+          const results = [];
+          for (let i = 0; i < storeValue.length; i++) {
+            const link = assertLink(storeValue[i]);
+            if (link === undefined) {
+              throw new Error(
+                'Expected link for ' +
+                  storeRecordName +
+                  ' on root ' +
+                  root.__link +
+                  '. Link is ' +
+                  JSON.stringify(storeValue[i]),
+              );
+            } else if (link === null) {
+              results.push(null);
+              continue;
+            }
+
+            // @ts-expect-error
+            const value = readData[key][i];
+
+            const result = proxyUpdatableData(
+              environment,
+              field.selections,
+              link,
+              variables,
+              value,
+              mutableUpdates,
+            );
+
+            results.push(result);
+          }
+          // @ts-expect-error
+          readData[key] = results;
+          break;
+        }
+        let link = assertLink(storeValue);
+
+        if (link === undefined) {
+          const missingFieldHandler = environment.missingFieldHandler;
+
+          const altLink = missingFieldHandler?.(
+            storeRecord,
+            root,
+            field.fieldName,
+            field.arguments,
+            variables,
+          );
+
+          if (altLink === undefined) {
+            throw new Error(
+              'Expected link for ' +
+                storeRecordName +
+                ' on root ' +
+                root.__link +
+                '. Link is ' +
+                JSON.stringify(storeValue),
+            );
+          } else {
+            link = altLink;
+          }
+        }
+
+        if (link === null) {
+          break;
+        }
+
+        // @ts-expect-error
+        const value = readData[key];
+
+        const mergedValue = proxyUpdatableData(
+          environment,
+          field.selections,
+          link,
+          variables,
+          value,
+          mutableUpdates,
+        );
+        // @ts-expect-error
+        readData[key] = mergedValue;
+        break;
+      }
+      case 'Resolver':
+      case 'Link':
+      case 'ImperativelyLoadedField':
+      case 'LoadablySelectedField':
+        break;
+      default: {
+        // Ensure we have covered all variants
+        let _: never = field;
+        _;
+        throw new Error('Unexpected case.');
+      }
+    }
+  }
+
+  return Object.keys(updatableData).length
+    ? new Proxy(readData, {
+        set(target, propertyKey, value, receiver) {
+          const setter = updatableData[propertyKey];
+          if (setter == undefined) {
+            throw new Error(`Error: "${String(propertyKey)}" is read-only`);
+          }
+          return setter(target, propertyKey, value, receiver);
+        },
+      })
+    : readData;
 }

--- a/libs/isograph-react/src/index.ts
+++ b/libs/isograph-react/src/index.ts
@@ -111,6 +111,7 @@ export {
   type VariableValue,
   type StableIdForFragmentReference,
 } from './core/FragmentReference';
+export { type Update } from './core/startUpdate';
 export {
   type LogMessage,
   type LogFunction,

--- a/libs/isograph-react/src/index.ts
+++ b/libs/isograph-react/src/index.ts
@@ -111,7 +111,7 @@ export {
   type VariableValue,
   type StableIdForFragmentReference,
 } from './core/FragmentReference';
-export { type Update } from './core/startUpdate';
+export { type StorePatch } from './core/startUpdate';
 export {
   type LogMessage,
   type LogFunction,

--- a/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
@@ -135,6 +135,7 @@ export function useConnectionSpecPagination<
                 environment,
                 fragmentReference,
                 readerWithRefetchQueries.readerArtifact.fieldName,
+                networkRequestOptions,
               ),
             }
           : undefined),

--- a/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
@@ -129,6 +129,7 @@ export function useSkipLimitPagination<
                 environment,
                 fragmentReference,
                 readerWithRefetchQueries.readerArtifact.kind,
+                networkRequestOptions,
               ),
             }
           : undefined),

--- a/libs/isograph-react/src/react/useResult.ts
+++ b/libs/isograph-react/src/react/useResult.ts
@@ -61,6 +61,7 @@ export function useResult<
                 environment,
                 fragmentReference,
                 readerWithRefetchQueries.readerArtifact.fieldName,
+                networkRequestOptions,
               ),
             }
           : undefined),

--- a/libs/isograph-react/src/tests/__isograph/Economist/asEconomist/resolver_reader.ts
+++ b/libs/isograph-react/src/tests/__isograph/Economist/asEconomist/resolver_reader.ts
@@ -1,0 +1,27 @@
+import type { EagerReaderArtifact, ReaderAst, Link } from '@isograph/react';
+
+const readerAst: ReaderAst<{ data: any, parameters: Record<PropertyKey, never> }> = [
+  {
+    kind: "Scalar",
+    fieldName: "__typename",
+    alias: null,
+    arguments: null,
+  },
+  {
+    kind: "Link",
+    alias: "link",
+  },
+];
+
+const artifact: EagerReaderArtifact<
+  { data: any, parameters: Record<PropertyKey, never> },
+  Link | null
+> = {
+  kind: "EagerReaderArtifact",
+  fieldName: "Economist.asEconomist",
+  resolver: ({ data }) => data.__typename === "Economist" ? data.link : null,
+  readerAst,
+  hasUpdatable: false,
+};
+
+export default artifact;

--- a/libs/isograph-react/src/tests/__isograph/Query/startUpdate/entrypoint.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/startUpdate/entrypoint.ts
@@ -1,0 +1,87 @@
+import type {IsographEntrypoint, NormalizationAst, RefetchQueryNormalizationArtifactWrapper} from '@isograph/react';
+import {Query__startUpdate__param} from './param_type';
+import {Query__startUpdate__output_type} from './output_type';
+import readerResolver from './resolver_reader';
+const nestedRefetchQueries: RefetchQueryNormalizationArtifactWrapper[] = [];
+
+const queryText = 'query startUpdate ($id: ID!) {\
+  node____id___v_id: node(id: $id) {\
+    __typename,\
+    id,\
+    ... on Economist {\
+      id,\
+      __typename,\
+      name,\
+    },\
+  },\
+}';
+
+const normalizationAst: NormalizationAst = {
+  kind: "NormalizationAst",
+  selections: [
+    {
+      kind: "Linked",
+      fieldName: "node",
+      arguments: [
+        [
+          "id",
+          { kind: "Variable", name: "id" },
+        ],
+      ],
+      concreteType: null,
+      selections: [
+        {
+          kind: "Scalar",
+          fieldName: "__typename",
+          arguments: null,
+        },
+        {
+          kind: "Scalar",
+          fieldName: "id",
+          arguments: null,
+        },
+        {
+          kind: "InlineFragment",
+          type: "Economist",
+          selections: [
+            {
+              kind: "Scalar",
+              fieldName: "id",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "__typename",
+              arguments: null,
+            },
+            {
+              kind: "Scalar",
+              fieldName: "name",
+              arguments: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+const artifact: IsographEntrypoint<
+  Query__startUpdate__param,
+  Query__startUpdate__output_type,
+  NormalizationAst
+> = {
+  kind: "Entrypoint",
+  networkRequestInfo: {
+    kind: "NetworkRequestInfo",
+    queryText,
+    normalizationAst,
+  },
+  concreteType: "Query",
+  readerWithRefetchQueries: {
+    kind: "ReaderWithRefetchQueries",
+    nestedRefetchQueries,
+    readerArtifact: readerResolver,
+  },
+};
+
+export default artifact;

--- a/libs/isograph-react/src/tests/__isograph/Query/startUpdate/output_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/startUpdate/output_type.ts
@@ -1,0 +1,3 @@
+import type React from 'react';
+import { startUpdate as resolver } from '../../../startUpdate.test';
+export type Query__startUpdate__output_type = ReturnType<typeof resolver>;

--- a/libs/isograph-react/src/tests/__isograph/Query/startUpdate/param_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/startUpdate/param_type.ts
@@ -1,0 +1,26 @@
+import type { StartUpdate } from '@isograph/react';
+import type { Query__startUpdate__parameters } from './parameters_type';
+
+export type Query__startUpdate__param = {
+  readonly data: {
+    readonly node: ({
+      /**
+A client pointer for the Economist type.
+      */
+      readonly asEconomist: ({
+        readonly name: string,
+      } | null),
+    } | null),
+  },
+  readonly parameters: Query__startUpdate__parameters,
+  readonly startUpdate: StartUpdate<{
+    readonly node: ({
+      /**
+A client pointer for the Economist type.
+      */
+      readonly asEconomist: ({
+        name: string,
+      } | null),
+    } | null),
+  }>,
+};

--- a/libs/isograph-react/src/tests/__isograph/Query/startUpdate/parameters_type.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/startUpdate/parameters_type.ts
@@ -1,0 +1,3 @@
+export type Query__startUpdate__parameters = {
+  readonly id: string,
+};

--- a/libs/isograph-react/src/tests/__isograph/Query/startUpdate/resolver_reader.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/startUpdate/resolver_reader.ts
@@ -1,0 +1,51 @@
+import type { EagerReaderArtifact, ReaderAst } from '@isograph/react';
+import { Query__startUpdate__param } from './param_type';
+import { Query__startUpdate__output_type } from './output_type';
+import { startUpdate as resolver } from '../../../startUpdate.test';
+import Economist__asEconomist__resolver_reader from '../../Economist/asEconomist/resolver_reader';
+
+const readerAst: ReaderAst<Query__startUpdate__param> = [
+  {
+    kind: "Linked",
+    fieldName: "node",
+    alias: null,
+    arguments: [
+      [
+        "id",
+        { kind: "Variable", name: "id" },
+      ],
+    ],
+    condition: null,
+    selections: [
+      {
+        kind: "Linked",
+        fieldName: "asEconomist",
+        alias: null,
+        arguments: null,
+        condition: Economist__asEconomist__resolver_reader,
+        selections: [
+          {
+            kind: "Scalar",
+            fieldName: "name",
+            alias: null,
+            arguments: null,
+            isUpdatable: true
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const artifact: EagerReaderArtifact<
+  Query__startUpdate__param,
+  Query__startUpdate__output_type
+> = {
+  kind: "EagerReaderArtifact",
+  fieldName: "Query.startUpdate",
+  resolver,
+  readerAst,
+  hasUpdatable: true,
+};
+
+export default artifact;

--- a/libs/isograph-react/src/tests/__isograph/iso.ts
+++ b/libs/isograph-react/src/tests/__isograph/iso.ts
@@ -2,10 +2,12 @@ import type { IsographEntrypoint } from '@isograph/react';
 import { type Query__meNameSuccessor__param } from './Query/meNameSuccessor/param_type';
 import { type Query__meName__param } from './Query/meName/param_type';
 import { type Query__nodeField__param } from './Query/nodeField/param_type';
+import { type Query__startUpdate__param } from './Query/startUpdate/param_type';
 import { type Query__subquery__param } from './Query/subquery/param_type';
 import entrypoint_Query__meNameSuccessor from '../__isograph/Query/meNameSuccessor/entrypoint';
 import entrypoint_Query__meName from '../__isograph/Query/meName/entrypoint';
 import entrypoint_Query__nodeField from '../__isograph/Query/nodeField/entrypoint';
+import entrypoint_Query__startUpdate from '../__isograph/Query/startUpdate/entrypoint';
 import entrypoint_Query__subquery from '../__isograph/Query/subquery/entrypoint';
 
 // This is the type given to regular client fields.
@@ -69,6 +71,10 @@ export function iso<T>(
 ): IdentityWithParam<Query__nodeField__param>;
 
 export function iso<T>(
+  param: T & MatchesWhitespaceAndString<'field Query.startUpdate', T>
+): IdentityWithParam<Query__startUpdate__param>;
+
+export function iso<T>(
   param: T & MatchesWhitespaceAndString<'field Query.subquery', T>
 ): IdentityWithParam<Query__subquery__param>;
 
@@ -83,6 +89,10 @@ export function iso<T>(
 export function iso<T>(
   param: T & MatchesWhitespaceAndString<'entrypoint Query.nodeField', T>
 ): typeof entrypoint_Query__nodeField;
+
+export function iso<T>(
+  param: T & MatchesWhitespaceAndString<'entrypoint Query.startUpdate', T>
+): typeof entrypoint_Query__startUpdate;
 
 export function iso<T>(
   param: T & MatchesWhitespaceAndString<'entrypoint Query.subquery', T>

--- a/libs/isograph-react/src/tests/normalizeData.test.ts
+++ b/libs/isograph-react/src/tests/normalizeData.test.ts
@@ -103,7 +103,7 @@ describe('readData', () => {
       throwOnNetworkError: false,
     });
 
-    expect(data).toStrictEqual({
+    expect(data).toMatchObject({
       encounteredRecords: new Map([
         ['Economist', new Set(['1'])],
         ['Query', new Set([ROOT_ID])],

--- a/libs/isograph-react/src/tests/startUpdate.test.ts
+++ b/libs/isograph-react/src/tests/startUpdate.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { getOrCreateCacheForArtifact } from '../core/cache';
+import {
+  createIsographEnvironment,
+  ROOT_ID,
+  type IsographStore,
+} from '../core/IsographEnvironment';
+import { createStartUpdate } from '../core/startUpdate';
+import { iso } from './__isograph/iso';
+
+const getDefaultStore = (): IsographStore => ({
+  Query: {
+    [ROOT_ID]: {
+      me: { __link: '0', __typename: 'Economist' },
+      you: { __link: '1', __typename: 'Economist' },
+      node____id___0: {
+        __link: '0',
+        __typename: 'Economist',
+      },
+    },
+  },
+  Economist: {
+    0: {
+      __typename: 'Economist',
+      id: '0',
+      name: 'Jeremy Bentham',
+      successor: { __link: '1', __typename: 'Economist' },
+    },
+    1: {
+      __typename: 'Economist',
+      id: '1',
+      name: 'John Stuart Mill',
+      predecessor: { __link: '0', __typename: 'Economist' },
+      successor: { __link: '2', __typename: 'Economist' },
+    },
+    2: {
+      __typename: 'Economist',
+      id: '2',
+      name: 'Henry Sidgwick',
+      predecessor: { __link: '1', __typename: 'Economist' },
+    },
+  },
+});
+
+export const startUpdate = iso(`
+  field Query.startUpdate($id: ID!) {
+    node(id: $id) {
+      asEconomist {
+        name @updatable
+      }
+    }
+  }  
+`)(() => {});
+
+describe('startUpdate', () => {
+  let environment: ReturnType<typeof createIsographEnvironment>;
+
+  beforeEach(() => {
+    const store = getDefaultStore();
+    const networkFunction = vi
+      .fn()
+      .mockRejectedValue(new Error('Fetch failed'));
+    environment = createIsographEnvironment(store, networkFunction);
+  });
+
+  test('startUpdate', () => {
+    const [_cacheItem, item, _disposeOfTemporaryRetain] =
+      getOrCreateCacheForArtifact(
+        environment,
+        iso(`entrypoint Query.startUpdate`),
+        {
+          id: '0',
+        },
+      ).getOrPopulateAndTemporaryRetain();
+    let startUpdate = createStartUpdate(environment, item, {
+      suspendIfInFlight: true,
+      throwOnNetworkError: false,
+    });
+
+    startUpdate((data) => {
+      if (data.node?.asEconomist) {
+        data.node.asEconomist.name = 'Foo';
+      }
+    });
+
+    expect(environment.store.Economist!['0']!.name).toBe('Foo');
+  });
+});


### PR DESCRIPTION
I've had to copy a bunch of code from `readData` to map the data back to the store.

- This doesn't support arrays, I have not done this part on rust part yet.
- I also need to generate `isUpdatable` for each node.

Is`Pet.PetTaglineCard` broken? The tagline doesn't refresh after mutation.

Part of updatable fields #312