### PR TITLE
Combine two NetworkProtocol trait methods into one

### DIFF
--- a/crates/graphql_network_protocol/src/graphql_network_protocol.rs
+++ b/crates/graphql_network_protocol/src/graphql_network_protocol.rs
@@ -1,6 +1,6 @@
-use std::error::Error;
+use std::{collections::BTreeMap, error::Error};
 
-use common_lang_types::{QueryOperationName, QueryText};
+use common_lang_types::{QueryOperationName, QueryText, RelativePathToSourceFile};
 use graphql_lang_types::{GraphQLTypeSystemDocument, GraphQLTypeSystemExtensionDocument};
 use isograph_lang_types::SchemaSource;
 use isograph_schema::{
@@ -10,7 +10,7 @@ use isograph_schema::{
 use pico::{Database, MemoRef, SourceId};
 
 use crate::{
-    parse_graphql_schema, parse_schema_extensions_file,
+    parse_graphql_schema,
     process_type_system_definition::{
         process_graphql_type_extension_document, process_graphql_type_system_document,
     },
@@ -27,18 +27,18 @@ impl NetworkProtocol for GraphQLNetworkProtocol {
 
     type SchemaObjectAssociatedData = GraphQLSchemaObjectAssociatedData;
 
-    fn parse_type_system_document(
+    fn parse_type_system_documents(
         db: &Database,
         schema_source_id: SourceId<SchemaSource>,
-    ) -> Result<MemoRef<Self::TypeSystemDocument>, Box<dyn Error>> {
-        Ok(parse_graphql_schema(db, schema_source_id).to_owned()?)
-    }
-
-    fn parse_type_system_extension_document(
-        db: &Database,
-        schema_extension_source_id: SourceId<SchemaSource>,
-    ) -> Result<MemoRef<Self::TypeSystemExtensionDocument>, Box<dyn Error>> {
-        Ok(parse_schema_extensions_file(db, schema_extension_source_id).to_owned()?)
+        schema_extension_sources: &BTreeMap<RelativePathToSourceFile, SourceId<SchemaSource>>,
+    ) -> Result<
+        (
+            MemoRef<Self::TypeSystemDocument>,
+            BTreeMap<RelativePathToSourceFile, MemoRef<Self::TypeSystemExtensionDocument>>,
+        ),
+        Box<dyn Error>,
+    > {
+        Ok(parse_graphql_schema(db, schema_source_id, schema_extension_sources).to_owned()?)
     }
 
     fn process_type_system_document(

--- a/crates/graphql_network_protocol/src/read_schema.rs
+++ b/crates/graphql_network_protocol/src/read_schema.rs
@@ -1,6 +1,6 @@
-use std::{path::PathBuf, str::Utf8Error};
+use std::{collections::BTreeMap, path::PathBuf, str::Utf8Error};
 
-use common_lang_types::WithLocation;
+use common_lang_types::{RelativePathToSourceFile, WithLocation};
 use graphql_lang_types::{GraphQLTypeSystemDocument, GraphQLTypeSystemExtensionDocument};
 use graphql_schema_parser::{parse_schema, parse_schema_extensions, SchemaParseError};
 use isograph_lang_types::SchemaSource;
@@ -8,20 +8,36 @@ use pico::{Database, MemoRef, SourceId};
 use pico_macros::memo;
 use thiserror::Error;
 
+#[allow(clippy::type_complexity)]
 #[memo]
 pub fn parse_graphql_schema(
     db: &Database,
     schema_source_id: SourceId<SchemaSource>,
-) -> Result<MemoRef<GraphQLTypeSystemDocument>, BatchCompileError> {
+    schema_extension_sources: &BTreeMap<RelativePathToSourceFile, SourceId<SchemaSource>>,
+) -> Result<
+    (
+        MemoRef<GraphQLTypeSystemDocument>,
+        BTreeMap<RelativePathToSourceFile, MemoRef<GraphQLTypeSystemExtensionDocument>>,
+    ),
+    BatchCompileError,
+> {
     let SchemaSource {
         content,
         text_source,
         ..
     } = db.get(schema_source_id);
+
     let schema = parse_schema(content, *text_source)
-        .map(|document| db.intern(document))
         .map_err(|with_span| with_span.to_with_location(*text_source))?;
-    Ok(schema)
+
+    let mut schema_extensions = BTreeMap::new();
+    for (relative_path, schema_extension_source_id) in schema_extension_sources.iter() {
+        let extensions_document =
+            parse_schema_extensions_file(db, *schema_extension_source_id).to_owned()?;
+        schema_extensions.insert(*relative_path, extensions_document);
+    }
+
+    Ok((db.intern(schema), schema_extensions))
 }
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
@@ -64,8 +80,7 @@ pub fn parse_schema_extensions_file(
         ..
     } = db.get(schema_extension_source_id);
     let schema_extensions = parse_schema_extensions(content, *text_source)
-        .map(|document| db.intern(document))
         .map_err(|with_span| with_span.to_with_location(*text_source))?;
 
-    Ok(schema_extensions)
+    Ok(db.intern(schema_extensions))
 }

--- a/crates/isograph_schema/src/network_protocol.rs
+++ b/crates/isograph_schema/src/network_protocol.rs
@@ -1,6 +1,6 @@
-use std::{error::Error, fmt::Debug, hash::Hash};
+use std::{collections::BTreeMap, error::Error, fmt::Debug, hash::Hash};
 
-use common_lang_types::{QueryOperationName, QueryText};
+use common_lang_types::{QueryOperationName, QueryText, RelativePathToSourceFile};
 use isograph_config::CompilerConfigOptions;
 use isograph_lang_types::SchemaSource;
 use pico::{Database, MemoRef, SourceId};
@@ -22,15 +22,18 @@ where
 
     type SchemaObjectAssociatedData: Debug;
 
-    fn parse_type_system_document(
+    #[allow(clippy::type_complexity)]
+    fn parse_type_system_documents(
         db: &Database,
         schema_source_id: SourceId<SchemaSource>,
-    ) -> Result<MemoRef<Self::TypeSystemDocument>, Box<dyn Error>>;
-
-    fn parse_type_system_extension_document(
-        db: &Database,
-        schema_extension_source_id: SourceId<SchemaSource>,
-    ) -> Result<MemoRef<Self::TypeSystemExtensionDocument>, Box<dyn Error>>;
+        schema_extension_sources: &BTreeMap<RelativePathToSourceFile, SourceId<SchemaSource>>,
+    ) -> Result<
+        (
+            MemoRef<Self::TypeSystemDocument>,
+            BTreeMap<RelativePathToSourceFile, MemoRef<Self::TypeSystemExtensionDocument>>,
+        ),
+        Box<dyn Error>,
+    >;
 
     // TODO refactor this to return a Vec or Iterator of IsographObjectDefinition or the like,
     // instead of mutating the Schema


### PR DESCRIPTION
- Combine NetworkProtocol's parse_type_system_document and parse_type_system_extension_document into parse_type_system_documents
- This is an initial step; the goal is to also combine process_type_system_document and process_type_system_extension_document into a single method that returns an object and doesn't mutate schema

@ch1ffa can you review? In particular, am I doing the right thing with

```
    Result<
        MemoRef<(
            Self::TypeSystemDocument,
            BTreeMap<RelativePathToSourceFile, Self::TypeSystemExtensionDocument>,
        )>,
        E
    >
```

My heuristic is that the correct (and performant) thing to do is to wrap `T` in `Result<T, E>` in `MemoRef`, so that we don't clone the underlying `T` excessively.

We still need to clone the underlying object in `create_unvalidated_schema`, which might not be necessary when we unify all of the methods, or I can try to refactor out in the future.