### PR TITLE
intern memoref

### DIFF
--- a/crates/pico/src/derived_node.rs
+++ b/crates/pico/src/derived_node.rs
@@ -1,4 +1,4 @@
-use std::{fmt, hash::Hash, marker::PhantomData, ops::Deref};
+use std::{fmt, hash::Hash};
 
 use intern::{intern_struct, InternId};
 use serde::{Deserialize, Serialize};
@@ -63,47 +63,4 @@ pub struct DerivedNodeRevision {
     pub time_updated: Epoch,
     pub time_verified: Epoch,
     pub index: Index<DerivedNodeId>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct MemoRef<'db, T> {
-    pub(crate) db: &'db Database,
-    pub(crate) derived_node_id: DerivedNodeId,
-    phantom: PhantomData<T>,
-}
-
-impl<'db, T: 'static + Clone> MemoRef<'db, T> {
-    pub fn new(db: &'db Database, derived_node_id: DerivedNodeId) -> Self {
-        Self {
-            db,
-            derived_node_id,
-            phantom: PhantomData,
-        }
-    }
-
-    pub fn to_owned(&self) -> T {
-        self.deref().clone()
-    }
-}
-
-impl<T> From<MemoRef<'_, T>> for ParamId {
-    fn from(val: MemoRef<'_, T>) -> Self {
-        let idx: u64 = val.derived_node_id.index().into();
-        ParamId::from(idx)
-    }
-}
-
-impl<T: 'static> Deref for MemoRef<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.db
-            .storage
-            .get_derived_node(self.derived_node_id)
-            .unwrap()
-            .value
-            .as_any()
-            .downcast_ref::<T>()
-            .unwrap()
-    }
 }

--- a/crates/pico/src/lib.rs
+++ b/crates/pico/src/lib.rs
@@ -8,6 +8,7 @@ mod garbage_collection;
 mod index;
 mod intern;
 pub mod macro_fns;
+mod memo_ref;
 mod retained_query;
 mod source;
 
@@ -15,4 +16,5 @@ pub use database::*;
 pub use derived_node::*;
 pub use execute_memoized_function::*;
 pub use intern::*;
+pub use memo_ref::*;
 pub use source::*;

--- a/crates/pico/src/memo_ref.rs
+++ b/crates/pico/src/memo_ref.rs
@@ -1,0 +1,49 @@
+use std::{marker::PhantomData, ops::Deref};
+
+use intern::InternId;
+
+use crate::{Database, DerivedNodeId, ParamId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoRef<T> {
+    pub(crate) db: *const Database,
+    pub(crate) derived_node_id: DerivedNodeId,
+    phantom: PhantomData<T>,
+}
+
+impl<T: 'static + Clone> MemoRef<T> {
+    pub fn new(db: &Database, derived_node_id: DerivedNodeId) -> Self {
+        Self {
+            db,
+            derived_node_id,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn to_owned(&self) -> T {
+        self.deref().clone()
+    }
+}
+
+impl<T> From<MemoRef<T>> for ParamId {
+    fn from(val: MemoRef<T>) -> Self {
+        let idx: u64 = val.derived_node_id.index().into();
+        ParamId::from(idx)
+    }
+}
+
+impl<T: 'static> Deref for MemoRef<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: `db` must outlive `MemoRef`
+        let db = unsafe { &*self.db };
+        db.storage
+            .get_derived_node(self.derived_node_id)
+            .unwrap()
+            .value
+            .as_any()
+            .downcast_ref::<T>()
+            .unwrap()
+    }
+}

--- a/crates/pico/src/retained_query.rs
+++ b/crates/pico/src/retained_query.rs
@@ -2,7 +2,7 @@ use dashmap::Entry;
 
 use crate::{Database, DerivedNodeId, MemoRef};
 
-/// Calling [`db.retain(&memoized_result)`][Database::retain] returns a
+/// Calling [`db.retain(memoized_result)`][Database::retain] returns a
 /// [`RetainedQuery`] object. **This object acts as a temporary guard**
 /// — as long as it exists, the memoized function and its dependencies
 /// will not be garbage collected.
