### PR TITLE
generate linked field updatable data type

### DIFF
--- a/crates/generate_artifacts/src/eager_reader_artifact.rs
+++ b/crates/generate_artifacts/src/eager_reader_artifact.rs
@@ -12,10 +12,10 @@ use std::{borrow::Cow, collections::BTreeSet, path::PathBuf};
 
 use crate::{
     generate_artifacts::{
-        generate_client_field_parameter_type, generate_output_type, generate_parameters,
-        ClientFieldFunctionImportStatement, RESOLVER_OUTPUT_TYPE, RESOLVER_OUTPUT_TYPE_FILE_NAME,
-        RESOLVER_PARAMETERS_TYPE_FILE_NAME, RESOLVER_PARAM_TYPE, RESOLVER_PARAM_TYPE_FILE_NAME,
-        RESOLVER_READER_FILE_NAME,
+        generate_client_field_parameter_type, generate_client_field_updatable_data_type,
+        generate_output_type, generate_parameters, ClientFieldFunctionImportStatement,
+        RESOLVER_OUTPUT_TYPE, RESOLVER_OUTPUT_TYPE_FILE_NAME, RESOLVER_PARAMETERS_TYPE_FILE_NAME,
+        RESOLVER_PARAM_TYPE, RESOLVER_PARAM_TYPE_FILE_NAME, RESOLVER_READER_FILE_NAME,
     },
     import_statements::{
         param_type_imports_to_import_param_statement, param_type_imports_to_import_statement,
@@ -208,7 +208,16 @@ pub(crate) fn generate_eager_reader_param_type_artifact<TOutputFormat: OutputFor
     let mut loadable_fields = BTreeSet::new();
     let mut link_fields = false;
     let mut updatable_fields = false;
-    let (client_field_parameter_type, updatable_data_type) = generate_client_field_parameter_type(
+    let client_field_parameter_type = generate_client_field_parameter_type(
+        schema,
+        client_field.selection_set_for_parent_query(),
+        parent_type,
+        &mut param_type_imports,
+        &mut loadable_fields,
+        1,
+        &mut link_fields,
+    );
+    let updatable_data_type = generate_client_field_updatable_data_type(
         schema,
         client_field.selection_set_for_parent_query(),
         parent_type,

--- a/crates/isograph_compiler/src/field_directives.rs
+++ b/crates/isograph_compiler/src/field_directives.rs
@@ -94,7 +94,18 @@ pub fn validate_isograph_selection_set_directives(
                 Ok(IsographSelectionVariant::Regular)
             }
         },
-        &|_object_pointer_selection| Ok(IsographSelectionVariant::Regular),
+        &|linked_field_selection| {
+            let updatable_directive = find_directive_named(
+                &linked_field_selection.directives,
+                *UPDATABLE_DIRECTIVE_NAME,
+            );
+
+            Ok(if updatable_directive.is_some() {
+                IsographSelectionVariant::Updatable
+            } else {
+                IsographSelectionVariant::Regular
+            })
+        },
     )
 }
 

--- a/crates/isograph_lang_parser/src/parse_iso_literal.rs
+++ b/crates/isograph_lang_parser/src/parse_iso_literal.rs
@@ -416,10 +416,10 @@ fn parse_selection(
         // TODO distinguish field groups
         let arguments = parse_optional_arguments(tokens, text_source)?;
 
+        let directives = parse_directives(tokens, text_source)?;
+
         // If we encounter a selection set, we are parsing a linked field. Otherwise, a scalar field.
         let selection_set = parse_optional_selection_set(tokens, text_source)?;
-
-        let directives = parse_directives(tokens, text_source)?;
 
         parse_comma_line_break_or_curly(tokens)?;
 

--- a/crates/isograph_schema/src/validate_client_field.rs
+++ b/crates/isograph_schema/src/validate_client_field.rs
@@ -796,6 +796,10 @@ fn validate_field_type_exists_and_is_linked<TOutputFormat: OutputFormat>(
                                     ))
                                 }
                                 IsographSelectionVariant::Updatable => {
+                                    assert_no_missing_arguments(
+                                        missing_arguments,
+                                        linked_field_selection.name.location,
+                                    )?;
                                     ValidatedIsographSelectionVariant::Updatable
                                 }
                             },


### PR DESCRIPTION
When updating linked fields, the client fields need to be omitted,
This requires generating getter and setter.
```tsx
type X = {
  get linked(): {
    readonly name: string
    readonly omitted: Type
  }
  set linked(value: {
    readonly name: string
  })
}
```

For this reason I've deleted the `DualStringProxy`
and there's a bunch of duplication now