### PR TITLE
add singleton macro

### DIFF
--- a/crates/pico/tests/singleton.rs
+++ b/crates/pico/tests/singleton.rs
@@ -1,0 +1,37 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use pico::{Database, SourceId};
+use pico_macros::{memo, Singleton};
+
+static FIRST_LETTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[test]
+fn singleton() {
+    let mut db = Database::default();
+
+    let input_id = db.set(Input {
+        value: "asdf".to_string(),
+    });
+
+    assert_eq!(*first_letter(&db, input_id), 'a');
+    assert_eq!(FIRST_LETTER_COUNTER.load(Ordering::SeqCst), 1);
+
+    db.set(Input {
+        value: "qwer".to_string(),
+    });
+
+    assert_eq!(*first_letter(&db, input_id), 'q');
+    assert_eq!(FIRST_LETTER_COUNTER.load(Ordering::SeqCst), 2);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Singleton)]
+struct Input {
+    pub value: String,
+}
+
+#[memo]
+fn first_letter(db: &Database, input_id: SourceId<Input>) -> char {
+    FIRST_LETTER_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let input = db.get(input_id);
+    input.value.chars().next().unwrap()
+}

--- a/crates/pico_macros/src/lib.rs
+++ b/crates/pico_macros/src/lib.rs
@@ -1,4 +1,5 @@
 mod memo_macro;
+mod singleton;
 mod source;
 
 extern crate proc_macro2;
@@ -13,4 +14,9 @@ pub fn memo(args: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Source, attributes(key))]
 pub fn source(input: TokenStream) -> TokenStream {
     source::source(input)
+}
+
+#[proc_macro_derive(Singleton)]
+pub fn singleton(input: TokenStream) -> TokenStream {
+    singleton::singleton(input)
 }

--- a/crates/pico_macros/src/singleton.rs
+++ b/crates/pico_macros/src/singleton.rs
@@ -1,0 +1,21 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+pub(crate) fn singleton(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+    let struct_name = input.ident.clone();
+
+    let output = quote! {
+        impl ::pico::Source for #struct_name {
+            fn get_key(&self) -> ::pico::Key {
+                use ::std::hash::{Hash, Hasher, DefaultHasher};
+                let mut s = DefaultHasher::new();
+                ::core::any::TypeId::of::<#struct_name>().hash(&mut s);
+                s.finish().into()
+            }
+        }
+    };
+
+    output.into()
+}


### PR DESCRIPTION
Closes #414 by introducing `Singleton` macro that uses `TypeId` of a struct as `Key`.