### PR TITLE
Split selectables into two structs: Object selectable and scalar selectable

### DIFF
--- a/crates/generate_artifacts/src/eager_reader_artifact.rs
+++ b/crates/generate_artifacts/src/eager_reader_artifact.rs
@@ -5,11 +5,11 @@ use isograph_config::{CompilerConfig, GenerateFileExtensionsOption};
 
 use isograph_schema::{
     initial_variable_context, ClientField, ClientFieldOrPointer, NetworkProtocol, Schema,
-    ValidatedSelectionType,
+    ServerObjectSelectable, ValidatedSelectionType,
 };
 use isograph_schema::{
-    RefetchedPathsMap, ServerFieldTypeAssociatedDataInlineFragment, ServerScalarSelectable,
-    UserWrittenClientTypeInfo, UserWrittenComponentVariant,
+    RefetchedPathsMap, ServerFieldTypeAssociatedDataInlineFragment, UserWrittenClientTypeInfo,
+    UserWrittenComponentVariant,
 };
 
 use std::{borrow::Cow, collections::BTreeSet, path::PathBuf};
@@ -151,7 +151,7 @@ pub(crate) fn generate_eager_reader_artifacts<TNetworkProtocol: NetworkProtocol>
 
 pub(crate) fn generate_eager_reader_condition_artifact<TNetworkProtocol: NetworkProtocol>(
     schema: &Schema<TNetworkProtocol>,
-    encountered_server_field: &ServerScalarSelectable<TNetworkProtocol>,
+    encountered_server_field: &ServerObjectSelectable<TNetworkProtocol>,
     inline_fragment: &ServerFieldTypeAssociatedDataInlineFragment,
     refetch_paths: &RefetchedPathsMap,
     file_extensions: GenerateFileExtensionsOption,
@@ -224,7 +224,6 @@ pub(crate) fn generate_eager_reader_param_type_artifact<TNetworkProtocol: Networ
     let client_field_parameter_type = generate_client_field_parameter_type(
         schema,
         client_field.selection_set_for_parent_query(),
-        parent_type,
         &mut param_type_imports,
         &mut loadable_fields,
         1,
@@ -233,7 +232,6 @@ pub(crate) fn generate_eager_reader_param_type_artifact<TNetworkProtocol: Networ
     let updatable_data_type = generate_client_field_updatable_data_type(
         schema,
         client_field.selection_set_for_parent_query(),
-        parent_type,
         &mut param_type_imports,
         &mut loadable_fields,
         1,

--- a/crates/isograph_lang_types/src/id_types.rs
+++ b/crates/isograph_lang_types/src/id_types.rs
@@ -4,6 +4,7 @@ use crate::SelectionType;
 
 // Any field defined on the server
 u32_newtype!(ServerScalarSelectableId);
+u32_newtype!(ServerObjectSelectableId);
 // A field that acts as an id
 u32_newtype!(ServerStrongIdFieldId);
 

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -12,8 +12,8 @@ use intern::string_key::Intern;
 use isograph_lang_types::{
     ArgumentKeyAndValue, ClientFieldId, DefinitionLocation, EmptyDirectiveSet, NonConstantValue,
     RefetchQueryIndex, ScalarSelectionDirectiveSet, SelectionFieldArgument, SelectionType,
-    SelectionTypeContainingSelections, ServerEntityId, ServerObjectId, ServerScalarId,
-    ServerScalarSelectableId, VariableDefinition,
+    SelectionTypeContainingSelections, ServerEntityId, ServerObjectId, ServerObjectSelectableId,
+    ServerScalarId, VariableDefinition,
 };
 use lazy_static::lazy_static;
 
@@ -33,7 +33,7 @@ pub type MergedSelectionMap = BTreeMap<NormalizationKey, MergedServerSelection>;
 
 // Maybe this should be FNVHashMap? We don't really need stable iteration order
 pub type FieldToCompletedMergeTraversalStateMap = BTreeMap<
-    DefinitionLocation<ServerScalarSelectableId, ClientFieldOrPointerId>,
+    DefinitionLocation<ServerObjectSelectableId, ClientFieldOrPointerId>,
     FieldTraversalResult,
 >;
 
@@ -409,7 +409,7 @@ pub fn create_merged_selection_map_for_field_and_insert_into_global_map<
     parent_type: &SchemaObject<TNetworkProtocol>,
     validated_selections: &[WithSpan<ValidatedSelection>],
     encountered_client_type_map: &mut FieldToCompletedMergeTraversalStateMap,
-    root_field_id: DefinitionLocation<ServerScalarSelectableId, ClientFieldOrPointerId>,
+    root_field_id: DefinitionLocation<ServerObjectSelectableId, ClientFieldOrPointerId>,
     variable_context: &VariableContext,
     // TODO return Cow?
 ) -> FieldTraversalResult {
@@ -772,154 +772,141 @@ fn merge_validated_selections_into_selection_map<TNetworkProtocol: NetworkProtoc
                         )
                     }
                     DefinitionLocation::Server(server_field_id) => {
-                        let server_field = schema.server_scalar_selectable(server_field_id);
+                        let server_field = schema.server_object_selectable(server_field_id);
 
-                        match &server_field.target_server_entity {
-                            SelectionType::Scalar(_) => {}
-                            SelectionType::Object((object_selectable_variant, _)) => {
-                                match &object_selectable_variant {
-                                    SchemaServerObjectSelectableVariant::InlineFragment(
-                                        inline_fragment_variant,
-                                    ) => {
-                                        let type_to_refine_to = object_selection_parent_object.name;
-                                        let normalization_key =
-                                            NormalizationKey::InlineFragment(type_to_refine_to);
+                        match &server_field.object_selectable_variant {
+                            SchemaServerObjectSelectableVariant::InlineFragment(
+                                inline_fragment_variant,
+                            ) => {
+                                let type_to_refine_to = object_selection_parent_object.name;
+                                let normalization_key =
+                                    NormalizationKey::InlineFragment(type_to_refine_to);
 
-                                        let inline_fragment = parent_map
-                                            .entry(normalization_key)
-                                            .or_insert_with(|| {
-                                                MergedServerSelection::InlineFragment(
-                                                    MergedInlineFragmentSelection {
-                                                        type_to_refine_to,
-                                                        selection_map: BTreeMap::new(),
-                                                    },
-                                                )
-                                            });
+                                let inline_fragment =
+                                    parent_map.entry(normalization_key).or_insert_with(|| {
+                                        MergedServerSelection::InlineFragment(
+                                            MergedInlineFragmentSelection {
+                                                type_to_refine_to,
+                                                selection_map: BTreeMap::new(),
+                                            },
+                                        )
+                                    });
 
-                                        match inline_fragment {
-                                            MergedServerSelection::ScalarField(_) => {
-                                                panic!(
-                                                    "Expected inline fragment, but encountered scalar. \
+                                match inline_fragment {
+                                    MergedServerSelection::ScalarField(_) => {
+                                        panic!(
+                                            "Expected inline fragment, but encountered scalar. \
                                                     This is indicative of a bug in Isograph."
-                                                )
-                                            }
-                                            MergedServerSelection::LinkedField(_) => {
-                                                panic!(
+                                        )
+                                    }
+                                    MergedServerSelection::LinkedField(_) => {
+                                        panic!(
                                                     "Expected inline fragment, but encountered linked field. \
                                                     This is indicative of a bug in Isograph."
                                                 )
-                                            }
-                                            MergedServerSelection::InlineFragment(
-                                                existing_inline_fragment,
-                                            ) => {
-                                                let object_selection_parent_object = schema
-                                                    .server_field_data
-                                                    .object(object_selection_parent_object.id);
+                                    }
+                                    MergedServerSelection::InlineFragment(
+                                        existing_inline_fragment,
+                                    ) => {
+                                        let object_selection_parent_object = schema
+                                            .server_field_data
+                                            .object(object_selection_parent_object.id);
 
-                                                merge_validated_selections_into_selection_map(
-                                                    schema,
-                                                    &mut existing_inline_fragment.selection_map,
-                                                    object_selection_parent_object,
-                                                    &inline_fragment_variant.reader_selection_set,
-                                                    merge_traversal_state,
-                                                    encountered_client_field_map,
-                                                    variable_context,
-                                                );
-                                                merge_validated_selections_into_selection_map(
-                                                    schema,
-                                                    &mut existing_inline_fragment.selection_map,
-                                                    object_selection_parent_object,
-                                                    &object_selection.selection_set,
-                                                    merge_traversal_state,
-                                                    encountered_client_field_map,
-                                                    variable_context,
-                                                );
+                                        merge_validated_selections_into_selection_map(
+                                            schema,
+                                            &mut existing_inline_fragment.selection_map,
+                                            object_selection_parent_object,
+                                            &inline_fragment_variant.reader_selection_set,
+                                            merge_traversal_state,
+                                            encountered_client_field_map,
+                                            variable_context,
+                                        );
+                                        merge_validated_selections_into_selection_map(
+                                            schema,
+                                            &mut existing_inline_fragment.selection_map,
+                                            object_selection_parent_object,
+                                            &object_selection.selection_set,
+                                            merge_traversal_state,
+                                            encountered_client_field_map,
+                                            variable_context,
+                                        );
 
-                                                let server_field = schema.server_scalar_selectable(
-                                                    inline_fragment_variant.server_field_id,
-                                                );
+                                        let server_object_selectable = schema
+                                            .server_object_selectable(
+                                                inline_fragment_variant.server_object_selectable_id,
+                                            );
 
-                                                create_merged_selection_map_for_field_and_insert_into_global_map(
+                                        create_merged_selection_map_for_field_and_insert_into_global_map(
                                                     schema,
                                                     parent_object,
                                                     &object_selection.selection_set,
                                                     encountered_client_field_map,
-                                                    DefinitionLocation::Server(inline_fragment_variant.server_field_id),
-                                                    &server_field.initial_variable_context()
+                                                    DefinitionLocation::Server(inline_fragment_variant.server_object_selectable_id),
+                                                    &server_object_selectable.initial_variable_context()
                                                 );
-                                            }
-                                        }
                                     }
-                                    SchemaServerObjectSelectableVariant::LinkedField => {
-                                        let normalization_key =
-                                            create_transformed_name_and_arguments(
-                                                object_selection.name.item.into(),
-                                                &object_selection.arguments,
-                                                variable_context,
-                                            )
-                                            .normalization_key();
+                                }
+                            }
+                            SchemaServerObjectSelectableVariant::LinkedField => {
+                                let normalization_key = create_transformed_name_and_arguments(
+                                    object_selection.name.item.into(),
+                                    &object_selection.arguments,
+                                    variable_context,
+                                )
+                                .normalization_key();
 
-                                        merge_traversal_state
-                                            .traversal_path
-                                            .push(normalization_key.clone());
+                                merge_traversal_state
+                                    .traversal_path
+                                    .push(normalization_key.clone());
 
-                                        // We are creating the linked field, and inserting it into the parent object
-                                        // first, because otherwise, when we try to merge the results into the parent
-                                        // selection_map, we find that the linked field we are about to insert is
-                                        // missing, and panic.
-                                        //
-                                        // This might be indicative of poor modeling.
-                                        let linked_field = parent_map
-                                            .entry(normalization_key)
-                                            .or_insert_with(|| {
-                                                MergedServerSelection::LinkedField(
-                                                    MergedLinkedFieldSelection {
-                                                        concrete_type: object_selection
-                                                            .associated_data
-                                                            .concrete_type,
-                                                        name: object_selection.name.item,
-                                                        selection_map: BTreeMap::new(),
-                                                        arguments:
-                                                            transform_arguments_with_child_context(
-                                                                object_selection
-                                                                    .arguments
-                                                                    .iter()
-                                                                    .map(|arg| {
-                                                                        arg.item
-                                                                            .into_key_and_value()
-                                                                    }),
-                                                                variable_context,
-                                                            ),
-                                                    },
-                                                )
-                                            });
-                                        match linked_field {
-                                            MergedServerSelection::ScalarField(_) => {
-                                                panic!(
-                                                    "Expected linked field, but encountered scalar. \
-                                                    This is indicative of a bug in Isograph."
-                                                )
-                                            }
-                                            MergedServerSelection::LinkedField(
-                                                existing_linked_field,
-                                            ) => {
-                                                merge_validated_selections_into_selection_map(
-                                                    schema,
-                                                    &mut existing_linked_field.selection_map,
-                                                    object_selection_parent_object,
-                                                    &object_selection.selection_set,
-                                                    merge_traversal_state,
-                                                    encountered_client_field_map,
+                                // We are creating the linked field, and inserting it into the parent object
+                                // first, because otherwise, when we try to merge the results into the parent
+                                // selection_map, we find that the linked field we are about to insert is
+                                // missing, and panic.
+                                //
+                                // This might be indicative of poor modeling.
+                                let linked_field =
+                                    parent_map.entry(normalization_key).or_insert_with(|| {
+                                        MergedServerSelection::LinkedField(
+                                            MergedLinkedFieldSelection {
+                                                concrete_type: object_selection
+                                                    .associated_data
+                                                    .concrete_type,
+                                                name: object_selection.name.item,
+                                                selection_map: BTreeMap::new(),
+                                                arguments: transform_arguments_with_child_context(
+                                                    object_selection
+                                                        .arguments
+                                                        .iter()
+                                                        .map(|arg| arg.item.into_key_and_value()),
                                                     variable_context,
-                                                );
-                                            }
-                                            MergedServerSelection::InlineFragment(_) => {
-                                                panic!(
+                                                ),
+                                            },
+                                        )
+                                    });
+                                match linked_field {
+                                    MergedServerSelection::ScalarField(_) => {
+                                        panic!(
+                                            "Expected linked field, but encountered scalar. \
+                                                    This is indicative of a bug in Isograph."
+                                        )
+                                    }
+                                    MergedServerSelection::LinkedField(existing_linked_field) => {
+                                        merge_validated_selections_into_selection_map(
+                                            schema,
+                                            &mut existing_linked_field.selection_map,
+                                            object_selection_parent_object,
+                                            &object_selection.selection_set,
+                                            merge_traversal_state,
+                                            encountered_client_field_map,
+                                            variable_context,
+                                        );
+                                    }
+                                    MergedServerSelection::InlineFragment(_) => {
+                                        panic!(
                                                     "Expected linked field, but encountered inline fragment. \
                                                     This is indicative of a bug in Isograph."
                                                 )
-                                            }
-                                        }
                                     }
                                 }
                             }

--- a/crates/isograph_schema/src/definition_location_fns.rs
+++ b/crates/isograph_schema/src/definition_location_fns.rs
@@ -1,12 +1,12 @@
 use common_lang_types::DescriptionValue;
-use isograph_lang_types::{DefinitionLocation, SelectionType, ServerObjectId, TypeAnnotation};
+use isograph_lang_types::{DefinitionLocation, ServerObjectId, TypeAnnotation};
 
-use crate::{ClientPointer, NetworkProtocol, ServerScalarSelectable};
+use crate::{ClientPointer, NetworkProtocol, ServerObjectSelectable};
 
 #[allow(clippy::type_complexity)]
 pub fn description<TNetworkProtocol: NetworkProtocol>(
     definition_location: &DefinitionLocation<
-        &ServerScalarSelectable<TNetworkProtocol>,
+        &ServerObjectSelectable<TNetworkProtocol>,
         &ClientPointer<TNetworkProtocol>,
     >,
 ) -> Option<DescriptionValue> {
@@ -18,20 +18,12 @@ pub fn description<TNetworkProtocol: NetworkProtocol>(
 
 pub fn output_type_annotation<'a, TNetworkProtocol: NetworkProtocol>(
     definition_location: &'a DefinitionLocation<
-        &ServerScalarSelectable<TNetworkProtocol>,
+        &ServerObjectSelectable<TNetworkProtocol>,
         &ClientPointer<TNetworkProtocol>,
     >,
 ) -> &'a TypeAnnotation<ServerObjectId> {
     match definition_location {
         DefinitionLocation::Client(client_pointer) => &client_pointer.to,
-        DefinitionLocation::Server(server_field) => match &server_field.target_server_entity {
-            SelectionType::Scalar(_) => {
-                panic!(
-                    "output_type_id should be an object. \
-                    This is indicative of a bug in Isograph.",
-                )
-            }
-            SelectionType::Object((_, type_annotation)) => type_annotation,
-        },
+        DefinitionLocation::Server(server_field) => &server_field.target_object_entity,
     }
 }

--- a/crates/isograph_schema/src/server_scalar_and_object.rs
+++ b/crates/isograph_schema/src/server_scalar_and_object.rs
@@ -7,11 +7,10 @@ use common_lang_types::{
 use graphql_lang_types::{GraphQLConstantValue, GraphQLDirective};
 use impl_base_types_macro::impl_for_selection_type;
 use isograph_lang_types::{
-    DefinitionLocation, SelectionType, ServerObjectId, ServerScalarId, ServerScalarSelectableId,
-    ServerStrongIdFieldId,
+    DefinitionLocation, SelectionType, ServerObjectId, ServerScalarId, ServerStrongIdFieldId,
 };
 
-use crate::{ClientFieldOrPointerId, NetworkProtocol};
+use crate::{ClientFieldOrPointerId, NetworkProtocol, ServerScalarOrObjectSelectableId};
 
 /// A scalar type in the schema.
 #[derive(Debug)]
@@ -23,8 +22,10 @@ pub struct SchemaScalar<TNetworkProtocol: NetworkProtocol> {
     pub output_format: PhantomData<TNetworkProtocol>,
 }
 
-pub type ObjectEncounteredFields =
-    BTreeMap<SelectableName, DefinitionLocation<ServerScalarSelectableId, ClientFieldOrPointerId>>;
+pub type ObjectEncounteredFields = BTreeMap<
+    SelectableName,
+    DefinitionLocation<ServerScalarOrObjectSelectableId, ClientFieldOrPointerId>,
+>;
 
 /// An object type in the schema.
 #[derive(Debug)]

--- a/crates/isograph_schema/src/validate_use_of_arguments.rs
+++ b/crates/isograph_schema/src/validate_use_of_arguments.rs
@@ -110,14 +110,14 @@ fn validate_use_of_arguments_for_client_type<TNetworkProtocol: NetworkProtocol>(
             }
             SelectionType::Object(object_selection) => {
                 let field_argument_definitions = match object_selection.associated_data.field_id {
-                    DefinitionLocation::Server(s) => schema
-                        .server_scalar_selectable(s)
+                    DefinitionLocation::Server(object_selectable_id) => schema
+                        .server_object_selectable(object_selectable_id)
                         .arguments
                         .iter()
                         .map(|x| &x.item)
                         .collect::<Vec<_>>(),
-                    DefinitionLocation::Client(c) => schema
-                        .client_pointer(c)
+                    DefinitionLocation::Client(pointer_id) => schema
+                        .client_pointer(pointer_id)
                         .variable_definitions
                         .iter()
                         .map(|x| &x.item)
@@ -179,6 +179,7 @@ fn validate_use_of_arguments_impl<TNetworkProtocol: NetworkProtocol>(
                         client_type_variable_definitions,
                         &schema.server_field_data,
                         &schema.server_scalar_selectables,
+                        &schema.server_object_selectables,
                     )
                     .map_err(|with_location| with_location.map(|e| e.into())),
                 );

--- a/crates/isograph_schema/src/variable_context.rs
+++ b/crates/isograph_schema/src/variable_context.rs
@@ -8,7 +8,7 @@ use isograph_lang_types::{
 
 use crate::{
     ClientField, ClientFieldOrPointer, ClientPointer, NameAndArguments, NetworkProtocol,
-    ServerScalarSelectable, ValidatedVariableDefinition,
+    ServerObjectSelectable, ServerScalarSelectable, ValidatedVariableDefinition,
 };
 
 #[derive(Debug)]
@@ -121,6 +121,23 @@ pub fn initial_variable_context<TNetworkProtocol: NetworkProtocol>(
 }
 
 impl<TNetworkProtocol: NetworkProtocol> ServerScalarSelectable<TNetworkProtocol> {
+    pub fn initial_variable_context(&self) -> VariableContext {
+        let variable_context = self
+            .arguments
+            .iter()
+            .map(|variable_definition| {
+                (
+                    variable_definition.item.name.item,
+                    NonConstantValue::Variable(variable_definition.item.name.item),
+                )
+            })
+            .collect();
+
+        VariableContext(variable_context)
+    }
+}
+
+impl<TNetworkProtocol: NetworkProtocol> ServerObjectSelectable<TNetworkProtocol> {
     pub fn initial_variable_context(&self) -> VariableContext {
         let variable_context = self
             .arguments


### PR DESCRIPTION
# What

- There previously was a struct `ServerScalarSelectable` which was incorrectly named, and which was actually `ServerSelectable`, i.e. it could represent both a scalar selectable (i.e. scalar field) and an object selectable (linked field)
- Now these are two separate fields, importantly, with `ServerScalarSelectable` having a field `target_scalar_entity: TypeAnnotation<ServerScalarId>,` and `ServerObjectSelectable` having ` target_object_entity: TypeAnnotation<ServerObjectId>,`.
- This allows us to avoid redundant checks and avoid panics in our codebase! (This PR gets rid of 4 expects and 5 panics, but this isn't an exact count.)
- Namely, once we are in a fully validated state, we can go from scalar selection -> scalar selectable -> scalar entity without any panics (in "user" code, at least). Namely, there we don't have to do `.as_scalar().expect(...)` or the like. NICE

# Big picture: what's next

- Relax? Drink a beer? Celebrate? NO.
- The next big goal is to do two things
    - Dissemble the schema (and store the parts in pico)
    - Make "validation" pull-based, (e.g. if we are validating a single selection, we just need to validate its selectable, and thus its scalar entity, not anything else). It's not really validation, though, it's more like "dissembled schema creation". 

## What does that mean

- If we open up VSCode and the isograph language server is running, and the initial request is to provide hover information for "name" in:
```
field User.UserName {
  pet {
    name
  }
  other_fields
}
```
- We can do the following:
    - (if possible) split the GraphQL schema into chunks, creating a map of each entity type/field name (e.g. `User`, `User.pet`, `Pet`, `Pet.name`, `String`) to a vec of unparsed chunks (with only one item)
    - do the bare minimum of parsing of iso literals, i.e. just parse their declarations, and thus add `User.UserName` -> unprocessed chunk to that map
    - validate that `User` exists by looking up `User` in the chunks DB. Validate that it is an object
    - validate that `User.UserName` is unique
    - break apart the selection set into chunks and identify the chunk under the cursor
    - validate that `User.name` exists and is an object, look up where it points (`Pet`)
    - validate that `Pet` exists and is an object
    - break apart the nested selection set `{ name }` into chunks (i.e. a single chunk) and pick the chunk under the cursor (the only chunk)
    - validate that `Pet.name` exists and is a scalar, look up where it points (`String`)
    - validate that `String` exists and is a scalar
    - Show information about the `String` scalar, `name` field, `Pet` entity.

- What we didn't do
    - validate the selection `other_selection` is valid
    - validate any other type or selectable

- We can consider:
    - validating that `UserName` is unique asynchronously, but presumably we need to at least create a map of `selectable -> chunk` in advance, since otherwise how would we know where to find items in the selection set we are parsing
    
Step 3: profit