### PR TITLE
add pico to the compiler [1/N]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,8 @@ dependencies = [
  "isograph_schema",
  "lazy_static",
  "pathdiff",
+ "pico",
+ "pico_macros",
  "thiserror",
 ]
 
@@ -1005,6 +1007,8 @@ dependencies = [
  "notify",
  "notify-debouncer-full",
  "pathdiff",
+ "pico",
+ "pico_macros",
  "pretty-duration",
  "regex",
  "thiserror",
@@ -1030,6 +1034,7 @@ name = "isograph_fixture_tests"
 version = "0.3.1"
 dependencies = [
  "clap 4.5.31",
+ "common_lang_types",
  "intern",
  "isograph_compiler",
  "isograph_config",
@@ -1056,6 +1061,8 @@ dependencies = [
  "common_lang_types",
  "graphql_lang_types",
  "intern",
+ "pico",
+ "pico_macros",
  "serde",
  "thiserror",
  "u32_newtypes",
@@ -1092,6 +1099,8 @@ dependencies = [
  "isograph_config",
  "isograph_lang_types",
  "lazy_static",
+ "pico",
+ "pico_macros",
  "serde",
  "thiserror",
 ]

--- a/crates/common_lang_types/src/absolute_and_relative_path.rs
+++ b/crates/common_lang_types/src/absolute_and_relative_path.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+use crate::RelativePathToSourceFile;
+
+#[derive(Debug, Clone)]
+pub struct AbsolutePathAndRelativePath {
+    pub absolute_path: PathBuf,
+    pub relative_path: RelativePathToSourceFile,
+}

--- a/crates/common_lang_types/src/lib.rs
+++ b/crates/common_lang_types/src/lib.rs
@@ -1,3 +1,4 @@
+mod absolute_and_relative_path;
 mod location;
 mod path_and_content;
 mod selectable_name;
@@ -7,6 +8,7 @@ mod string_types;
 mod text_with_carats;
 mod type_and_field;
 
+pub use absolute_and_relative_path::*;
 pub use location::*;
 pub use path_and_content::*;
 pub use selectable_name::*;

--- a/crates/graphql_lang_types/src/graphql_sdl.rs
+++ b/crates/graphql_lang_types/src/graphql_sdl.rs
@@ -12,7 +12,7 @@ use intern::{string_key::Intern, Lookup};
 use strum::EnumString;
 
 // also Schema
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub enum GraphQLTypeSystemDefinition {
     ObjectTypeDefinition(GraphQLObjectTypeDefinition),
     ScalarTypeDefinition(GraphQLScalarTypeDefinition),
@@ -72,7 +72,7 @@ impl From<GraphQLSchemaDefinition> for GraphQLTypeSystemDefinition {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Hash)]
 pub struct GraphQLTypeSystemDocument(pub Vec<WithLocation<GraphQLTypeSystemDefinition>>);
 
 impl Deref for GraphQLTypeSystemDocument {
@@ -83,18 +83,18 @@ impl Deref for GraphQLTypeSystemDocument {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLTypeSystemExtensionDocument(
     pub Vec<WithLocation<GraphQLTypeSystemExtensionOrDefinition>>,
 );
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub enum GraphQLTypeSystemExtensionOrDefinition {
     Definition(GraphQLTypeSystemDefinition),
     Extension(GraphQLTypeSystemExtension),
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub enum GraphQLTypeSystemExtension {
     ObjectTypeExtension(GraphQLObjectTypeExtension),
     // ScalarTypeExtension
@@ -111,7 +111,7 @@ impl From<GraphQLObjectTypeExtension> for GraphQLTypeSystemExtension {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLObjectTypeDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub name: WithLocation<GraphQLObjectTypeName>,
@@ -120,7 +120,7 @@ pub struct GraphQLObjectTypeDefinition {
     pub fields: Vec<WithLocation<GraphQLFieldDefinition>>,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLObjectTypeExtension {
     pub name: WithLocation<GraphQLObjectTypeName>,
     pub interfaces: Vec<WithLocation<GraphQLInterfaceTypeName>>,
@@ -128,14 +128,14 @@ pub struct GraphQLObjectTypeExtension {
     pub fields: Vec<WithLocation<GraphQLFieldDefinition>>,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLScalarTypeDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub name: WithLocation<GraphQLScalarTypeName>,
     pub directives: Vec<GraphQLDirective<GraphQLConstantValue>>,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLInterfaceTypeDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub name: WithLocation<GraphQLInterfaceTypeName>,
@@ -144,7 +144,7 @@ pub struct GraphQLInterfaceTypeDefinition {
     pub fields: Vec<WithLocation<GraphQLFieldDefinition>>,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLInputObjectTypeDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub name: WithLocation<GraphQLInterfaceTypeName>,
@@ -152,7 +152,7 @@ pub struct GraphQLInputObjectTypeDefinition {
     pub fields: Vec<WithLocation<GraphQLInputValueDefinition>>,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLSchemaDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub query: Option<WithLocation<GraphQLObjectTypeName>>,
@@ -162,7 +162,7 @@ pub struct GraphQLSchemaDefinition {
 }
 
 #[allow(unused)]
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, EnumString)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, EnumString, Hash)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum DirectiveLocation {
     Query,
@@ -186,7 +186,7 @@ pub enum DirectiveLocation {
     InputFieldDefinition,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLDirectiveDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub name: WithLocation<DirectiveName>,
@@ -195,7 +195,7 @@ pub struct GraphQLDirectiveDefinition {
     pub locations: Vec<WithSpan<DirectiveLocation>>,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLEnumDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub name: WithLocation<DirectiveName>,
@@ -203,14 +203,14 @@ pub struct GraphQLEnumDefinition {
     pub enum_value_definitions: Vec<WithLocation<GraphQLEnumValueDefinition>>,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLEnumValueDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub value: WithLocation<EnumLiteralValue>,
     pub directives: Vec<GraphQLDirective<GraphQLConstantValue>>,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLUnionTypeDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub name: WithLocation<GraphQLUnionTypeName>,
@@ -233,7 +233,7 @@ impl From<GraphQLInputValueDefinition> for GraphQLFieldDefinition {
 }
 
 /// A server field definition on an object or interface
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct GraphQLFieldDefinition {
     pub description: Option<WithSpan<DescriptionValue>>,
     pub name: WithLocation<ServerSelectableName>,

--- a/crates/graphql_output_format/Cargo.toml
+++ b/crates/graphql_output_format/Cargo.toml
@@ -12,6 +12,8 @@ intern = { path = "../../relay-crates/intern" }
 isograph_config = { path = "../isograph_config" }
 isograph_lang_types = { path = "../isograph_lang_types" }
 isograph_schema = { path = "../isograph_schema" }
+pico = { path = "../pico" }
+pico_macros = { path = "../pico_macros" }
 lazy_static = { workspace = true }
 pathdiff = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/graphql_output_format/src/lib.rs
+++ b/crates/graphql_output_format/src/lib.rs
@@ -7,6 +7,7 @@ pub use graphql_output_format::*;
 use isograph_schema::{
     Schema, SchemaObject, UnvalidatedSchema, ValidatedClientField, ValidatedSchema,
 };
+pub use read_schema::*;
 
 pub type ValidatedGraphqlSchema = ValidatedSchema<GraphQLOutputFormat>;
 pub type GraphqlSchema<TSchemaValidationState> =

--- a/crates/graphql_schema_parser/src/peekable_lexer.rs
+++ b/crates/graphql_schema_parser/src/peekable_lexer.rs
@@ -147,7 +147,7 @@ impl<'source> PeekableLexer<'source> {
 
 /// Low-level errors. If peekable_lexer could be made generic (it can't because it needs to know
 /// about EOF), these would belong in a different crate than the parser itself.
-#[derive(Error, Eq, PartialEq, Debug)]
+#[derive(Error, Clone, Eq, PartialEq, Debug)]
 pub enum LowLevelParseError {
     #[error("Expected {expected_kind}, found {found_kind}")]
     ParseTokenKindError {

--- a/crates/graphql_schema_parser/src/schema_parse_error.rs
+++ b/crates/graphql_schema_parser/src/schema_parse_error.rs
@@ -6,7 +6,7 @@ use super::peekable_lexer::LowLevelParseError;
 pub(crate) type ParseResult<T> = Result<T, WithSpan<SchemaParseError>>;
 
 /// Errors tha make semantic sense when referring to parsing a GraphQL schema file
-#[derive(Error, Eq, PartialEq, Debug)]
+#[derive(Error, Clone, Eq, PartialEq, Debug)]
 pub enum SchemaParseError {
     #[error("{error}")]
     ParseError { error: LowLevelParseError },

--- a/crates/isograph_compiler/Cargo.toml
+++ b/crates/isograph_compiler/Cargo.toml
@@ -14,6 +14,8 @@ isograph_lang_types = { path = "../isograph_lang_types" }
 common_lang_types = { path = "../common_lang_types" }
 thiserror = "1.0.40"
 intern = { path = "../../relay-crates/intern" }
+pico = { path = "../pico" }
+pico_macros = { path = "../pico_macros" }
 lazy_static = { workspace = true }
 regex = { workspace = true }
 colored = { workspace = true }

--- a/crates/isograph_compiler/src/compiler_state.rs
+++ b/crates/isograph_compiler/src/compiler_state.rs
@@ -1,153 +1,91 @@
-use std::{error::Error, path::PathBuf};
+use std::{
+    error::Error,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 use common_lang_types::CurrentWorkingDirectory;
 use generate_artifacts::get_artifact_path_and_content;
 use isograph_config::{create_config, CompilerConfig};
-use isograph_schema::{OutputFormat, Schema, UnvalidatedSchema};
+use isograph_schema::{OutputFormat, Schema};
+use pico::Database;
 
 use crate::{
     batch_compile::{BatchCompileError, CompilationStats},
+    create_unvalidated_schema::create_unvalidated_schema,
     source_files::SourceFiles,
-    watch::SourceFileEvent,
     write_artifacts::write_artifacts_to_disk,
 };
 
-pub struct CompilerState<TOutputFormat: OutputFormat> {
+const GC_DURATION: u64 = 60;
+
+pub struct CompilerState {
+    pub db: Database,
     pub config: CompilerConfig,
-    pub source_files: Option<SourceFiles<TOutputFormat>>,
+    pub source_files: Option<SourceFiles>,
+    pub last_gc_run: Instant,
 }
 
-impl<TOutputFormat: OutputFormat> CompilerState<TOutputFormat> {
+impl CompilerState {
     pub fn new(
         config_location: PathBuf,
         current_working_directory: CurrentWorkingDirectory,
     ) -> Self {
         Self {
+            db: Database::new(),
             config: create_config(config_location, current_working_directory),
             source_files: None,
+            last_gc_run: Instant::now(),
         }
     }
 
-    /// This the "workhorse" command of batch compilation.
-    ///
-    /// ## Overall plan
-    ///
-    /// When the compiler runs in batch mode, we must do the following things. This
-    /// description is a bit simplified.
-    ///
-    /// - Read and parse things:
-    ///   - Read and parse the GraphQL schema
-    ///   - Read and parse the Isograph literals
-    /// - Combine everything into an UnvalidatedSchema.
-    /// - Turn the UnvalidatedSchema into a ValidatedSchema
-    ///   - Note: at this point, we do most of the validations, like ensuring that
-    ///     all selected fields exist and are of the correct types, parameters are
-    ///     passed when needed, etc.
-    /// - Generate an in-memory representation of all of the generated files
-    ///   (called artifacts). This step should not fail. It should panic if any
-    ///   invariant is violated, or represent that invariant in the type system.
-    /// - Delete and recreate the artifacts on disk.
-    ///
-    /// ## Additional things we do
-    ///
-    /// In addition to the things we do above, we also do some specific things like:
-    ///
-    /// - if a client field is defined on an interface, add it to each concrete
-    ///   type. So, if User implements Actor, you can define Actor.NameDisplay, and
-    ///   select User.NameDisplay
-    /// - create fields from exposeAs directives
-    ///
-    /// These are less "core" to the overall mission, and thus invite the question
-    /// of whether they belong in this function, or at all.
-    ///
-    /// ## Sequentially written vs Salsa architecture
-    ///
-    /// Isograph is currently written in a fairly sequential fashion, e.g.:
-    ///
-    /// let result_1 = step_1()?;
-    /// let result_2 = step_2()?;
-    /// step_3(result_1, result_2)?;
-    ///
-    /// Where each step is completed before the next one starts. This has advantages:
-    /// namely, it is easy to read. But, we most likely want to report all the errors
-    /// we can (i.e. from both step_1 and step_2), rather than just the first error
-    /// encountered (i.e. just step_1).
-    ///
-    /// In the long term, we want to describe everything as a tree, e.g.
-    /// `step_3 -> [step_1, step_2]`, and this will "naturally" parallelize everything.
-    /// This is also necessary to adopt a Rust Analyzer-like (Salsa) architecture, which is
-    /// important for language server performance. In a Salsa architecture, we invalidate
-    /// leaves (e.g. a given file changed), and invalidate everything that depends on that
-    /// leaf. Then, when we need a result (e.g. the errors to show on a given file), we
-    /// re-evaluate (or re-use the cached value) of everything from that result on down.
-    pub fn batch_compile(self) -> Result<CompilationStats, Box<dyn Error>> {
-        let source_files = SourceFiles::read_and_parse_all_files(&self.config)?;
-        let stats = source_files.contains_iso.stats();
-        let total_artifacts_written = validate_and_create_artifacts_from_source_files::<
-            TOutputFormat,
-        >(source_files, &self.config)?;
-        Ok(CompilationStats {
-            client_field_count: stats.client_field_count,
-            entrypoint_count: stats.entrypoint_count,
-            total_artifacts_written,
-        })
-    }
-
-    pub fn compile(&mut self) -> Result<CompilationStats, Box<dyn Error>> {
-        let source_files = SourceFiles::read_and_parse_all_files(&self.config)?;
-        let stats = source_files.contains_iso.stats();
-        self.source_files = Some(source_files.clone());
-        let total_artifacts_written = validate_and_create_artifacts_from_source_files::<
-            TOutputFormat,
-        >(source_files, &self.config)?;
-        Ok(CompilationStats {
-            client_field_count: stats.client_field_count,
-            entrypoint_count: stats.entrypoint_count,
-            total_artifacts_written,
-        })
-    }
-
-    pub fn update(
-        &mut self,
-        changes: &[SourceFileEvent],
-    ) -> Result<CompilationStats, Box<dyn Error>> {
-        let source_files = self.update_and_clone_source_files(changes)?;
-        let stats = source_files.contains_iso.stats();
-        let total_artifacts_written = validate_and_create_artifacts_from_source_files::<
-            TOutputFormat,
-        >(source_files, &self.config)?;
-        Ok(CompilationStats {
-            client_field_count: stats.client_field_count,
-            entrypoint_count: stats.entrypoint_count,
-            total_artifacts_written,
-        })
-    }
-
-    fn update_and_clone_source_files(
-        &mut self,
-        changes: &[SourceFileEvent],
-    ) -> Result<SourceFiles<TOutputFormat>, Box<dyn Error>> {
-        match &mut self.source_files {
-            Some(source_files) => {
-                source_files.update(&self.config, changes)?;
-                Ok(source_files.clone())
-            }
-            None => {
-                let source_files = SourceFiles::read_and_parse_all_files(&self.config)?;
-                self.source_files = Some(source_files.clone());
-                Ok(source_files)
-            }
+    pub fn run_garbage_collection(&mut self) {
+        if self.last_gc_run.elapsed() >= Duration::from_secs(GC_DURATION) {
+            self.db.run_garbage_collection();
+            self.last_gc_run = Instant::now();
         }
     }
 }
 
-pub fn validate_and_create_artifacts_from_source_files<TOutputFormat: OutputFormat>(
-    source_files: SourceFiles<TOutputFormat>,
+/// This the "workhorse" command of batch compilation.
+///
+/// ## Overall plan
+///
+/// When the compiler runs in batch mode, we must do the following things. This
+/// description is a bit simplified.
+///
+/// - Read and parse things:
+///   - Read and parse the GraphQL schema
+///   - Read and parse the Isograph literals
+/// - Combine everything into an UnvalidatedSchema.
+/// - Turn the UnvalidatedSchema into a ValidatedSchema
+///   - Note: at this point, we do most of the validations, like ensuring that
+///     all selected fields exist and are of the correct types, parameters are
+///     passed when needed, etc.
+/// - Generate an in-memory representation of all of the generated files
+///   (called artifacts). This step should not fail. It should panic if any
+///   invariant is violated, or represent that invariant in the type system.
+/// - Delete and recreate the artifacts on disk.
+///
+/// ## Additional things we do
+///
+/// In addition to the things we do above, we also do some specific things like:
+///
+/// - if a client field is defined on an interface, add it to each concrete
+///   type. So, if User implements Actor, you can define Actor.NameDisplay, and
+///   select User.NameDisplay
+/// - create fields from exposeAs directives
+///
+/// These are less "core" to the overall mission, and thus invite the question
+/// of whether they belong in this function, or at all.
+pub fn compile<TOutputFormat: OutputFormat>(
+    db: &Database,
+    source_files: &SourceFiles,
     config: &CompilerConfig,
-) -> Result<usize, Box<dyn Error>> {
+) -> Result<CompilationStats, Box<dyn Error>> {
     // Create schema
-    let mut unvalidated_schema = UnvalidatedSchema::<TOutputFormat>::new();
-    source_files.create_unvalidated_schema(&mut unvalidated_schema, config)?;
+    let (unvalidated_schema, stats) =
+        create_unvalidated_schema::<TOutputFormat>(db, source_files, config)?;
 
     // Validate
     let validated_schema = Schema::validate_and_construct(unvalidated_schema)
@@ -161,5 +99,9 @@ pub fn validate_and_create_artifacts_from_source_files<TOutputFormat: OutputForm
 
     let total_artifacts_written =
         write_artifacts_to_disk(artifacts, &config.artifact_directory.absolute_path)?;
-    Ok(total_artifacts_written)
+    Ok(CompilationStats {
+        client_field_count: stats.client_field_count,
+        entrypoint_count: stats.entrypoint_count,
+        total_artifacts_written,
+    })
 }

--- a/crates/isograph_compiler/src/create_unvalidated_schema.rs
+++ b/crates/isograph_compiler/src/create_unvalidated_schema.rs
@@ -1,0 +1,167 @@
+use std::{
+    collections::HashMap,
+    error::Error,
+    ops::{Deref, DerefMut},
+};
+
+use common_lang_types::{CurrentWorkingDirectory, RelativePathToSourceFile, TextSource};
+use isograph_config::CompilerConfig;
+use isograph_lang_parser::IsoLiteralExtractionResult;
+use isograph_lang_types::{IsoLiteralsSource, SchemaSource};
+use isograph_schema::{OutputFormat, UnvalidatedSchema};
+use pico::{Database, SourceId};
+
+use crate::{
+    batch_compile::BatchCompileError,
+    isograph_literals::{parse_iso_literal_in_source, process_iso_literals},
+    refetch_fields::add_refetch_fields_to_objects,
+    source_files::SourceFiles,
+};
+
+pub fn create_unvalidated_schema<TOutputFormat: OutputFormat>(
+    db: &Database,
+    source_files: &SourceFiles,
+    config: &CompilerConfig,
+) -> Result<(UnvalidatedSchema<TOutputFormat>, ContainsIsoStats), Box<dyn Error>> {
+    let mut unvalidated_isograph_schema = UnvalidatedSchema::<TOutputFormat>::new();
+    let schema = TOutputFormat::parse_type_system_document(db, source_files.schema)?.to_owned();
+    let outcome = TOutputFormat::process_type_system_document(
+        &mut unvalidated_isograph_schema,
+        schema,
+        &config.options,
+    )?;
+    let schema_extensions =
+        parse_schema_extensions::<TOutputFormat>(db, &source_files.schema_extensions)?;
+    for extension_document in schema_extensions.into_values() {
+        TOutputFormat::process_type_system_extension_document(
+            &mut unvalidated_isograph_schema,
+            extension_document,
+            &config.options,
+        )?;
+    }
+    let contains_iso = parse_iso_literals(
+        db,
+        &source_files.iso_literals,
+        config.current_working_directory,
+    )?;
+    let contains_iso_stats = contains_iso.stats();
+    process_iso_literals(&mut unvalidated_isograph_schema, contains_iso)?;
+    process_exposed_fields(&mut unvalidated_isograph_schema)?;
+    unvalidated_isograph_schema
+        .add_fields_to_subtypes(&outcome.type_refinement_maps.supertype_to_subtype_map)?;
+    unvalidated_isograph_schema.add_link_fields()?;
+    unvalidated_isograph_schema
+        .add_pointers_to_supertypes(&outcome.type_refinement_maps.subtype_to_supertype_map)?;
+    add_refetch_fields_to_objects(&mut unvalidated_isograph_schema)?;
+    Ok((unvalidated_isograph_schema, contains_iso_stats))
+}
+
+fn parse_schema_extensions<TOutputFormat: OutputFormat>(
+    db: &Database,
+    schema_extensions_sources: &HashMap<RelativePathToSourceFile, SourceId<SchemaSource>>,
+) -> Result<
+    HashMap<RelativePathToSourceFile, TOutputFormat::TypeSystemExtensionDocument>,
+    Box<dyn Error>,
+> {
+    let mut schema_extensions = HashMap::new();
+    for (relative_path, schema_extension_source_id) in schema_extensions_sources.iter() {
+        let extensions_document =
+            TOutputFormat::parse_type_system_extension_document(db, *schema_extension_source_id)?
+                .to_owned();
+        schema_extensions.insert(*relative_path, extensions_document);
+    }
+    Ok(schema_extensions)
+}
+
+fn parse_iso_literals(
+    db: &Database,
+    iso_literals_sources: &HashMap<RelativePathToSourceFile, SourceId<IsoLiteralsSource>>,
+    current_working_directory: CurrentWorkingDirectory,
+) -> Result<ContainsIso, BatchCompileError> {
+    let mut contains_iso = ContainsIso::default();
+    let mut iso_literal_parse_errors = vec![];
+    for (relative_path, iso_literals_source_id) in iso_literals_sources.iter() {
+        match parse_iso_literal_in_source(db, *iso_literals_source_id, current_working_directory)
+            .to_owned()
+        {
+            Ok(iso_literals) => {
+                if !iso_literals.is_empty() {
+                    contains_iso.insert(*relative_path, iso_literals);
+                }
+            }
+            Err(e) => {
+                iso_literal_parse_errors.extend(e);
+            }
+        };
+    }
+    if iso_literal_parse_errors.is_empty() {
+        Ok(contains_iso)
+    } else {
+        Err(iso_literal_parse_errors.into())
+    }
+}
+
+/// Here, we are processing exposeAs fields. Note that we only process these
+/// directives on root objects (Query, Mutation, Subscription) and we should
+/// validate that no other types have exposeAs directives.
+fn process_exposed_fields<TOutputFormat: OutputFormat>(
+    schema: &mut UnvalidatedSchema<TOutputFormat>,
+) -> Result<(), BatchCompileError> {
+    let fetchable_types: Vec<_> = schema.fetchable_types.keys().copied().collect();
+    for fetchable_object_id in fetchable_types.into_iter() {
+        schema.add_exposed_fields_to_parent_object_types(fetchable_object_id)?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub struct ContainsIso {
+    pub files: HashMap<RelativePathToSourceFile, Vec<(IsoLiteralExtractionResult, TextSource)>>,
+}
+
+impl ContainsIso {
+    pub fn stats(&self) -> ContainsIsoStats {
+        let mut client_field_count: usize = 0;
+        let mut client_pointer_count: usize = 0;
+        let mut entrypoint_count: usize = 0;
+        for iso_literals in self.values() {
+            for (iso_literal, ..) in iso_literals {
+                match iso_literal {
+                    IsoLiteralExtractionResult::ClientFieldDeclaration(_) => {
+                        client_field_count += 1
+                    }
+                    IsoLiteralExtractionResult::EntrypointDeclaration(_) => entrypoint_count += 1,
+                    IsoLiteralExtractionResult::ClientPointerDeclaration(_) => {
+                        client_pointer_count += 1
+                    }
+                }
+            }
+        }
+        ContainsIsoStats {
+            client_field_count,
+            entrypoint_count,
+            client_pointer_count,
+        }
+    }
+}
+
+impl Deref for ContainsIso {
+    type Target = HashMap<RelativePathToSourceFile, Vec<(IsoLiteralExtractionResult, TextSource)>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.files
+    }
+}
+
+impl DerefMut for ContainsIso {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.files
+    }
+}
+
+pub struct ContainsIsoStats {
+    pub client_field_count: usize,
+    pub entrypoint_count: usize,
+    #[allow(unused)]
+    pub client_pointer_count: usize,
+}

--- a/crates/isograph_compiler/src/isograph_literals.rs
+++ b/crates/isograph_compiler/src/isograph_literals.rs
@@ -1,13 +1,15 @@
 use common_lang_types::{
-    relative_path_from_absolute_and_working_directory, Location, RelativePathToSourceFile, Span,
-    TextSource, WithLocation,
+    relative_path_from_absolute_and_working_directory, CurrentWorkingDirectory, Location,
+    RelativePathToSourceFile, Span, TextSource, WithLocation,
 };
-use isograph_config::CompilerConfig;
 use isograph_lang_parser::{
     parse_iso_literal, IsoLiteralExtractionResult, IsographLiteralParseError,
 };
+use isograph_lang_types::IsoLiteralsSource;
 use isograph_schema::{OutputFormat, UnvalidatedSchema};
 use lazy_static::lazy_static;
+use pico::{Database, SourceId};
+use pico_macros::memo;
 use regex::Regex;
 use std::{
     fs::{self, DirEntry},
@@ -17,21 +19,14 @@ use std::{
 
 use crate::{
     batch_compile::BatchCompileError,
+    create_unvalidated_schema::ContainsIso,
     field_directives::{validate_isograph_field_directives, validate_isograph_pointer_directives},
-    source_files::ContainsIso,
 };
 
-pub(crate) fn read_files_in_folder(
+pub fn read_files_in_folder(
     folder: &Path,
-    canonicalized_root_path: &Path,
-) -> Result<Vec<(PathBuf, String)>, BatchCompileError> {
-    if !canonicalized_root_path.is_dir() {
-        return Err(BatchCompileError::ProjectRootNotADirectory {
-            // TODO avoid cloning
-            path: canonicalized_root_path.to_path_buf(),
-        });
-    }
-
+    current_working_directory: CurrentWorkingDirectory,
+) -> Result<Vec<(RelativePathToSourceFile, String)>, BatchCompileError> {
     read_dir_recursive(folder)?
         .into_iter()
         .filter(|p| {
@@ -47,14 +42,14 @@ pub(crate) fn read_files_in_folder(
                 .expect("Expected path to be stringable")
                 .contains("__isograph")
         })
-        .map(|path| read_file(path, canonicalized_root_path))
+        .map(|path| read_file(path, current_working_directory))
         .collect()
 }
 
 pub fn read_file(
     path: PathBuf,
-    canonicalized_root_path: &Path,
-) -> Result<(PathBuf, String), BatchCompileError> {
+    current_working_directory: CurrentWorkingDirectory,
+) -> Result<(RelativePathToSourceFile, String), BatchCompileError> {
     // This isn't ideal. We can avoid a clone if we changed .map_err to match
     let path_2 = path.clone();
 
@@ -64,17 +59,14 @@ pub fn read_file(
         message: e.to_string(),
     })?;
 
+    let relative_path =
+        relative_path_from_absolute_and_working_directory(current_working_directory, &path);
+
     let contents = std::str::from_utf8(&contents)
-        .map_err(|e| BatchCompileError::UnableToConvertToString {
-            path: path.clone(),
-            reason: e,
-        })?
+        .map_err(|e| BatchCompileError::UnableToConvertToString { path, reason: e })?
         .to_owned();
 
-    Ok((
-        path.strip_prefix(canonicalized_root_path)?.to_path_buf(),
-        contents,
-    ))
+    Ok((relative_path, contents))
 }
 
 fn read_dir_recursive(root_js_path: &Path) -> Result<Vec<PathBuf>, BatchCompileError> {
@@ -110,23 +102,13 @@ fn visit_dirs_skipping_isograph(dir: &Path, cb: &mut dyn FnMut(&DirEntry)) -> io
 // both valid and invalid iso literals.
 #[allow(clippy::type_complexity)]
 pub fn parse_iso_literals_in_file_content(
-    file_path: PathBuf,
+    relative_path_to_source_file: RelativePathToSourceFile,
     file_content: String,
-    canonicalized_root_path: &Path,
-    config: &CompilerConfig,
+    current_working_directory: CurrentWorkingDirectory,
 ) -> Result<
-    (
-        RelativePathToSourceFile,
-        Vec<(IsoLiteralExtractionResult, TextSource)>,
-    ),
+    Vec<(IsoLiteralExtractionResult, TextSource)>,
     Vec<WithLocation<IsographLiteralParseError>>,
 > {
-    let absolute_path = canonicalized_root_path.join(&file_path);
-    let relative_path_to_source_file = relative_path_from_absolute_and_working_directory(
-        config.current_working_directory,
-        &absolute_path,
-    );
-
     let mut extraction_results = vec![];
     let mut isograph_literal_parse_errors = vec![];
 
@@ -134,8 +116,7 @@ pub fn parse_iso_literals_in_file_content(
         match process_iso_literal_extraction(
             iso_literal_extraction,
             relative_path_to_source_file,
-            relative_path_to_source_file,
-            config,
+            current_working_directory,
         ) {
             Ok(result) => extraction_results.push(result),
             Err(e) => isograph_literal_parse_errors.push(e),
@@ -143,10 +124,27 @@ pub fn parse_iso_literals_in_file_content(
     }
 
     if isograph_literal_parse_errors.is_empty() {
-        Ok((relative_path_to_source_file, extraction_results))
+        Ok(extraction_results)
     } else {
         Err(isograph_literal_parse_errors)
     }
+}
+
+#[allow(clippy::type_complexity)]
+#[memo]
+pub fn parse_iso_literal_in_source(
+    db: &Database,
+    iso_literals_source_id: SourceId<IsoLiteralsSource>,
+    current_working_directory: CurrentWorkingDirectory,
+) -> Result<
+    Vec<(IsoLiteralExtractionResult, TextSource)>,
+    Vec<WithLocation<IsographLiteralParseError>>,
+> {
+    let IsoLiteralsSource {
+        relative_path,
+        content,
+    } = db.get(iso_literals_source_id).clone();
+    parse_iso_literals_in_file_content(relative_path, content, current_working_directory)
 }
 
 pub(crate) fn process_iso_literals<TOutputFormat: OutputFormat>(
@@ -201,9 +199,8 @@ pub(crate) fn process_iso_literals<TOutputFormat: OutputFormat>(
 
 pub fn process_iso_literal_extraction(
     iso_literal_extraction: IsoLiteralExtraction<'_>,
-    file_name: RelativePathToSourceFile,
-    interned_file_path: RelativePathToSourceFile,
-    config: &CompilerConfig,
+    relative_path_to_source_file: RelativePathToSourceFile,
+    current_working_directory: CurrentWorkingDirectory,
 ) -> Result<(IsoLiteralExtractionResult, TextSource), WithLocation<IsographLiteralParseError>> {
     let IsoLiteralExtraction {
         iso_literal_text,
@@ -213,12 +210,12 @@ pub fn process_iso_literal_extraction(
         iso_function_called_with_paren: has_paren,
     } = iso_literal_extraction;
     let text_source = TextSource {
-        relative_path_to_source_file: file_name,
+        relative_path_to_source_file,
         span: Some(Span::new(
             iso_literal_start_index as u32,
             (iso_literal_start_index + iso_literal_text.len()) as u32,
         )),
-        current_working_directory: config.current_working_directory,
+        current_working_directory,
     };
 
     if !has_paren {
@@ -231,7 +228,7 @@ pub fn process_iso_literal_extraction(
     // TODO return errors if any occurred, otherwise Ok
     let iso_literal_extraction_result = parse_iso_literal(
         iso_literal_text,
-        interned_file_path,
+        relative_path_to_source_file,
         const_export_name,
         text_source,
     )?;

--- a/crates/isograph_compiler/src/lib.rs
+++ b/crates/isograph_compiler/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod batch_compile;
 mod compiler_state;
+mod create_unvalidated_schema;
 mod field_directives;
 mod isograph_literals;
 mod refetch_fields;

--- a/crates/isograph_config/src/compilation_options.rs
+++ b/crates/isograph_config/src/compilation_options.rs
@@ -1,6 +1,6 @@
 use common_lang_types::{
-    relative_path_from_absolute_and_working_directory, CurrentWorkingDirectory,
-    GeneratedFileHeader, RelativePathToSourceFile,
+    relative_path_from_absolute_and_working_directory, AbsolutePathAndRelativePath,
+    CurrentWorkingDirectory, GeneratedFileHeader,
 };
 use intern::string_key::Intern;
 use schemars::JsonSchema;
@@ -11,12 +11,6 @@ use tracing::warn;
 pub static ISOGRAPH_FOLDER: &str = "__isograph";
 
 use std::error::Error;
-
-#[derive(Debug, Clone)]
-pub struct AbsolutePathAndRelativePath {
-    pub absolute_path: PathBuf,
-    pub relative_path: RelativePathToSourceFile,
-}
 
 /// This struct is the internal representation of the schema. It
 /// is a transformed version of IsographProjectConfig.

--- a/crates/isograph_fixture_tests/Cargo.toml
+++ b/crates/isograph_fixture_tests/Cargo.toml
@@ -15,3 +15,4 @@ lazy_static = { workspace = true }
 intern = { path = "../../relay-crates/intern" }
 isograph_compiler = { path = "../isograph_compiler" }
 isograph_config = { path = "../isograph_config" }
+common_lang_types = { path = "../common_lang_types" }

--- a/crates/isograph_fixture_tests/src/main.rs
+++ b/crates/isograph_fixture_tests/src/main.rs
@@ -3,8 +3,9 @@ mod config_for_test;
 use std::{ffi::OsStr, fs, path::PathBuf};
 
 use clap::Parser;
+use common_lang_types::relative_path_from_absolute_and_working_directory;
 use config_for_test::isograph_config_for_tests;
-use intern::string_key::Lookup;
+use intern::Lookup;
 use isograph_compiler::parse_iso_literals_in_file_content;
 use isograph_config::CompilerConfig;
 use lazy_static::lazy_static;
@@ -112,11 +113,16 @@ fn generate_content_for_output_file(
     content: String,
     config: &CompilerConfig,
 ) -> String {
+    let canonicalized_root_path = &PathBuf::from(config.current_working_directory.lookup());
+    let absolute_path = canonicalized_root_path.join(&input_file);
+    let relative_path_to_source_file = relative_path_from_absolute_and_working_directory(
+        config.current_working_directory,
+        &absolute_path,
+    );
     match parse_iso_literals_in_file_content(
-        input_file,
+        relative_path_to_source_file,
         content,
-        &PathBuf::from(config.current_working_directory.lookup()),
-        config,
+        config.current_working_directory,
     ) {
         Ok(item) => {
             let item: Result<_, ()> = Ok(item);

--- a/crates/isograph_lang_parser/fixtures/commented-out.output
+++ b/crates/isograph_lang_parser/fixtures/commented-out.output
@@ -1,8 +1,3 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/commented-out.input.js",
-        ),
-        [],
-    ),
+    [],
 )

--- a/crates/isograph_lang_parser/fixtures/entrypoint-basic.output
+++ b/crates/isograph_lang_parser/fixtures/entrypoint-basic.output
@@ -1,68 +1,63 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/entrypoint-basic.input.js",
-        ),
-        [
-            (
-                EntrypointDeclaration(
-                    WithSpan {
-                        item: EntrypointDeclaration {
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 11,
-                                    end: 15,
-                                },
-                            },
-                            client_field_name: WithSpan {
-                                item: ServerScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 16,
-                                    end: 20,
-                                },
-                            },
-                            entrypoint_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 0,
-                                    end: 10,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 15,
-                                    end: 16,
-                                },
-                            },
-                            iso_literal_text: IsoLiteralText(
-                                "entrypoint Type.Name",
+    [
+        (
+            EntrypointDeclaration(
+                WithSpan {
+                    item: EntrypointDeclaration {
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
+                            span: Span {
+                                start: 11,
+                                end: 15,
+                            },
                         },
-                        span: Span {
-                            start: 11,
-                            end: 20,
+                        client_field_name: WithSpan {
+                            item: ServerScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 16,
+                                end: 20,
+                            },
                         },
+                        entrypoint_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 0,
+                                end: 10,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 15,
+                                end: 16,
+                            },
+                        },
+                        iso_literal_text: IsoLiteralText(
+                            "entrypoint Type.Name",
+                        ),
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/entrypoint-basic.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 5,
-                            end: 25,
-                        },
-                    ),
+                    span: Span {
+                        start: 11,
+                        end: 20,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/entrypoint-basic.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 5,
+                        end: 25,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-args-boolean.output
+++ b/crates/isograph_lang_parser/fixtures/field-args-boolean.output
@@ -1,40 +1,66 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-args-boolean.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "ValidArgs",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "ValidArgs",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-args-boolean.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 30,
+                                                                end: 76,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 29,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "args",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [
+                                            WithLocation {
                                                 location: Embedded(
                                                     EmbeddedLocation {
                                                         text_source: TextSource {
@@ -50,126 +76,95 @@ Ok(
                                                             ),
                                                         },
                                                         span: Span {
-                                                            start: 25,
-                                                            end: 29,
+                                                            start: 30,
+                                                            end: 40,
                                                         },
                                                     },
                                                 ),
-                                                item: ScalarSelectableName(
-                                                    "args",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [
-                                                WithLocation {
-                                                    location: Embedded(
-                                                        EmbeddedLocation {
-                                                            text_source: TextSource {
-                                                                current_working_directory: CurrentWorkingDirectory,
-                                                                relative_path_to_source_file: RelativePathToSourceFile(
-                                                                    "crates/isograph_lang_parser/fixtures/field-args-boolean.input.js",
-                                                                ),
-                                                                span: Some(
-                                                                    Span {
-                                                                        start: 30,
-                                                                        end: 76,
-                                                                    },
-                                                                ),
-                                                            },
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 40,
-                                                            },
+                                                item: SelectionFieldArgument {
+                                                    name: WithSpan {
+                                                        item: FieldArgumentName(
+                                                            "arg1",
+                                                        ),
+                                                        span: Span {
+                                                            start: 30,
+                                                            end: 34,
                                                         },
-                                                    ),
-                                                    item: SelectionFieldArgument {
-                                                        name: WithSpan {
-                                                            item: FieldArgumentName(
-                                                                "arg1",
-                                                            ),
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 34,
-                                                            },
-                                                        },
-                                                        value: WithLocation {
-                                                            location: Embedded(
-                                                                EmbeddedLocation {
-                                                                    text_source: TextSource {
-                                                                        current_working_directory: CurrentWorkingDirectory,
-                                                                        relative_path_to_source_file: RelativePathToSourceFile(
-                                                                            "crates/isograph_lang_parser/fixtures/field-args-boolean.input.js",
-                                                                        ),
-                                                                        span: Some(
-                                                                            Span {
-                                                                                start: 30,
-                                                                                end: 76,
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                    span: Span {
-                                                                        start: 36,
-                                                                        end: 40,
-                                                                    },
+                                                    },
+                                                    value: WithLocation {
+                                                        location: Embedded(
+                                                            EmbeddedLocation {
+                                                                text_source: TextSource {
+                                                                    current_working_directory: CurrentWorkingDirectory,
+                                                                    relative_path_to_source_file: RelativePathToSourceFile(
+                                                                        "crates/isograph_lang_parser/fixtures/field-args-boolean.input.js",
+                                                                    ),
+                                                                    span: Some(
+                                                                        Span {
+                                                                            start: 30,
+                                                                            end: 76,
+                                                                        },
+                                                                    ),
                                                                 },
-                                                            ),
-                                                            item: Boolean(
-                                                                true,
-                                                            ),
-                                                        },
+                                                                span: Span {
+                                                                    start: 36,
+                                                                    end: 40,
+                                                                },
+                                                            },
+                                                        ),
+                                                        item: Boolean(
+                                                            true,
+                                                        ),
                                                     },
                                                 },
-                                            ],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 41,
+                                            },
+                                        ],
                                     },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-args-boolean.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
+                                ),
                                 span: Span {
-                                    start: 3,
-                                    end: 8,
+                                    start: 25,
+                                    end: 41,
                                 },
                             },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-args-boolean.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 45,
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-args-boolean.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 30,
-                            end: 76,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 45,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-args-boolean.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 30,
+                        end: 76,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-args-null.output
+++ b/crates/isograph_lang_parser/fixtures/field-args-null.output
@@ -1,40 +1,66 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-args-null.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "ValidArgs",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "ValidArgs",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-args-null.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 30,
+                                                                end: 76,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 29,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "args",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [
+                                            WithLocation {
                                                 location: Embedded(
                                                     EmbeddedLocation {
                                                         text_source: TextSource {
@@ -50,124 +76,93 @@ Ok(
                                                             ),
                                                         },
                                                         span: Span {
-                                                            start: 25,
-                                                            end: 29,
+                                                            start: 30,
+                                                            end: 40,
                                                         },
                                                     },
                                                 ),
-                                                item: ScalarSelectableName(
-                                                    "args",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [
-                                                WithLocation {
-                                                    location: Embedded(
-                                                        EmbeddedLocation {
-                                                            text_source: TextSource {
-                                                                current_working_directory: CurrentWorkingDirectory,
-                                                                relative_path_to_source_file: RelativePathToSourceFile(
-                                                                    "crates/isograph_lang_parser/fixtures/field-args-null.input.js",
-                                                                ),
-                                                                span: Some(
-                                                                    Span {
-                                                                        start: 30,
-                                                                        end: 76,
-                                                                    },
-                                                                ),
-                                                            },
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 40,
-                                                            },
+                                                item: SelectionFieldArgument {
+                                                    name: WithSpan {
+                                                        item: FieldArgumentName(
+                                                            "arg1",
+                                                        ),
+                                                        span: Span {
+                                                            start: 30,
+                                                            end: 34,
                                                         },
-                                                    ),
-                                                    item: SelectionFieldArgument {
-                                                        name: WithSpan {
-                                                            item: FieldArgumentName(
-                                                                "arg1",
-                                                            ),
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 34,
-                                                            },
-                                                        },
-                                                        value: WithLocation {
-                                                            location: Embedded(
-                                                                EmbeddedLocation {
-                                                                    text_source: TextSource {
-                                                                        current_working_directory: CurrentWorkingDirectory,
-                                                                        relative_path_to_source_file: RelativePathToSourceFile(
-                                                                            "crates/isograph_lang_parser/fixtures/field-args-null.input.js",
-                                                                        ),
-                                                                        span: Some(
-                                                                            Span {
-                                                                                start: 30,
-                                                                                end: 76,
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                    span: Span {
-                                                                        start: 36,
-                                                                        end: 40,
-                                                                    },
+                                                    },
+                                                    value: WithLocation {
+                                                        location: Embedded(
+                                                            EmbeddedLocation {
+                                                                text_source: TextSource {
+                                                                    current_working_directory: CurrentWorkingDirectory,
+                                                                    relative_path_to_source_file: RelativePathToSourceFile(
+                                                                        "crates/isograph_lang_parser/fixtures/field-args-null.input.js",
+                                                                    ),
+                                                                    span: Some(
+                                                                        Span {
+                                                                            start: 30,
+                                                                            end: 76,
+                                                                        },
+                                                                    ),
                                                                 },
-                                                            ),
-                                                            item: Null,
-                                                        },
+                                                                span: Span {
+                                                                    start: 36,
+                                                                    end: 40,
+                                                                },
+                                                            },
+                                                        ),
+                                                        item: Null,
                                                     },
                                                 },
-                                            ],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 41,
+                                            },
+                                        ],
                                     },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-args-null.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
+                                ),
                                 span: Span {
-                                    start: 3,
-                                    end: 8,
+                                    start: 25,
+                                    end: 41,
                                 },
                             },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-args-null.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 45,
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-args-null.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 30,
-                            end: 76,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 45,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-args-null.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 30,
+                        end: 76,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-args-number.output
+++ b/crates/isograph_lang_parser/fixtures/field-args-number.output
@@ -1,40 +1,66 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-args-number.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "ValidArgs",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "ValidArgs",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-args-number.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 30,
+                                                                end: 75,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 29,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "args",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [
+                                            WithLocation {
                                                 location: Embedded(
                                                     EmbeddedLocation {
                                                         text_source: TextSource {
@@ -50,126 +76,95 @@ Ok(
                                                             ),
                                                         },
                                                         span: Span {
-                                                            start: 25,
-                                                            end: 29,
+                                                            start: 30,
+                                                            end: 39,
                                                         },
                                                     },
                                                 ),
-                                                item: ScalarSelectableName(
-                                                    "args",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [
-                                                WithLocation {
-                                                    location: Embedded(
-                                                        EmbeddedLocation {
-                                                            text_source: TextSource {
-                                                                current_working_directory: CurrentWorkingDirectory,
-                                                                relative_path_to_source_file: RelativePathToSourceFile(
-                                                                    "crates/isograph_lang_parser/fixtures/field-args-number.input.js",
-                                                                ),
-                                                                span: Some(
-                                                                    Span {
-                                                                        start: 30,
-                                                                        end: 75,
-                                                                    },
-                                                                ),
-                                                            },
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 39,
-                                                            },
+                                                item: SelectionFieldArgument {
+                                                    name: WithSpan {
+                                                        item: FieldArgumentName(
+                                                            "arg1",
+                                                        ),
+                                                        span: Span {
+                                                            start: 30,
+                                                            end: 34,
                                                         },
-                                                    ),
-                                                    item: SelectionFieldArgument {
-                                                        name: WithSpan {
-                                                            item: FieldArgumentName(
-                                                                "arg1",
-                                                            ),
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 34,
-                                                            },
-                                                        },
-                                                        value: WithLocation {
-                                                            location: Embedded(
-                                                                EmbeddedLocation {
-                                                                    text_source: TextSource {
-                                                                        current_working_directory: CurrentWorkingDirectory,
-                                                                        relative_path_to_source_file: RelativePathToSourceFile(
-                                                                            "crates/isograph_lang_parser/fixtures/field-args-number.input.js",
-                                                                        ),
-                                                                        span: Some(
-                                                                            Span {
-                                                                                start: 30,
-                                                                                end: 75,
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                    span: Span {
-                                                                        start: 36,
-                                                                        end: 39,
-                                                                    },
+                                                    },
+                                                    value: WithLocation {
+                                                        location: Embedded(
+                                                            EmbeddedLocation {
+                                                                text_source: TextSource {
+                                                                    current_working_directory: CurrentWorkingDirectory,
+                                                                    relative_path_to_source_file: RelativePathToSourceFile(
+                                                                        "crates/isograph_lang_parser/fixtures/field-args-number.input.js",
+                                                                    ),
+                                                                    span: Some(
+                                                                        Span {
+                                                                            start: 30,
+                                                                            end: 75,
+                                                                        },
+                                                                    ),
                                                                 },
-                                                            ),
-                                                            item: Integer(
-                                                                123,
-                                                            ),
-                                                        },
+                                                                span: Span {
+                                                                    start: 36,
+                                                                    end: 39,
+                                                                },
+                                                            },
+                                                        ),
+                                                        item: Integer(
+                                                            123,
+                                                        ),
                                                     },
                                                 },
-                                            ],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 40,
+                                            },
+                                        ],
                                     },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-args-number.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
+                                ),
                                 span: Span {
-                                    start: 3,
-                                    end: 8,
+                                    start: 25,
+                                    end: 40,
                                 },
                             },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-args-number.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 44,
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-args-number.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 30,
-                            end: 75,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 44,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-args-number.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 30,
+                        end: 75,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-args-obj.output
+++ b/crates/isograph_lang_parser/fixtures/field-args-obj.output
@@ -1,40 +1,66 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "ValidArgs",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "ValidArgs",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 30,
+                                                                end: 86,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 29,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "args",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [
+                                            WithLocation {
                                                 location: Embedded(
                                                     EmbeddedLocation {
                                                         text_source: TextSource {
@@ -50,181 +76,150 @@ Ok(
                                                             ),
                                                         },
                                                         span: Span {
-                                                            start: 25,
-                                                            end: 29,
+                                                            start: 30,
+                                                            end: 50,
                                                         },
                                                     },
                                                 ),
-                                                item: ScalarSelectableName(
-                                                    "args",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [
-                                                WithLocation {
-                                                    location: Embedded(
-                                                        EmbeddedLocation {
-                                                            text_source: TextSource {
-                                                                current_working_directory: CurrentWorkingDirectory,
-                                                                relative_path_to_source_file: RelativePathToSourceFile(
-                                                                    "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
-                                                                ),
-                                                                span: Some(
-                                                                    Span {
-                                                                        start: 30,
-                                                                        end: 86,
-                                                                    },
-                                                                ),
-                                                            },
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 50,
-                                                            },
+                                                item: SelectionFieldArgument {
+                                                    name: WithSpan {
+                                                        item: FieldArgumentName(
+                                                            "arg1",
+                                                        ),
+                                                        span: Span {
+                                                            start: 30,
+                                                            end: 34,
                                                         },
-                                                    ),
-                                                    item: SelectionFieldArgument {
-                                                        name: WithSpan {
-                                                            item: FieldArgumentName(
-                                                                "arg1",
-                                                            ),
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 34,
+                                                    },
+                                                    value: WithLocation {
+                                                        location: Embedded(
+                                                            EmbeddedLocation {
+                                                                text_source: TextSource {
+                                                                    current_working_directory: CurrentWorkingDirectory,
+                                                                    relative_path_to_source_file: RelativePathToSourceFile(
+                                                                        "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
+                                                                    ),
+                                                                    span: Some(
+                                                                        Span {
+                                                                            start: 30,
+                                                                            end: 86,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                                span: Span {
+                                                                    start: 36,
+                                                                    end: 50,
+                                                                },
                                                             },
-                                                        },
-                                                        value: WithLocation {
-                                                            location: Embedded(
-                                                                EmbeddedLocation {
-                                                                    text_source: TextSource {
-                                                                        current_working_directory: CurrentWorkingDirectory,
-                                                                        relative_path_to_source_file: RelativePathToSourceFile(
-                                                                            "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
-                                                                        ),
-                                                                        span: Some(
-                                                                            Span {
-                                                                                start: 30,
-                                                                                end: 86,
+                                                        ),
+                                                        item: Object(
+                                                            [
+                                                                NameValuePair {
+                                                                    name: WithLocation {
+                                                                        location: Embedded(
+                                                                            EmbeddedLocation {
+                                                                                text_source: TextSource {
+                                                                                    current_working_directory: CurrentWorkingDirectory,
+                                                                                    relative_path_to_source_file: RelativePathToSourceFile(
+                                                                                        "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
+                                                                                    ),
+                                                                                    span: Some(
+                                                                                        Span {
+                                                                                            start: 30,
+                                                                                            end: 86,
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                                span: Span {
+                                                                                    start: 38,
+                                                                                    end: 41,
+                                                                                },
                                                                             },
                                                                         ),
+                                                                        item: ValueKeyName(
+                                                                            "foo",
+                                                                        ),
                                                                     },
-                                                                    span: Span {
-                                                                        start: 36,
-                                                                        end: 50,
+                                                                    value: WithLocation {
+                                                                        location: Embedded(
+                                                                            EmbeddedLocation {
+                                                                                text_source: TextSource {
+                                                                                    current_working_directory: CurrentWorkingDirectory,
+                                                                                    relative_path_to_source_file: RelativePathToSourceFile(
+                                                                                        "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
+                                                                                    ),
+                                                                                    span: Some(
+                                                                                        Span {
+                                                                                            start: 30,
+                                                                                            end: 86,
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                                span: Span {
+                                                                                    start: 43,
+                                                                                    end: 48,
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                        item: String(
+                                                                            StringLiteralValue(
+                                                                                "bar",
+                                                                            ),
+                                                                        ),
                                                                     },
                                                                 },
-                                                            ),
-                                                            item: Object(
-                                                                [
-                                                                    NameValuePair {
-                                                                        name: WithLocation {
-                                                                            location: Embedded(
-                                                                                EmbeddedLocation {
-                                                                                    text_source: TextSource {
-                                                                                        current_working_directory: CurrentWorkingDirectory,
-                                                                                        relative_path_to_source_file: RelativePathToSourceFile(
-                                                                                            "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
-                                                                                        ),
-                                                                                        span: Some(
-                                                                                            Span {
-                                                                                                start: 30,
-                                                                                                end: 86,
-                                                                                            },
-                                                                                        ),
-                                                                                    },
-                                                                                    span: Span {
-                                                                                        start: 38,
-                                                                                        end: 41,
-                                                                                    },
-                                                                                },
-                                                                            ),
-                                                                            item: ValueKeyName(
-                                                                                "foo",
-                                                                            ),
-                                                                        },
-                                                                        value: WithLocation {
-                                                                            location: Embedded(
-                                                                                EmbeddedLocation {
-                                                                                    text_source: TextSource {
-                                                                                        current_working_directory: CurrentWorkingDirectory,
-                                                                                        relative_path_to_source_file: RelativePathToSourceFile(
-                                                                                            "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
-                                                                                        ),
-                                                                                        span: Some(
-                                                                                            Span {
-                                                                                                start: 30,
-                                                                                                end: 86,
-                                                                                            },
-                                                                                        ),
-                                                                                    },
-                                                                                    span: Span {
-                                                                                        start: 43,
-                                                                                        end: 48,
-                                                                                    },
-                                                                                },
-                                                                            ),
-                                                                            item: String(
-                                                                                StringLiteralValue(
-                                                                                    "bar",
-                                                                                ),
-                                                                            ),
-                                                                        },
-                                                                    },
-                                                                ],
-                                                            ),
-                                                        },
+                                                            ],
+                                                        ),
                                                     },
                                                 },
-                                            ],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 51,
+                                            },
+                                        ],
                                     },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
+                                ),
                                 span: Span {
-                                    start: 3,
-                                    end: 8,
+                                    start: 25,
+                                    end: 51,
                                 },
                             },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 55,
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 30,
-                            end: 86,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 55,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-args-obj.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 30,
+                        end: 86,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-args-string.output
+++ b/crates/isograph_lang_parser/fixtures/field-args-string.output
@@ -1,40 +1,66 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-args-string.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "ValidArgs",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "ValidArgs",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-args-string.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 30,
+                                                                end: 88,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 29,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "args",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [
+                                            WithLocation {
                                                 location: Embedded(
                                                     EmbeddedLocation {
                                                         text_source: TextSource {
@@ -50,128 +76,97 @@ Ok(
                                                             ),
                                                         },
                                                         span: Span {
-                                                            start: 25,
-                                                            end: 29,
+                                                            start: 30,
+                                                            end: 52,
                                                         },
                                                     },
                                                 ),
-                                                item: ScalarSelectableName(
-                                                    "args",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [
-                                                WithLocation {
-                                                    location: Embedded(
-                                                        EmbeddedLocation {
-                                                            text_source: TextSource {
-                                                                current_working_directory: CurrentWorkingDirectory,
-                                                                relative_path_to_source_file: RelativePathToSourceFile(
-                                                                    "crates/isograph_lang_parser/fixtures/field-args-string.input.js",
-                                                                ),
-                                                                span: Some(
-                                                                    Span {
-                                                                        start: 30,
-                                                                        end: 88,
-                                                                    },
-                                                                ),
-                                                            },
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 52,
-                                                            },
+                                                item: SelectionFieldArgument {
+                                                    name: WithSpan {
+                                                        item: FieldArgumentName(
+                                                            "arg1",
+                                                        ),
+                                                        span: Span {
+                                                            start: 30,
+                                                            end: 34,
                                                         },
-                                                    ),
-                                                    item: SelectionFieldArgument {
-                                                        name: WithSpan {
-                                                            item: FieldArgumentName(
-                                                                "arg1",
-                                                            ),
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 34,
-                                                            },
-                                                        },
-                                                        value: WithLocation {
-                                                            location: Embedded(
-                                                                EmbeddedLocation {
-                                                                    text_source: TextSource {
-                                                                        current_working_directory: CurrentWorkingDirectory,
-                                                                        relative_path_to_source_file: RelativePathToSourceFile(
-                                                                            "crates/isograph_lang_parser/fixtures/field-args-string.input.js",
-                                                                        ),
-                                                                        span: Some(
-                                                                            Span {
-                                                                                start: 30,
-                                                                                end: 88,
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                    span: Span {
-                                                                        start: 36,
-                                                                        end: 52,
-                                                                    },
+                                                    },
+                                                    value: WithLocation {
+                                                        location: Embedded(
+                                                            EmbeddedLocation {
+                                                                text_source: TextSource {
+                                                                    current_working_directory: CurrentWorkingDirectory,
+                                                                    relative_path_to_source_file: RelativePathToSourceFile(
+                                                                        "crates/isograph_lang_parser/fixtures/field-args-string.input.js",
+                                                                    ),
+                                                                    span: Some(
+                                                                        Span {
+                                                                            start: 30,
+                                                                            end: 88,
+                                                                        },
+                                                                    ),
                                                                 },
+                                                                span: Span {
+                                                                    start: 36,
+                                                                    end: 52,
+                                                                },
+                                                            },
+                                                        ),
+                                                        item: String(
+                                                            StringLiteralValue(
+                                                                "string literal",
                                                             ),
-                                                            item: String(
-                                                                StringLiteralValue(
-                                                                    "string literal",
-                                                                ),
-                                                            ),
-                                                        },
+                                                        ),
                                                     },
                                                 },
-                                            ],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 53,
+                                            },
+                                        ],
                                     },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-args-string.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
+                                ),
                                 span: Span {
-                                    start: 3,
-                                    end: 8,
+                                    start: 25,
+                                    end: 53,
                                 },
                             },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-args-string.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 57,
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-args-string.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 30,
-                            end: 88,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 57,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-args-string.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 30,
+                        end: 88,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-args-variable.output
+++ b/crates/isograph_lang_parser/fixtures/field-args-variable.output
@@ -1,40 +1,66 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-args-variable.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "ValidArgs",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "ValidArgs",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-args-variable.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 30,
+                                                                end: 76,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 29,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "args",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [
+                                            WithLocation {
                                                 location: Embedded(
                                                     EmbeddedLocation {
                                                         text_source: TextSource {
@@ -50,128 +76,97 @@ Ok(
                                                             ),
                                                         },
                                                         span: Span {
-                                                            start: 25,
-                                                            end: 29,
+                                                            start: 30,
+                                                            end: 40,
                                                         },
                                                     },
                                                 ),
-                                                item: ScalarSelectableName(
-                                                    "args",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [
-                                                WithLocation {
-                                                    location: Embedded(
-                                                        EmbeddedLocation {
-                                                            text_source: TextSource {
-                                                                current_working_directory: CurrentWorkingDirectory,
-                                                                relative_path_to_source_file: RelativePathToSourceFile(
-                                                                    "crates/isograph_lang_parser/fixtures/field-args-variable.input.js",
-                                                                ),
-                                                                span: Some(
-                                                                    Span {
-                                                                        start: 30,
-                                                                        end: 76,
-                                                                    },
-                                                                ),
-                                                            },
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 40,
-                                                            },
+                                                item: SelectionFieldArgument {
+                                                    name: WithSpan {
+                                                        item: FieldArgumentName(
+                                                            "arg1",
+                                                        ),
+                                                        span: Span {
+                                                            start: 30,
+                                                            end: 34,
                                                         },
-                                                    ),
-                                                    item: SelectionFieldArgument {
-                                                        name: WithSpan {
-                                                            item: FieldArgumentName(
-                                                                "arg1",
-                                                            ),
-                                                            span: Span {
-                                                                start: 30,
-                                                                end: 34,
-                                                            },
-                                                        },
-                                                        value: WithLocation {
-                                                            location: Embedded(
-                                                                EmbeddedLocation {
-                                                                    text_source: TextSource {
-                                                                        current_working_directory: CurrentWorkingDirectory,
-                                                                        relative_path_to_source_file: RelativePathToSourceFile(
-                                                                            "crates/isograph_lang_parser/fixtures/field-args-variable.input.js",
-                                                                        ),
-                                                                        span: Some(
-                                                                            Span {
-                                                                                start: 30,
-                                                                                end: 76,
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                    span: Span {
-                                                                        start: 37,
-                                                                        end: 40,
-                                                                    },
+                                                    },
+                                                    value: WithLocation {
+                                                        location: Embedded(
+                                                            EmbeddedLocation {
+                                                                text_source: TextSource {
+                                                                    current_working_directory: CurrentWorkingDirectory,
+                                                                    relative_path_to_source_file: RelativePathToSourceFile(
+                                                                        "crates/isograph_lang_parser/fixtures/field-args-variable.input.js",
+                                                                    ),
+                                                                    span: Some(
+                                                                        Span {
+                                                                            start: 30,
+                                                                            end: 76,
+                                                                        },
+                                                                    ),
                                                                 },
+                                                                span: Span {
+                                                                    start: 37,
+                                                                    end: 40,
+                                                                },
+                                                            },
+                                                        ),
+                                                        item: Variable(
+                                                            VariableName(
+                                                                "var",
                                                             ),
-                                                            item: Variable(
-                                                                VariableName(
-                                                                    "var",
-                                                                ),
-                                                            ),
-                                                        },
+                                                        ),
                                                     },
                                                 },
-                                            ],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 41,
+                                            },
+                                        ],
                                     },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-args-variable.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
+                                ),
                                 span: Span {
-                                    start: 3,
-                                    end: 8,
+                                    start: 25,
+                                    end: 41,
                                 },
                             },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-args-variable.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 45,
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-args-variable.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 30,
-                            end: 76,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 45,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-args-variable.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 30,
+                        end: 76,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-directives-on-definition-invalid.output
+++ b/crates/isograph_lang_parser/fixtures/field-directives-on-definition-invalid.output
@@ -1,112 +1,107 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-directives-on-definition-invalid.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
-                            },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
-                            },
-                            description: None,
-                            selection_set: [],
-                            directives: [
-                                WithSpan {
-                                    item: IsographFieldDirective {
-                                        name: WithSpan {
-                                            item: IsographDirectiveName(
-                                                "hello",
-                                            ),
-                                            span: Span {
-                                                start: 20,
-                                                end: 25,
-                                            },
-                                        },
-                                        arguments: [],
-                                    },
-                                    span: Span {
-                                        start: 19,
-                                        end: 25,
-                                    },
-                                },
-                                WithSpan {
-                                    item: IsographFieldDirective {
-                                        name: WithSpan {
-                                            item: IsographDirectiveName(
-                                                "there",
-                                            ),
-                                            span: Span {
-                                                start: 27,
-                                                end: 32,
-                                            },
-                                        },
-                                        arguments: [],
-                                    },
-                                    span: Span {
-                                        start: 26,
-                                        end: 32,
-                                    },
-                                },
-                            ],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-directives-on-definition-invalid.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 8,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 38,
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
+                            },
+                        },
+                        description: None,
+                        selection_set: [],
+                        directives: [
+                            WithSpan {
+                                item: IsographFieldDirective {
+                                    name: WithSpan {
+                                        item: IsographDirectiveName(
+                                            "hello",
+                                        ),
+                                        span: Span {
+                                            start: 20,
+                                            end: 25,
+                                        },
+                                    },
+                                    arguments: [],
+                                },
+                                span: Span {
+                                    start: 19,
+                                    end: 25,
+                                },
+                            },
+                            WithSpan {
+                                item: IsographFieldDirective {
+                                    name: WithSpan {
+                                        item: IsographDirectiveName(
+                                            "there",
+                                        ),
+                                        span: Span {
+                                            start: 27,
+                                            end: 32,
+                                        },
+                                    },
+                                    arguments: [],
+                                },
+                                span: Span {
+                                    start: 26,
+                                    end: 32,
+                                },
+                            },
+                        ],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-directives-on-definition-invalid.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-directives-on-definition-invalid.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 31,
-                            end: 70,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 38,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-directives-on-definition-invalid.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 31,
+                        end: 70,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-directives-on-definition-valid.output
+++ b/crates/isograph_lang_parser/fixtures/field-directives-on-definition-valid.output
@@ -1,94 +1,89 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-directives-on-definition-valid.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
-                            },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
-                            },
-                            description: None,
-                            selection_set: [],
-                            directives: [
-                                WithSpan {
-                                    item: IsographFieldDirective {
-                                        name: WithSpan {
-                                            item: IsographDirectiveName(
-                                                "component",
-                                            ),
-                                            span: Span {
-                                                start: 20,
-                                                end: 29,
-                                            },
-                                        },
-                                        arguments: [],
-                                    },
-                                    span: Span {
-                                        start: 19,
-                                        end: 29,
-                                    },
-                                },
-                            ],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-directives-on-definition-valid.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 8,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 35,
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
+                            },
+                        },
+                        description: None,
+                        selection_set: [],
+                        directives: [
+                            WithSpan {
+                                item: IsographFieldDirective {
+                                    name: WithSpan {
+                                        item: IsographDirectiveName(
+                                            "component",
+                                        ),
+                                        span: Span {
+                                            start: 20,
+                                            end: 29,
+                                        },
+                                    },
+                                    arguments: [],
+                                },
+                                span: Span {
+                                    start: 19,
+                                    end: 29,
+                                },
+                            },
+                        ],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-directives-on-definition-valid.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-directives-on-definition-valid.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 31,
-                            end: 67,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 35,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-directives-on-definition-valid.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 31,
+                        end: 67,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.output
+++ b/crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.output
@@ -1,454 +1,449 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
+                            ),
+                            span: Span {
+                                start: 9,
+                                end: 13,
+                            },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
+                            },
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 77,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 31,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "scalar",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: Loadable(
+                                            LoadableDirectiveSet {
+                                                loadable: LoadableDirectiveParameters {
+                                                    complete_selection_set: false,
+                                                    lazy_load_artifact: false,
+                                                },
+                                            },
+                                        ),
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 25,
+                                    end: 41,
+                                },
+                            },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
+                        },
+                    },
+                    span: Span {
+                        start: 9,
+                        end: 45,
+                    },
+                },
+            ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 31,
+                        end: 77,
+                    },
+                ),
+            },
         ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField",
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField2",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 77,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 25,
-                                                            end: 31,
-                                                        },
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 116,
+                                                                end: 187,
+                                                            },
+                                                        ),
                                                     },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "scalar",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: Loadable(
-                                                LoadableDirectiveSet {
-                                                    loadable: LoadableDirectiveParameters {
-                                                        complete_selection_set: false,
-                                                        lazy_load_artifact: false,
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 31,
                                                     },
                                                 },
                                             ),
-                                            arguments: [],
+                                            item: ScalarSelectableName(
+                                                "scalar",
+                                            ),
                                         },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 41,
+                                        reader_alias: None,
+                                        associated_data: Loadable(
+                                            LoadableDirectiveSet {
+                                                loadable: LoadableDirectiveParameters {
+                                                    complete_selection_set: false,
+                                                    lazy_load_artifact: false,
+                                                },
+                                            },
+                                        ),
+                                        arguments: [],
                                     },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
+                                ),
                                 span: Span {
-                                    start: 3,
-                                    end: 8,
+                                    start: 25,
+                                    end: 66,
                                 },
                             },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 45,
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 31,
-                            end: 77,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 70,
+                    },
                 },
             ),
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField2",
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 116,
+                        end: 187,
+                    },
+                ),
+            },
+        ),
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField3",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 116,
-                                                                    end: 187,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 25,
-                                                            end: 31,
-                                                        },
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 226,
+                                                                end: 296,
+                                                            },
+                                                        ),
                                                     },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "scalar",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: Loadable(
-                                                LoadableDirectiveSet {
-                                                    loadable: LoadableDirectiveParameters {
-                                                        complete_selection_set: false,
-                                                        lazy_load_artifact: false,
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 31,
                                                     },
                                                 },
                                             ),
-                                            arguments: [],
+                                            item: ScalarSelectableName(
+                                                "scalar",
+                                            ),
                                         },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 66,
+                                        reader_alias: None,
+                                        associated_data: Loadable(
+                                            LoadableDirectiveSet {
+                                                loadable: LoadableDirectiveParameters {
+                                                    complete_selection_set: false,
+                                                    lazy_load_artifact: true,
+                                                },
+                                            },
+                                        ),
+                                        arguments: [],
                                     },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
+                                ),
                                 span: Span {
-                                    start: 3,
-                                    end: 8,
+                                    start: 25,
+                                    end: 65,
                                 },
                             },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 70,
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 116,
-                            end: 187,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 69,
+                    },
                 },
             ),
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField3",
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 226,
+                        end: 296,
+                    },
+                ),
+            },
+        ),
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "updatable",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
+                        },
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 226,
-                                                                    end: 296,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 25,
-                                                            end: 31,
-                                                        },
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 333,
+                                                                end: 380,
+                                                            },
+                                                        ),
                                                     },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "scalar",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: Loadable(
-                                                LoadableDirectiveSet {
-                                                    loadable: LoadableDirectiveParameters {
-                                                        complete_selection_set: false,
-                                                        lazy_load_artifact: true,
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 31,
                                                     },
                                                 },
                                             ),
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 65,
-                                    },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 8,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
-                            },
-                        },
-                        span: Span {
-                            start: 9,
-                            end: 69,
-                        },
-                    },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 226,
-                            end: 296,
-                        },
-                    ),
-                },
-            ),
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "updatable",
-                            ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
-                            },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
-                            },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 333,
-                                                                    end: 380,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 25,
-                                                            end: 31,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "scalar",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: Updatable(
-                                                UpdatableDirectiveSet {
-                                                    updatable: UpdatableDirectiveParameters,
-                                                },
+                                            item: ScalarSelectableName(
+                                                "scalar",
                                             ),
-                                            arguments: [],
                                         },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 42,
+                                        reader_alias: None,
+                                        associated_data: Updatable(
+                                            UpdatableDirectiveSet {
+                                                updatable: UpdatableDirectiveParameters,
+                                            },
+                                        ),
+                                        arguments: [],
                                     },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
+                                ),
                                 span: Span {
-                                    start: 3,
-                                    end: 8,
+                                    start: 25,
+                                    end: 42,
                                 },
                             },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 46,
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 333,
-                            end: 380,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 46,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-directives-on-scalar-valid.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 333,
+                        end: 380,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-empty-linked-field-selection-set.output
+++ b/crates/isograph_lang_parser/fixtures/field-empty-linked-field-selection-set.output
@@ -1,117 +1,112 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-empty-linked-field-selection-set.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
-                            },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
-                            },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Object(
-                                        LinkedFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-empty-linked-field-selection-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 70,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 25,
-                                                            end: 31,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ServerObjectSelectableName(
-                                                    "linked",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            selection_set: [],
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 25,
-                                        end: 34,
-                                    },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-empty-linked-field-selection-set.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 8,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 38,
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
+                            },
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Object(
+                                    LinkedFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-empty-linked-field-selection-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 70,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 25,
+                                                        end: 31,
+                                                    },
+                                                },
+                                            ),
+                                            item: ServerObjectSelectableName(
+                                                "linked",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        selection_set: [],
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 25,
+                                    end: 34,
+                                },
+                            },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-empty-linked-field-selection-set.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-empty-linked-field-selection-set.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 31,
-                            end: 70,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 38,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-empty-linked-field-selection-set.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 31,
+                        end: 70,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-empty-selection-set.output
+++ b/crates/isograph_lang_parser/fixtures/field-empty-selection-set.output
@@ -1,75 +1,70 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-empty-selection-set.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
-                            },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
-                            },
-                            description: None,
-                            selection_set: [],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-empty-selection-set.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 8,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 21,
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
+                            },
+                        },
+                        description: None,
+                        selection_set: [],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-empty-selection-set.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-empty-selection-set.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 31,
-                            end: 53,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 21,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-empty-selection-set.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 31,
+                        end: 53,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-grabbag-field-set.output
+++ b/crates/isograph_lang_parser/fixtures/field-grabbag-field-set.output
@@ -1,602 +1,597 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
-                            },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
-                            },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 27,
-                                                            end: 33,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "scalar",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 27,
-                                        end: 33,
-                                    },
-                                },
-                                WithSpan {
-                                    item: Object(
-                                        LinkedFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 38,
-                                                            end: 44,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ServerObjectSelectableName(
-                                                    "linked",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            selection_set: [
-                                                WithSpan {
-                                                    item: Scalar(
-                                                        ScalarFieldSelection {
-                                                            name: WithLocation {
-                                                                location: Embedded(
-                                                                    EmbeddedLocation {
-                                                                        text_source: TextSource {
-                                                                            current_working_directory: CurrentWorkingDirectory,
-                                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                                            ),
-                                                                            span: Some(
-                                                                                Span {
-                                                                                    start: 31,
-                                                                                    end: 261,
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                        span: Span {
-                                                                            start: 53,
-                                                                            end: 68,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                item: ScalarSelectableName(
-                                                                    "scalarWithComma",
-                                                                ),
-                                                            },
-                                                            reader_alias: None,
-                                                            associated_data: None(
-                                                                EmptyDirectiveSet,
-                                                            ),
-                                                            arguments: [],
-                                                        },
-                                                    ),
-                                                    span: Span {
-                                                        start: 53,
-                                                        end: 69,
-                                                    },
-                                                },
-                                            ],
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 38,
-                                        end: 75,
-                                    },
-                                },
-                                WithSpan {
-                                    item: Object(
-                                        LinkedFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 80,
-                                                            end: 95,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ServerObjectSelectableName(
-                                                    "linkedWithComma",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            selection_set: [
-                                                WithSpan {
-                                                    item: Scalar(
-                                                        ScalarFieldSelection {
-                                                            name: WithLocation {
-                                                                location: Embedded(
-                                                                    EmbeddedLocation {
-                                                                        text_source: TextSource {
-                                                                            current_working_directory: CurrentWorkingDirectory,
-                                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                                            ),
-                                                                            span: Some(
-                                                                                Span {
-                                                                                    start: 31,
-                                                                                    end: 261,
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                        span: Span {
-                                                                            start: 104,
-                                                                            end: 108,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                item: ScalarSelectableName(
-                                                                    "blah",
-                                                                ),
-                                                            },
-                                                            reader_alias: None,
-                                                            associated_data: None(
-                                                                EmptyDirectiveSet,
-                                                            ),
-                                                            arguments: [],
-                                                        },
-                                                    ),
-                                                    span: Span {
-                                                        start: 104,
-                                                        end: 108,
-                                                    },
-                                                },
-                                            ],
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 80,
-                                        end: 115,
-                                    },
-                                },
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 120,
-                                                            end: 128,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "multiple",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 120,
-                                        end: 129,
-                                    },
-                                },
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 130,
-                                                            end: 132,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "on",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 130,
-                                        end: 133,
-                                    },
-                                },
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 134,
-                                                            end: 137,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "the",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 134,
-                                        end: 138,
-                                    },
-                                },
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 139,
-                                                            end: 143,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "same",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 139,
-                                        end: 144,
-                                    },
-                                },
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 145,
-                                                            end: 149,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "line",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 145,
-                                        end: 149,
-                                    },
-                                },
-                                WithSpan {
-                                    item: Scalar(
-                                        ScalarFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 154,
-                                                            end: 163,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ScalarSelectableName(
-                                                    "including",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 154,
-                                        end: 164,
-                                    },
-                                },
-                                WithSpan {
-                                    item: Object(
-                                        LinkedFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 31,
-                                                                    end: 261,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 165,
-                                                            end: 190,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ServerObjectSelectableName(
-                                                    "youCanEndWithALinkedField",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            selection_set: [
-                                                WithSpan {
-                                                    item: Scalar(
-                                                        ScalarFieldSelection {
-                                                            name: WithLocation {
-                                                                location: Embedded(
-                                                                    EmbeddedLocation {
-                                                                        text_source: TextSource {
-                                                                            current_working_directory: CurrentWorkingDirectory,
-                                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                                                                            ),
-                                                                            span: Some(
-                                                                                Span {
-                                                                                    start: 31,
-                                                                                    end: 261,
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                        span: Span {
-                                                                            start: 199,
-                                                                            end: 219,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                item: ScalarSelectableName(
-                                                                    "butWhyWouldYouDoThat",
-                                                                ),
-                                                            },
-                                                            reader_alias: None,
-                                                            associated_data: None(
-                                                                EmptyDirectiveSet,
-                                                            ),
-                                                            arguments: [],
-                                                        },
-                                                    ),
-                                                    span: Span {
-                                                        start: 199,
-                                                        end: 219,
-                                                    },
-                                                },
-                                            ],
-                                            arguments: [],
-                                        },
-                                    ),
-                                    span: Span {
-                                        start: 165,
-                                        end: 225,
-                                    },
-                                },
-                            ],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 8,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 229,
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
+                            },
+                        },
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 27,
+                                                        end: 33,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "scalar",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 27,
+                                    end: 33,
+                                },
+                            },
+                            WithSpan {
+                                item: Object(
+                                    LinkedFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 38,
+                                                        end: 44,
+                                                    },
+                                                },
+                                            ),
+                                            item: ServerObjectSelectableName(
+                                                "linked",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        selection_set: [
+                                            WithSpan {
+                                                item: Scalar(
+                                                    ScalarFieldSelection {
+                                                        name: WithLocation {
+                                                            location: Embedded(
+                                                                EmbeddedLocation {
+                                                                    text_source: TextSource {
+                                                                        current_working_directory: CurrentWorkingDirectory,
+                                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                                        ),
+                                                                        span: Some(
+                                                                            Span {
+                                                                                start: 31,
+                                                                                end: 261,
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    span: Span {
+                                                                        start: 53,
+                                                                        end: 68,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            item: ScalarSelectableName(
+                                                                "scalarWithComma",
+                                                            ),
+                                                        },
+                                                        reader_alias: None,
+                                                        associated_data: None(
+                                                            EmptyDirectiveSet,
+                                                        ),
+                                                        arguments: [],
+                                                    },
+                                                ),
+                                                span: Span {
+                                                    start: 53,
+                                                    end: 69,
+                                                },
+                                            },
+                                        ],
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 38,
+                                    end: 75,
+                                },
+                            },
+                            WithSpan {
+                                item: Object(
+                                    LinkedFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 80,
+                                                        end: 95,
+                                                    },
+                                                },
+                                            ),
+                                            item: ServerObjectSelectableName(
+                                                "linkedWithComma",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        selection_set: [
+                                            WithSpan {
+                                                item: Scalar(
+                                                    ScalarFieldSelection {
+                                                        name: WithLocation {
+                                                            location: Embedded(
+                                                                EmbeddedLocation {
+                                                                    text_source: TextSource {
+                                                                        current_working_directory: CurrentWorkingDirectory,
+                                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                                        ),
+                                                                        span: Some(
+                                                                            Span {
+                                                                                start: 31,
+                                                                                end: 261,
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    span: Span {
+                                                                        start: 104,
+                                                                        end: 108,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            item: ScalarSelectableName(
+                                                                "blah",
+                                                            ),
+                                                        },
+                                                        reader_alias: None,
+                                                        associated_data: None(
+                                                            EmptyDirectiveSet,
+                                                        ),
+                                                        arguments: [],
+                                                    },
+                                                ),
+                                                span: Span {
+                                                    start: 104,
+                                                    end: 108,
+                                                },
+                                            },
+                                        ],
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 80,
+                                    end: 115,
+                                },
+                            },
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 120,
+                                                        end: 128,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "multiple",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 120,
+                                    end: 129,
+                                },
+                            },
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 130,
+                                                        end: 132,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "on",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 130,
+                                    end: 133,
+                                },
+                            },
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 134,
+                                                        end: 137,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "the",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 134,
+                                    end: 138,
+                                },
+                            },
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 139,
+                                                        end: 143,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "same",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 139,
+                                    end: 144,
+                                },
+                            },
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 145,
+                                                        end: 149,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "line",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 145,
+                                    end: 149,
+                                },
+                            },
+                            WithSpan {
+                                item: Scalar(
+                                    ScalarFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 154,
+                                                        end: 163,
+                                                    },
+                                                },
+                                            ),
+                                            item: ScalarSelectableName(
+                                                "including",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 154,
+                                    end: 164,
+                                },
+                            },
+                            WithSpan {
+                                item: Object(
+                                    LinkedFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 31,
+                                                                end: 261,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 165,
+                                                        end: 190,
+                                                    },
+                                                },
+                                            ),
+                                            item: ServerObjectSelectableName(
+                                                "youCanEndWithALinkedField",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        selection_set: [
+                                            WithSpan {
+                                                item: Scalar(
+                                                    ScalarFieldSelection {
+                                                        name: WithLocation {
+                                                            location: Embedded(
+                                                                EmbeddedLocation {
+                                                                    text_source: TextSource {
+                                                                        current_working_directory: CurrentWorkingDirectory,
+                                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                                                                        ),
+                                                                        span: Some(
+                                                                            Span {
+                                                                                start: 31,
+                                                                                end: 261,
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    span: Span {
+                                                                        start: 199,
+                                                                        end: 219,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            item: ScalarSelectableName(
+                                                                "butWhyWouldYouDoThat",
+                                                            ),
+                                                        },
+                                                        reader_alias: None,
+                                                        associated_data: None(
+                                                            EmptyDirectiveSet,
+                                                        ),
+                                                        arguments: [],
+                                                    },
+                                                ),
+                                                span: Span {
+                                                    start: 199,
+                                                    end: 219,
+                                                },
+                                            },
+                                        ],
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 165,
+                                    end: 225,
+                                },
+                            },
+                        ],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 31,
-                            end: 261,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 229,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-grabbag-field-set.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 31,
+                        end: 261,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-multi-line-description.output
+++ b/crates/isograph_lang_parser/fixtures/field-multi-line-description.output
@@ -1,85 +1,80 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-multi-line-description.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
-                            },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
-                            },
-                            description: Some(
-                                WithSpan {
-                                    item: DescriptionValue(
-                                        "Look, a multi-line description.\n\nVery cool.",
-                                    ),
-                                    span: Span {
-                                        start: 21,
-                                        end: 78,
-                                    },
-                                },
-                            ),
-                            selection_set: [],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-multi-line-description.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 8,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 83,
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
+                            },
+                        },
+                        description: Some(
+                            WithSpan {
+                                item: DescriptionValue(
+                                    "Look, a multi-line description.\n\nVery cool.",
+                                ),
+                                span: Span {
+                                    start: 21,
+                                    end: 78,
+                                },
+                            },
+                        ),
+                        selection_set: [],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-multi-line-description.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-multi-line-description.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 31,
-                            end: 115,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 83,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-multi-line-description.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 31,
+                        end: 115,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/field-single-line-description.output
+++ b/crates/isograph_lang_parser/fixtures/field-single-line-description.output
@@ -1,85 +1,80 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/field-single-line-description.input.js",
-        ),
-        [
-            (
-                ClientFieldDeclaration(
-                    WithSpan {
-                        item: ClientFieldDeclaration {
-                            const_export_name: ConstExportName(
-                                "BasicField",
+    [
+        (
+            ClientFieldDeclaration(
+                WithSpan {
+                    item: ClientFieldDeclaration {
+                        const_export_name: ConstExportName(
+                            "BasicField",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "Type",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "Type",
-                                ),
-                                span: Span {
-                                    start: 9,
-                                    end: 13,
-                                },
-                            },
-                            client_field_name: WithSpan {
-                                item: ClientScalarSelectableName(
-                                    "Name",
-                                ),
-                                span: Span {
-                                    start: 14,
-                                    end: 18,
-                                },
-                            },
-                            description: Some(
-                                WithSpan {
-                                    item: DescriptionValue(
-                                        "It's a bit weird to have a single line description, I think, but it's allowed",
-                                    ),
-                                    span: Span {
-                                        start: 21,
-                                        end: 100,
-                                    },
-                                },
-                            ),
-                            selection_set: [],
-                            directives: [],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/field-single-line-description.input.js",
-                            ),
-                            field_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 8,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 13,
-                                    end: 14,
-                                },
+                            span: Span {
+                                start: 9,
+                                end: 13,
                             },
                         },
-                        span: Span {
-                            start: 9,
-                            end: 105,
+                        client_field_name: WithSpan {
+                            item: ClientScalarSelectableName(
+                                "Name",
+                            ),
+                            span: Span {
+                                start: 14,
+                                end: 18,
+                            },
+                        },
+                        description: Some(
+                            WithSpan {
+                                item: DescriptionValue(
+                                    "It's a bit weird to have a single line description, I think, but it's allowed",
+                                ),
+                                span: Span {
+                                    start: 21,
+                                    end: 100,
+                                },
+                            },
+                        ),
+                        selection_set: [],
+                        directives: [],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/field-single-line-description.input.js",
+                        ),
+                        field_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 8,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 13,
+                                end: 14,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/field-single-line-description.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 31,
-                            end: 137,
-                        },
-                    ),
+                    span: Span {
+                        start: 9,
+                        end: 105,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/field-single-line-description.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 31,
+                        end: 137,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/pointer-basic.output
+++ b/crates/isograph_lang_parser/fixtures/pointer-basic.output
@@ -1,211 +1,206 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
-        ),
-        [
-            (
-                ClientPointerDeclaration(
-                    WithSpan {
-                        item: ClientPointerDeclaration {
-                            directives: [],
-                            const_export_name: ConstExportName(
-                                "pointer",
+    [
+        (
+            ClientPointerDeclaration(
+                WithSpan {
+                    item: ClientPointerDeclaration {
+                        directives: [],
+                        const_export_name: ConstExportName(
+                            "pointer",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "User",
                             ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "User",
-                                ),
-                                span: Span {
-                                    start: 11,
-                                    end: 15,
-                                },
+                            span: Span {
+                                start: 11,
+                                end: 15,
                             },
-                            target_type: Named(
-                                GraphQLNamedTypeAnnotation(
-                                    WithSpan {
-                                        item: UnvalidatedTypeName(
-                                            "User",
-                                        ),
-                                        span: Span {
-                                            start: 30,
-                                            end: 34,
-                                        },
-                                    },
-                                ),
-                            ),
-                            client_pointer_name: WithSpan {
-                                item: ClientObjectSelectableName(
-                                    "bestFriend",
-                                ),
-                                span: Span {
-                                    start: 16,
-                                    end: 26,
-                                },
-                            },
-                            description: None,
-                            selection_set: [
+                        },
+                        target_type: Named(
+                            GraphQLNamedTypeAnnotation(
                                 WithSpan {
-                                    item: Object(
-                                        LinkedFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 28,
-                                                                    end: 114,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 41,
-                                                            end: 48,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ServerObjectSelectableName(
-                                                    "friends",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            selection_set: [
-                                                WithSpan {
-                                                    item: Scalar(
-                                                        ScalarFieldSelection {
-                                                            name: WithLocation {
-                                                                location: Embedded(
-                                                                    EmbeddedLocation {
-                                                                        text_source: TextSource {
-                                                                            current_working_directory: CurrentWorkingDirectory,
-                                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                                "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
-                                                                            ),
-                                                                            span: Some(
-                                                                                Span {
-                                                                                    start: 28,
-                                                                                    end: 114,
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                        span: Span {
-                                                                            start: 57,
-                                                                            end: 59,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                item: ScalarSelectableName(
-                                                                    "id",
-                                                                ),
-                                                            },
-                                                            reader_alias: None,
-                                                            associated_data: None(
-                                                                EmptyDirectiveSet,
-                                                            ),
-                                                            arguments: [],
-                                                        },
-                                                    ),
-                                                    span: Span {
-                                                        start: 57,
-                                                        end: 59,
-                                                    },
-                                                },
-                                                WithSpan {
-                                                    item: Scalar(
-                                                        ScalarFieldSelection {
-                                                            name: WithLocation {
-                                                                location: Embedded(
-                                                                    EmbeddedLocation {
-                                                                        text_source: TextSource {
-                                                                            current_working_directory: CurrentWorkingDirectory,
-                                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                                "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
-                                                                            ),
-                                                                            span: Some(
-                                                                                Span {
-                                                                                    start: 28,
-                                                                                    end: 114,
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                        span: Span {
-                                                                            start: 66,
-                                                                            end: 75,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                item: ScalarSelectableName(
-                                                                    "closeness",
-                                                                ),
-                                                            },
-                                                            reader_alias: None,
-                                                            associated_data: None(
-                                                                EmptyDirectiveSet,
-                                                            ),
-                                                            arguments: [],
-                                                        },
-                                                    ),
-                                                    span: Span {
-                                                        start: 66,
-                                                        end: 75,
-                                                    },
-                                                },
-                                            ],
-                                            arguments: [],
-                                        },
+                                    item: UnvalidatedTypeName(
+                                        "User",
                                     ),
                                     span: Span {
-                                        start: 41,
-                                        end: 81,
+                                        start: 30,
+                                        end: 34,
                                     },
                                 },
-                            ],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
                             ),
-                            pointer_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 10,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 15,
-                                    end: 16,
-                                },
+                        ),
+                        client_pointer_name: WithSpan {
+                            item: ClientObjectSelectableName(
+                                "bestFriend",
+                            ),
+                            span: Span {
+                                start: 16,
+                                end: 26,
                             },
                         },
-                        span: Span {
-                            start: 11,
-                            end: 85,
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Object(
+                                    LinkedFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 28,
+                                                                end: 114,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 41,
+                                                        end: 48,
+                                                    },
+                                                },
+                                            ),
+                                            item: ServerObjectSelectableName(
+                                                "friends",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        selection_set: [
+                                            WithSpan {
+                                                item: Scalar(
+                                                    ScalarFieldSelection {
+                                                        name: WithLocation {
+                                                            location: Embedded(
+                                                                EmbeddedLocation {
+                                                                    text_source: TextSource {
+                                                                        current_working_directory: CurrentWorkingDirectory,
+                                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                                            "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
+                                                                        ),
+                                                                        span: Some(
+                                                                            Span {
+                                                                                start: 28,
+                                                                                end: 114,
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    span: Span {
+                                                                        start: 57,
+                                                                        end: 59,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            item: ScalarSelectableName(
+                                                                "id",
+                                                            ),
+                                                        },
+                                                        reader_alias: None,
+                                                        associated_data: None(
+                                                            EmptyDirectiveSet,
+                                                        ),
+                                                        arguments: [],
+                                                    },
+                                                ),
+                                                span: Span {
+                                                    start: 57,
+                                                    end: 59,
+                                                },
+                                            },
+                                            WithSpan {
+                                                item: Scalar(
+                                                    ScalarFieldSelection {
+                                                        name: WithLocation {
+                                                            location: Embedded(
+                                                                EmbeddedLocation {
+                                                                    text_source: TextSource {
+                                                                        current_working_directory: CurrentWorkingDirectory,
+                                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                                            "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
+                                                                        ),
+                                                                        span: Some(
+                                                                            Span {
+                                                                                start: 28,
+                                                                                end: 114,
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    span: Span {
+                                                                        start: 66,
+                                                                        end: 75,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            item: ScalarSelectableName(
+                                                                "closeness",
+                                                            ),
+                                                        },
+                                                        reader_alias: None,
+                                                        associated_data: None(
+                                                            EmptyDirectiveSet,
+                                                        ),
+                                                        arguments: [],
+                                                    },
+                                                ),
+                                                span: Span {
+                                                    start: 66,
+                                                    end: 75,
+                                                },
+                                            },
+                                        ],
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 41,
+                                    end: 81,
+                                },
+                            },
+                        ],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
+                        ),
+                        pointer_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 10,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 15,
+                                end: 16,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 28,
-                            end: 114,
-                        },
-                    ),
+                    span: Span {
+                        start: 11,
+                        end: 85,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/pointer-basic.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 28,
+                        end: 114,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/fixtures/pointer-directives.output
+++ b/crates/isograph_lang_parser/fixtures/pointer-directives.output
@@ -1,302 +1,297 @@
 Ok(
-    (
-        RelativePathToSourceFile(
-            "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
-        ),
-        [
-            (
-                ClientPointerDeclaration(
-                    WithSpan {
-                        item: ClientPointerDeclaration {
-                            directives: [
-                                WithSpan {
-                                    item: IsographFieldDirective {
-                                        name: WithSpan {
-                                            item: IsographDirectiveName(
-                                                "directives",
-                                            ),
-                                            span: Span {
-                                                start: 36,
-                                                end: 46,
-                                            },
-                                        },
-                                        arguments: [],
-                                    },
-                                    span: Span {
-                                        start: 35,
-                                        end: 46,
-                                    },
-                                },
-                                WithSpan {
-                                    item: IsographFieldDirective {
-                                        name: WithSpan {
-                                            item: IsographDirectiveName(
-                                                "allowed",
-                                            ),
-                                            span: Span {
-                                                start: 48,
-                                                end: 55,
-                                            },
-                                        },
-                                        arguments: [],
-                                    },
-                                    span: Span {
-                                        start: 47,
-                                        end: 55,
-                                    },
-                                },
-                                WithSpan {
-                                    item: IsographFieldDirective {
-                                        name: WithSpan {
-                                            item: IsographDirectiveName(
-                                                "at",
-                                            ),
-                                            span: Span {
-                                                start: 57,
-                                                end: 59,
-                                            },
-                                        },
-                                        arguments: [],
-                                    },
-                                    span: Span {
-                                        start: 56,
-                                        end: 59,
-                                    },
-                                },
-                                WithSpan {
-                                    item: IsographFieldDirective {
-                                        name: WithSpan {
-                                            item: IsographDirectiveName(
-                                                "parse",
-                                            ),
-                                            span: Span {
-                                                start: 61,
-                                                end: 66,
-                                            },
-                                        },
-                                        arguments: [],
-                                    },
-                                    span: Span {
-                                        start: 60,
-                                        end: 66,
-                                    },
-                                },
-                                WithSpan {
-                                    item: IsographFieldDirective {
-                                        name: WithSpan {
-                                            item: IsographDirectiveName(
-                                                "time",
-                                            ),
-                                            span: Span {
-                                                start: 68,
-                                                end: 72,
-                                            },
-                                        },
-                                        arguments: [],
-                                    },
-                                    span: Span {
-                                        start: 67,
-                                        end: 72,
-                                    },
-                                },
-                            ],
-                            const_export_name: ConstExportName(
-                                "pointer",
-                            ),
-                            parent_type: WithSpan {
-                                item: UnvalidatedTypeName(
-                                    "User",
-                                ),
-                                span: Span {
-                                    start: 11,
-                                    end: 15,
-                                },
-                            },
-                            target_type: Named(
-                                GraphQLNamedTypeAnnotation(
-                                    WithSpan {
-                                        item: UnvalidatedTypeName(
-                                            "User",
+    [
+        (
+            ClientPointerDeclaration(
+                WithSpan {
+                    item: ClientPointerDeclaration {
+                        directives: [
+                            WithSpan {
+                                item: IsographFieldDirective {
+                                    name: WithSpan {
+                                        item: IsographDirectiveName(
+                                            "directives",
                                         ),
                                         span: Span {
-                                            start: 30,
-                                            end: 34,
+                                            start: 36,
+                                            end: 46,
                                         },
                                     },
-                                ),
-                            ),
-                            client_pointer_name: WithSpan {
-                                item: ClientObjectSelectableName(
-                                    "bestFriend",
-                                ),
+                                    arguments: [],
+                                },
                                 span: Span {
-                                    start: 16,
-                                    end: 26,
+                                    start: 35,
+                                    end: 46,
                                 },
                             },
-                            description: None,
-                            selection_set: [
-                                WithSpan {
-                                    item: Object(
-                                        LinkedFieldSelection {
-                                            name: WithLocation {
-                                                location: Embedded(
-                                                    EmbeddedLocation {
-                                                        text_source: TextSource {
-                                                            current_working_directory: CurrentWorkingDirectory,
-                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
-                                                            ),
-                                                            span: Some(
-                                                                Span {
-                                                                    start: 112,
-                                                                    end: 236,
-                                                                },
-                                                            ),
-                                                        },
-                                                        span: Span {
-                                                            start: 79,
-                                                            end: 86,
-                                                        },
-                                                    },
-                                                ),
-                                                item: ServerObjectSelectableName(
-                                                    "friends",
-                                                ),
-                                            },
-                                            reader_alias: None,
-                                            associated_data: None(
-                                                EmptyDirectiveSet,
-                                            ),
-                                            selection_set: [
-                                                WithSpan {
-                                                    item: Scalar(
-                                                        ScalarFieldSelection {
-                                                            name: WithLocation {
-                                                                location: Embedded(
-                                                                    EmbeddedLocation {
-                                                                        text_source: TextSource {
-                                                                            current_working_directory: CurrentWorkingDirectory,
-                                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                                "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
-                                                                            ),
-                                                                            span: Some(
-                                                                                Span {
-                                                                                    start: 112,
-                                                                                    end: 236,
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                        span: Span {
-                                                                            start: 95,
-                                                                            end: 97,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                item: ScalarSelectableName(
-                                                                    "id",
-                                                                ),
-                                                            },
-                                                            reader_alias: None,
-                                                            associated_data: None(
-                                                                EmptyDirectiveSet,
-                                                            ),
-                                                            arguments: [],
-                                                        },
-                                                    ),
-                                                    span: Span {
-                                                        start: 95,
-                                                        end: 97,
-                                                    },
-                                                },
-                                                WithSpan {
-                                                    item: Scalar(
-                                                        ScalarFieldSelection {
-                                                            name: WithLocation {
-                                                                location: Embedded(
-                                                                    EmbeddedLocation {
-                                                                        text_source: TextSource {
-                                                                            current_working_directory: CurrentWorkingDirectory,
-                                                                            relative_path_to_source_file: RelativePathToSourceFile(
-                                                                                "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
-                                                                            ),
-                                                                            span: Some(
-                                                                                Span {
-                                                                                    start: 112,
-                                                                                    end: 236,
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                        span: Span {
-                                                                            start: 104,
-                                                                            end: 113,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                item: ScalarSelectableName(
-                                                                    "closeness",
-                                                                ),
-                                                            },
-                                                            reader_alias: None,
-                                                            associated_data: None(
-                                                                EmptyDirectiveSet,
-                                                            ),
-                                                            arguments: [],
-                                                        },
-                                                    ),
-                                                    span: Span {
-                                                        start: 104,
-                                                        end: 113,
-                                                    },
-                                                },
-                                            ],
-                                            arguments: [],
+                            WithSpan {
+                                item: IsographFieldDirective {
+                                    name: WithSpan {
+                                        item: IsographDirectiveName(
+                                            "allowed",
+                                        ),
+                                        span: Span {
+                                            start: 48,
+                                            end: 55,
                                         },
+                                    },
+                                    arguments: [],
+                                },
+                                span: Span {
+                                    start: 47,
+                                    end: 55,
+                                },
+                            },
+                            WithSpan {
+                                item: IsographFieldDirective {
+                                    name: WithSpan {
+                                        item: IsographDirectiveName(
+                                            "at",
+                                        ),
+                                        span: Span {
+                                            start: 57,
+                                            end: 59,
+                                        },
+                                    },
+                                    arguments: [],
+                                },
+                                span: Span {
+                                    start: 56,
+                                    end: 59,
+                                },
+                            },
+                            WithSpan {
+                                item: IsographFieldDirective {
+                                    name: WithSpan {
+                                        item: IsographDirectiveName(
+                                            "parse",
+                                        ),
+                                        span: Span {
+                                            start: 61,
+                                            end: 66,
+                                        },
+                                    },
+                                    arguments: [],
+                                },
+                                span: Span {
+                                    start: 60,
+                                    end: 66,
+                                },
+                            },
+                            WithSpan {
+                                item: IsographFieldDirective {
+                                    name: WithSpan {
+                                        item: IsographDirectiveName(
+                                            "time",
+                                        ),
+                                        span: Span {
+                                            start: 68,
+                                            end: 72,
+                                        },
+                                    },
+                                    arguments: [],
+                                },
+                                span: Span {
+                                    start: 67,
+                                    end: 72,
+                                },
+                            },
+                        ],
+                        const_export_name: ConstExportName(
+                            "pointer",
+                        ),
+                        parent_type: WithSpan {
+                            item: UnvalidatedTypeName(
+                                "User",
+                            ),
+                            span: Span {
+                                start: 11,
+                                end: 15,
+                            },
+                        },
+                        target_type: Named(
+                            GraphQLNamedTypeAnnotation(
+                                WithSpan {
+                                    item: UnvalidatedTypeName(
+                                        "User",
                                     ),
                                     span: Span {
-                                        start: 79,
-                                        end: 119,
+                                        start: 30,
+                                        end: 34,
                                     },
                                 },
-                            ],
-                            variable_definitions: [],
-                            definition_path: RelativePathToSourceFile(
-                                "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
                             ),
-                            pointer_keyword: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 3,
-                                    end: 10,
-                                },
-                            },
-                            dot: WithSpan {
-                                item: (),
-                                span: Span {
-                                    start: 15,
-                                    end: 16,
-                                },
+                        ),
+                        client_pointer_name: WithSpan {
+                            item: ClientObjectSelectableName(
+                                "bestFriend",
+                            ),
+                            span: Span {
+                                start: 16,
+                                end: 26,
                             },
                         },
-                        span: Span {
-                            start: 11,
-                            end: 123,
+                        description: None,
+                        selection_set: [
+                            WithSpan {
+                                item: Object(
+                                    LinkedFieldSelection {
+                                        name: WithLocation {
+                                            location: Embedded(
+                                                EmbeddedLocation {
+                                                    text_source: TextSource {
+                                                        current_working_directory: CurrentWorkingDirectory,
+                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                            "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
+                                                        ),
+                                                        span: Some(
+                                                            Span {
+                                                                start: 112,
+                                                                end: 236,
+                                                            },
+                                                        ),
+                                                    },
+                                                    span: Span {
+                                                        start: 79,
+                                                        end: 86,
+                                                    },
+                                                },
+                                            ),
+                                            item: ServerObjectSelectableName(
+                                                "friends",
+                                            ),
+                                        },
+                                        reader_alias: None,
+                                        associated_data: None(
+                                            EmptyDirectiveSet,
+                                        ),
+                                        selection_set: [
+                                            WithSpan {
+                                                item: Scalar(
+                                                    ScalarFieldSelection {
+                                                        name: WithLocation {
+                                                            location: Embedded(
+                                                                EmbeddedLocation {
+                                                                    text_source: TextSource {
+                                                                        current_working_directory: CurrentWorkingDirectory,
+                                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                                            "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
+                                                                        ),
+                                                                        span: Some(
+                                                                            Span {
+                                                                                start: 112,
+                                                                                end: 236,
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    span: Span {
+                                                                        start: 95,
+                                                                        end: 97,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            item: ScalarSelectableName(
+                                                                "id",
+                                                            ),
+                                                        },
+                                                        reader_alias: None,
+                                                        associated_data: None(
+                                                            EmptyDirectiveSet,
+                                                        ),
+                                                        arguments: [],
+                                                    },
+                                                ),
+                                                span: Span {
+                                                    start: 95,
+                                                    end: 97,
+                                                },
+                                            },
+                                            WithSpan {
+                                                item: Scalar(
+                                                    ScalarFieldSelection {
+                                                        name: WithLocation {
+                                                            location: Embedded(
+                                                                EmbeddedLocation {
+                                                                    text_source: TextSource {
+                                                                        current_working_directory: CurrentWorkingDirectory,
+                                                                        relative_path_to_source_file: RelativePathToSourceFile(
+                                                                            "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
+                                                                        ),
+                                                                        span: Some(
+                                                                            Span {
+                                                                                start: 112,
+                                                                                end: 236,
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    span: Span {
+                                                                        start: 104,
+                                                                        end: 113,
+                                                                    },
+                                                                },
+                                                            ),
+                                                            item: ScalarSelectableName(
+                                                                "closeness",
+                                                            ),
+                                                        },
+                                                        reader_alias: None,
+                                                        associated_data: None(
+                                                            EmptyDirectiveSet,
+                                                        ),
+                                                        arguments: [],
+                                                    },
+                                                ),
+                                                span: Span {
+                                                    start: 104,
+                                                    end: 113,
+                                                },
+                                            },
+                                        ],
+                                        arguments: [],
+                                    },
+                                ),
+                                span: Span {
+                                    start: 79,
+                                    end: 119,
+                                },
+                            },
+                        ],
+                        variable_definitions: [],
+                        definition_path: RelativePathToSourceFile(
+                            "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
+                        ),
+                        pointer_keyword: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 3,
+                                end: 10,
+                            },
+                        },
+                        dot: WithSpan {
+                            item: (),
+                            span: Span {
+                                start: 15,
+                                end: 16,
+                            },
                         },
                     },
-                ),
-                TextSource {
-                    current_working_directory: CurrentWorkingDirectory,
-                    relative_path_to_source_file: RelativePathToSourceFile(
-                        "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
-                    ),
-                    span: Some(
-                        Span {
-                            start: 112,
-                            end: 236,
-                        },
-                    ),
+                    span: Span {
+                        start: 11,
+                        end: 123,
+                    },
                 },
             ),
-        ],
-    ),
+            TextSource {
+                current_working_directory: CurrentWorkingDirectory,
+                relative_path_to_source_file: RelativePathToSourceFile(
+                    "crates/isograph_lang_parser/fixtures/pointer-directives.input.js",
+                ),
+                span: Some(
+                    Span {
+                        start: 112,
+                        end: 236,
+                    },
+                ),
+            },
+        ),
+    ],
 )

--- a/crates/isograph_lang_parser/src/isograph_literal_parse_error.rs
+++ b/crates/isograph_lang_parser/src/isograph_literal_parse_error.rs
@@ -10,7 +10,7 @@ pub(crate) type ParseResultWithLocation<T> = Result<T, WithLocation<IsographLite
 pub(crate) type ParseResultWithSpan<T> = Result<T, WithSpan<IsographLiteralParseError>>;
 
 /// Errors tha make semantic sense when referring to parsing a Isograph literal
-#[derive(Error, Eq, PartialEq, Debug)]
+#[derive(Error, Clone, Eq, PartialEq, Debug)]
 pub enum IsographLiteralParseError {
     #[error("{error}")]
     ParseError { error: LowLevelParseError },

--- a/crates/isograph_lang_parser/src/peekable_lexer.rs
+++ b/crates/isograph_lang_parser/src/peekable_lexer.rs
@@ -170,7 +170,7 @@ type LowLevelParseResult<T> = Result<T, WithSpan<LowLevelParseError>>;
 
 /// Low-level errors. If peekable_lexer could be made generic (it can't because it needs to know
 /// about EOF), these would belong in a different crate than the parser itself.
-#[derive(Error, Eq, PartialEq, Debug)]
+#[derive(Error, Clone, Eq, PartialEq, Debug)]
 pub enum LowLevelParseError {
     #[error("Expected {expected_kind}, found {found_kind}.")]
     ParseTokenKindError {

--- a/crates/isograph_lang_types/Cargo.toml
+++ b/crates/isograph_lang_types/Cargo.toml
@@ -8,6 +8,8 @@ license = { workspace = true }
 common_lang_types = { path = "../common_lang_types" }
 graphql_lang_types = { path = "../graphql_lang_types" }
 intern = { path = "../../relay-crates/intern" }
+pico = { path = "../pico" }
+pico_macros = { path = "../pico_macros" }
 u32_newtypes = { path = "../u32_newtypes" }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/isograph_lang_types/src/lib.rs
+++ b/crates/isograph_lang_types/src/lib.rs
@@ -5,6 +5,7 @@ mod id_types;
 mod isograph_directives;
 mod isograph_type_annotation;
 mod selection_directive_set;
+mod source_types;
 
 pub use base_types::*;
 pub use client_field_declaration::*;
@@ -13,3 +14,4 @@ pub use id_types::*;
 pub use isograph_directives::*;
 pub use isograph_type_annotation::*;
 pub use selection_directive_set::*;
+pub use source_types::*;

--- a/crates/isograph_lang_types/src/source_types.rs
+++ b/crates/isograph_lang_types/src/source_types.rs
@@ -1,0 +1,17 @@
+use common_lang_types::{RelativePathToSourceFile, TextSource};
+use pico_macros::Source;
+
+#[derive(Debug, Clone, PartialEq, Eq, Source)]
+pub struct SchemaSource {
+    #[key]
+    pub relative_path: RelativePathToSourceFile,
+    pub content: String,
+    pub text_source: TextSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Source)]
+pub struct IsoLiteralsSource {
+    #[key]
+    pub relative_path: RelativePathToSourceFile,
+    pub content: String,
+}

--- a/crates/isograph_schema/Cargo.toml
+++ b/crates/isograph_schema/Cargo.toml
@@ -13,6 +13,8 @@ impl_base_types_macro = { path = "../impl_base_types_macro" }
 intern = { path = "../../relay-crates/intern" }
 isograph_lang_types = { path = "../isograph_lang_types" }
 isograph_config = { path = "../isograph_config" }
+pico = { path = "../pico" }
+pico_macros = { path = "../pico_macros" }
 thiserror = { workspace = true }
 lazy_static = { workspace = true }
 colorize = { workspace = true }

--- a/crates/isograph_schema/src/create_additional_fields/create_additional_fields_error.rs
+++ b/crates/isograph_schema/src/create_additional_fields/create_additional_fields_error.rs
@@ -48,7 +48,7 @@ pub(crate) type ProcessTypeDefinitionResult<T> =
     Result<T, WithLocation<CreateAdditionalFieldsError>>;
 
 /// Errors that make semantic sense when referring to creating a GraphQL schema in-memory representation
-#[derive(Error, Eq, PartialEq, Debug)]
+#[derive(Error, Clone, Eq, PartialEq, Debug)]
 pub enum CreateAdditionalFieldsError {
     #[error(
         "The Isograph compiler attempted to create a field named \

--- a/crates/isograph_schema/src/output_format.rs
+++ b/crates/isograph_schema/src/output_format.rs
@@ -1,7 +1,9 @@
 use std::{error::Error, fmt::Debug, hash::Hash};
 
-use common_lang_types::{QueryOperationName, QueryText, RelativePathToSourceFile};
-use isograph_config::{AbsolutePathAndRelativePath, CompilerConfig, CompilerConfigOptions};
+use common_lang_types::{QueryOperationName, QueryText};
+use isograph_config::CompilerConfigOptions;
+use isograph_lang_types::SchemaSource;
+use pico::{Database, MemoRef, SourceId};
 
 use crate::{
     EncounteredRootTypes, MergedSelectionMap, RootOperationName, TypeRefinementMaps,
@@ -15,18 +17,20 @@ where
 {
     // These two types should be combined into a single type, this is a
     // GraphQL-ism leaking in
-    type TypeSystemDocument: Debug + Clone;
-    type TypeSystemExtensionDocument: Debug + Clone;
+    type TypeSystemDocument: Debug + Clone + 'static;
+    type TypeSystemExtensionDocument: Debug + Clone + 'static;
 
     type SchemaObjectAssociatedData: Debug;
 
-    fn read_and_parse_type_system_document(
-        config: &CompilerConfig,
-    ) -> Result<Self::TypeSystemDocument, Box<dyn Error>>;
-    fn read_and_parse_type_system_extension_document(
-        schema_extension_path: &AbsolutePathAndRelativePath,
-        config: &CompilerConfig,
-    ) -> Result<(RelativePathToSourceFile, Self::TypeSystemExtensionDocument), Box<dyn Error>>;
+    fn parse_type_system_document(
+        db: &Database,
+        schema_source_id: SourceId<SchemaSource>,
+    ) -> Result<MemoRef<Self::TypeSystemDocument>, Box<dyn Error>>;
+
+    fn parse_type_system_extension_document(
+        db: &Database,
+        schema_extension_source_id: SourceId<SchemaSource>,
+    ) -> Result<MemoRef<Self::TypeSystemExtensionDocument>, Box<dyn Error>>;
 
     // TODO refactor this to return a Vec or Iterator of IsographObjectDefinition or the like,
     // instead of mutating the UnvalidatedSchema


### PR DESCRIPTION
This is the first iteration of applying `Pico` to the Isograph compiler.

This implementation recreates what we are currently doing in the `main` branch by memoizing only parsed sources. It has slightly worse performance due to pico overhead.

What has been done:
- extracted creating `source_files` step from the `compile` function 
- removed intermediate `SourceFiles` structure (now it is a struct of `SourceId`)
- added 3 memoized functions that parse source texts
- all parse functions inlined into the `create_unvalidated_schema` step awaiting further refactoring
- added simple GC call that runs no sooner than 60 secs after the last change