### PR TITLE
coerce literals when typechecking

### DIFF
--- a/crates/isograph_schema/src/validate_argument_types.rs
+++ b/crates/isograph_schema/src/validate_argument_types.rs
@@ -157,7 +157,25 @@ pub fn value_satisfies_type(
             field_argument_definition_type,
             schema_data,
             selection_supplied_argument_value.location,
-        ),
+        )
+        .or_else(|error| {
+            scalar_literal_satisfies_type(
+                &schema_data.float_type_id,
+                field_argument_definition_type,
+                schema_data,
+                selection_supplied_argument_value.location,
+            )
+            .map_err(|_| error)
+        })
+        .or_else(|error| {
+            scalar_literal_satisfies_type(
+                &schema_data.id_type_id,
+                field_argument_definition_type,
+                schema_data,
+                selection_supplied_argument_value.location,
+            )
+            .map_err(|_| error)
+        }),
         NonConstantValue::Boolean(_) => scalar_literal_satisfies_type(
             &schema_data.boolean_type_id,
             field_argument_definition_type,
@@ -169,7 +187,16 @@ pub fn value_satisfies_type(
             field_argument_definition_type,
             schema_data,
             selection_supplied_argument_value.location,
-        ),
+        )
+        .or_else(|error| {
+            scalar_literal_satisfies_type(
+                &schema_data.id_type_id,
+                field_argument_definition_type,
+                schema_data,
+                selection_supplied_argument_value.location,
+            )
+            .map_err(|_| error)
+        }),
         NonConstantValue::Float(_) => scalar_literal_satisfies_type(
             &schema_data.float_type_id,
             field_argument_definition_type,


### PR DESCRIPTION
FIxes #383 and allows Int literals for Float arguments