@@ -43,7 +43,7 @@ impl std::ops::Drop for RetainedQuery {
 }
 
 impl Database {
-    pub fn retain<'db, T>(&'db self, memo_ref: &MemoRef<'db, T>) -> RetainedQuery {
+    pub fn retain<T>(&self, memo_ref: MemoRef<T>) -> RetainedQuery {
         debug_assert!(std::ptr::eq(self, memo_ref.db));
         match self.retained_calls.entry(memo_ref.derived_node_id) {
             Entry::Occupied(mut occupied_entry) => {

--- a/crates/pico/tests/garbage_collection/retained.rs
+++ b/crates/pico/tests/garbage_collection/retained.rs
@@ -17,7 +17,7 @@ fn basic_retained() {
     memoized_b(&db);
     assert_eq!(B_COUNTER.load(Ordering::SeqCst), 1);
 
-    let retain = db.retain(&memo_ref_a);
+    let retain = db.retain(memo_ref_a);
     retain.never_garbage_collect();
 
     // Run GC. both are retained — b, because of the LRU cache, and a, because of

--- a/crates/pico/tests/garbage_collection/retained_and_in_lru.rs
+++ b/crates/pico/tests/garbage_collection/retained_and_in_lru.rs
@@ -17,7 +17,7 @@ fn basic_retained() {
     memoized_b(&db);
     assert_eq!(B_COUNTER.load(Ordering::SeqCst), 1);
 
-    let retain = db.retain(&memo_ref_a);
+    let retain = db.retain(memo_ref_a);
     retain.never_garbage_collect();
 
     memoized_a(&db);

--- a/crates/pico/tests/intern.rs
+++ b/crates/pico/tests/intern.rs
@@ -1,0 +1,56 @@
+use pico::{Database, MemoRef, SourceId};
+use pico_macros::{memo, Source};
+use thiserror::Error;
+
+#[test]
+fn intern() {
+    let mut db = Database::default();
+
+    let id = db.set(Input {
+        key: "key",
+        value: "asdf".to_string(),
+    });
+
+    assert_eq!(**process_input(&db, id).as_ref().unwrap(), 'a');
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Source)]
+struct Input {
+    #[key]
+    pub key: &'static str,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+enum FirstLetterError {
+    #[error("empty string")]
+    EmptyString,
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+enum ProcessInputError {
+    #[error("cannot process input")]
+    ReadError(#[from] FirstLetterError),
+}
+
+#[memo]
+fn first_letter(
+    db: &Database,
+    input_id: SourceId<Input>,
+) -> Result<MemoRef<char>, FirstLetterError> {
+    db.get(input_id)
+        .value
+        .chars()
+        .next()
+        .ok_or(FirstLetterError::EmptyString)
+        .map(|v| db.intern(v))
+}
+
+#[memo]
+fn process_input(
+    db: &Database,
+    input_id: SourceId<Input>,
+) -> Result<MemoRef<char>, ProcessInputError> {
+    let result = first_letter(db, input_id).to_owned()?;
+    Ok(result)
+}

--- a/crates/pico/tests/params/memo_ref_never_cloned.rs
+++ b/crates/pico/tests/params/memo_ref_never_cloned.rs
@@ -34,4 +34,4 @@ fn get_output(_db: &Database) -> Output {
 }
 
 #[memo]
-fn consume_output<'db1>(db: &'db1 Database, _output: MemoRef<'_, Output>) {}
+fn consume_output(db: &Database, _output: MemoRef<Output>) {}

--- a/crates/pico/tests/store_memo_ref.rs
+++ b/crates/pico/tests/store_memo_ref.rs
@@ -1,0 +1,50 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use pico::{Database, MemoRef, SourceId};
+use pico_macros::{memo, Source};
+
+static FIRST_LETTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
+static FIRST_LETTER_AS_MEMO_REF_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[test]
+fn store_memo_ref() {
+    let mut db = Database::default();
+
+    let id = db.set(Input {
+        key: "key",
+        value: "asdf".to_string(),
+    });
+
+    assert_eq!(**first_letter_as_memo_ref(&db, id), 'a');
+    assert_eq!(FIRST_LETTER_COUNTER.load(Ordering::SeqCst), 1);
+    assert_eq!(FIRST_LETTER_AS_MEMO_REF_COUNTER.load(Ordering::SeqCst), 1);
+
+    db.set(Input {
+        key: "key",
+        value: "alto".to_string(),
+    });
+
+    assert_eq!(**first_letter_as_memo_ref(&db, id), 'a');
+    assert_eq!(FIRST_LETTER_COUNTER.load(Ordering::SeqCst), 2);
+    assert_eq!(FIRST_LETTER_AS_MEMO_REF_COUNTER.load(Ordering::SeqCst), 1);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Source)]
+struct Input {
+    #[key]
+    pub key: &'static str,
+    pub value: String,
+}
+
+#[memo]
+fn first_letter(db: &Database, input_id: SourceId<Input>) -> char {
+    FIRST_LETTER_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let input = db.get(input_id);
+    input.value.chars().next().unwrap()
+}
+
+#[memo]
+fn first_letter_as_memo_ref(db: &Database, input_id: SourceId<Input>) -> MemoRef<char> {
+    FIRST_LETTER_AS_MEMO_REF_COUNTER.fetch_add(1, Ordering::SeqCst);
+    first_letter(db, input_id)
+}


### PR DESCRIPTION
This PR explores how to use Pico with `Result` return type.

A memoized function puts its return value to the storage as `Box<dyn Any>` so we can't easily use error conversion by `?` or `map_err` which is a common pattern in the isograph compiler code. To achieve it we need to store `MemoRef` in the database using a pinch of `unsafe` code and explore a good pattern how to map errors properly.