### PR TITLE
[Client Pointers] generate entrypoints

### DIFF
--- a/crates/generate_artifacts/src/entrypoint_artifact.rs
+++ b/crates/generate_artifacts/src/entrypoint_artifact.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use common_lang_types::{
     ArtifactPathAndContent, ClientScalarSelectableName, ParentObjectEntityNameAndSelectableName,
     QueryOperationName, QueryText, ServerObjectEntityName, VariableName,
@@ -9,21 +7,26 @@ use isograph_lang_types::{
     DefinitionLocation, EmptyDirectiveSet, EntrypointDirectiveSet, ScalarSelectionDirectiveSet,
     SelectionType,
 };
+
+use isograph_schema::ClientScalarSelectable;
 use isograph_schema::{
     create_merged_selection_map_for_field_and_insert_into_global_map,
     current_target_merged_selections, get_imperatively_loaded_artifact_info,
     get_reachable_variables, initial_variable_context, ClientScalarOrObjectSelectable,
-    ClientScalarSelectable, EntrypointDeclarationInfo, FieldToCompletedMergeTraversalStateMap,
-    FieldTraversalResult, Format, MergedSelectionMap, NetworkProtocol, RootOperationName,
-    RootRefetchedPath, ScalarClientFieldTraversalState, Schema, ServerObjectEntity,
-    ValidatedVariableDefinition, WrappedSelectionMapSelection,
+    EntrypointDeclarationInfo, FieldToCompletedMergeTraversalStateMap, FieldTraversalResult,
+    Format, MergedSelectionMap, NetworkProtocol, RootOperationName, RootRefetchedPath,
+    ScalarClientFieldTraversalState, Schema, ServerObjectEntity, ValidatedVariableDefinition,
+    WrappedSelectionMapSelection,
 };
+use std::collections::BTreeSet;
 
+use crate::generate_artifacts::ENTRYPOINT_FILE_NAME;
+use crate::generate_artifacts::NORMALIZATION_AST_FILE_NAME;
+use crate::generate_artifacts::QUERY_TEXT_FILE_NAME;
 use crate::{
     generate_artifacts::{
-        NormalizationAstText, RefetchQueryArtifactImport, ENTRYPOINT_FILE_NAME, NORMALIZATION_AST,
-        NORMALIZATION_AST_FILE_NAME, QUERY_TEXT, QUERY_TEXT_FILE_NAME, RESOLVER_OUTPUT_TYPE,
-        RESOLVER_PARAM_TYPE, RESOLVER_READER,
+        NormalizationAstText, RefetchQueryArtifactImport, NORMALIZATION_AST, QUERY_TEXT,
+        RESOLVER_OUTPUT_TYPE, RESOLVER_PARAM_TYPE, RESOLVER_READER,
     },
     imperatively_loaded_fields::get_artifact_for_imperatively_loaded_field,
     normalization_ast_text::generate_normalization_ast_text,
@@ -163,14 +166,11 @@ pub(crate) fn generate_entrypoint_artifacts_with_client_field_traversal_result<
                     // Note: it would be cleaner to include a reference to the merged selection set here via
                     // the selection_variant variable, instead of by looking it up like this.
                     &encountered_client_type_map
-                        .get(&DefinitionLocation::Client(SelectionType::Scalar((
+                        .get(&DefinitionLocation::Client(
                             root_refetch_path
                                 .path_to_refetch_field_info
-                                .refetch_field_parent_object_entity_name,
-                            root_refetch_path
-                                .path_to_refetch_field_info
-                                .client_field_name,
-                        ))))
+                                .client_selectable_id,
+                        ))
                         .expect(
                             "Expected field to have been encountered, \
                                 since it is being used as a refetch field.",

--- a/crates/generate_artifacts/src/entrypoint_artifact.rs
+++ b/crates/generate_artifacts/src/entrypoint_artifact.rs
@@ -177,7 +177,7 @@ pub(crate) fn generate_entrypoint_artifacts_with_client_field_traversal_result<
                                 ))
                                 .expect(
                                     "Expected field to have been encountered, \
-                                        since it is being used as a refetch field.",
+                                    since it is being used as a refetch field.",
                                 )
                                 .merged_selection_map
                         }

--- a/crates/generate_artifacts/src/entrypoint_artifact.rs
+++ b/crates/generate_artifacts/src/entrypoint_artifact.rs
@@ -1,3 +1,14 @@
+use crate::{
+    generate_artifacts::{
+        NormalizationAstText, RefetchQueryArtifactImport, ENTRYPOINT_FILE_NAME, NORMALIZATION_AST,
+        NORMALIZATION_AST_FILE_NAME, QUERY_TEXT, QUERY_TEXT_FILE_NAME, RESOLVER_OUTPUT_TYPE,
+        RESOLVER_PARAM_TYPE, RESOLVER_READER,
+    },
+    imperatively_loaded_fields::get_artifact_for_imperatively_loaded_field,
+    normalization_ast_text::generate_normalization_ast_text,
+    operation_text::{generate_operation_text, OperationText},
+    persisted_documents::PersistedDocuments,
+};
 use common_lang_types::{
     ArtifactPathAndContent, ClientScalarSelectableName, ParentObjectEntityNameAndSelectableName,
     QueryOperationName, QueryText, ServerObjectEntityName, VariableName,
@@ -7,32 +18,16 @@ use isograph_lang_types::{
     DefinitionLocation, EmptyDirectiveSet, EntrypointDirectiveSet, ScalarSelectionDirectiveSet,
     SelectionType,
 };
-
 use isograph_schema::{
     create_merged_selection_map_for_field_and_insert_into_global_map,
     current_target_merged_selections, get_imperatively_loaded_artifact_info,
     get_reachable_variables, initial_variable_context, ClientScalarOrObjectSelectable,
-    EntrypointDeclarationInfo, FieldToCompletedMergeTraversalStateMap, FieldTraversalResult,
-    Format, MergedSelectionMap, NetworkProtocol, RootOperationName, RootRefetchedPath,
-    ScalarClientFieldTraversalState, Schema, ServerObjectEntity, ValidatedVariableDefinition,
-    WrappedSelectionMapSelection,
+    ClientScalarSelectable, EntrypointDeclarationInfo, FieldToCompletedMergeTraversalStateMap,
+    FieldTraversalResult, Format, MergedSelectionMap, NetworkProtocol, NormalizationKey,
+    RootOperationName, RootRefetchedPath, ScalarClientFieldTraversalState, Schema,
+    ServerObjectEntity, ValidatedVariableDefinition, WrappedSelectionMapSelection,
 };
-use isograph_schema::{ClientScalarSelectable, NormalizationKey};
 use std::collections::BTreeSet;
-
-use crate::generate_artifacts::ENTRYPOINT_FILE_NAME;
-use crate::generate_artifacts::NORMALIZATION_AST_FILE_NAME;
-use crate::generate_artifacts::QUERY_TEXT_FILE_NAME;
-use crate::{
-    generate_artifacts::{
-        NormalizationAstText, RefetchQueryArtifactImport, NORMALIZATION_AST, QUERY_TEXT,
-        RESOLVER_OUTPUT_TYPE, RESOLVER_PARAM_TYPE, RESOLVER_READER,
-    },
-    imperatively_loaded_fields::get_artifact_for_imperatively_loaded_field,
-    normalization_ast_text::generate_normalization_ast_text,
-    operation_text::{generate_operation_text, OperationText},
-    persisted_documents::PersistedDocuments,
-};
 
 #[derive(Debug)]
 struct EntrypointArtifactInfo<'schema, TNetworkProtocol: NetworkProtocol> {

--- a/crates/generate_artifacts/src/generate_artifacts.rs
+++ b/crates/generate_artifacts/src/generate_artifacts.rs
@@ -727,26 +727,12 @@ fn write_param_type_from_selection<TNetworkProtocol: NetworkProtocol>(
             }
         }
         SelectionTypeContainingSelections::Object(linked_field) => {
-            let field = match linked_field.associated_data {
-                DefinitionLocation::Server((
-                    parent_object_entity_name,
-                    server_object_selectable_name,
-                )) => schema
-                    .server_object_selectable(
-                        parent_object_entity_name,
-                        server_object_selectable_name,
-                    )
-                    .map(DefinitionLocation::Server),
-                DefinitionLocation::Client((parent_object_entity_name, client_pointer_name)) => {
-                    schema
-                        .client_pointer(parent_object_entity_name, client_pointer_name)
-                        .map(DefinitionLocation::Client)
-                }
-            }
-            .expect(
-                "Expected selectable to exist. \
-                This is indicative of a bug in Isograph.",
-            );
+            let field = schema
+                .object_selectable(linked_field.associated_data)
+                .expect(
+                    "Expected selectable to exist. \
+                        This is indicative of a bug in Isograph.",
+                );
 
             write_optional_description(
                 description(&field),

--- a/crates/generate_artifacts/src/imperatively_loaded_fields.rs
+++ b/crates/generate_artifacts/src/imperatively_loaded_fields.rs
@@ -1,5 +1,5 @@
 use common_lang_types::{
-    ArtifactPathAndContent, ClientScalarSelectableName, ParentObjectEntityNameAndSelectableName,
+    ArtifactPathAndContent, ClientSelectableName, ParentObjectEntityNameAndSelectableName,
     QueryText, ServerObjectEntityName,
 };
 use intern::string_key::Intern;
@@ -21,7 +21,7 @@ pub(crate) struct ImperativelyLoadedEntrypointArtifactInfo {
     pub normalization_ast_text: NormalizationAstText,
     pub query_text: QueryText,
     pub operation_text: OperationText,
-    pub root_fetchable_field: ClientScalarSelectableName,
+    pub root_fetchable_field: ClientSelectableName,
     pub root_fetchable_field_parent_object: ServerObjectEntityName,
     pub refetch_query_index: RefetchQueryIndex,
     pub concrete_type: ServerObjectEntityName,

--- a/crates/generate_artifacts/src/normalization_ast_text.rs
+++ b/crates/generate_artifacts/src/normalization_ast_text.rs
@@ -77,6 +77,7 @@ fn generate_normalization_ast_node<TNetworkProtocol: NetworkProtocol>(
                 {indent}}},\n"
             )
         }
+        MergedServerSelection::ClientPointer(_) => "".to_string(),
         MergedServerSelection::InlineFragment(inline_fragment) => {
             let MergedInlineFragmentSelection {
                 type_to_refine_to,

--- a/crates/generate_artifacts/src/reader_ast.rs
+++ b/crates/generate_artifacts/src/reader_ast.rs
@@ -784,10 +784,12 @@ fn refetched_paths_with_path<TNetworkProtocol: NetworkProtocol>(
                         parent_object_entity_name,
                         client_pointer_name,
                     )) => {
-                        let client_pointer =
-                            schema.client_pointer(parent_object_entity_name, client_pointer_name)
-                            .expect("Expected selectable to exist. \
-                                This is indicative of a bug in Isograph.");
+                        let client_pointer = schema
+                            .client_pointer(parent_object_entity_name, client_pointer_name)
+                            .expect(
+                                "Expected selectable to exist. \
+                                This is indicative of a bug in Isograph.",
+                            );
 
                         let new_paths = refetched_paths_with_path(
                             client_pointer.selection_set_for_parent_query(),

--- a/crates/generate_artifacts/src/reader_ast.rs
+++ b/crates/generate_artifacts/src/reader_ast.rs
@@ -5,7 +5,7 @@ use common_lang_types::{
 };
 use isograph_lang_types::{
     DefinitionLocation, EmptyDirectiveSet, LoadableDirectiveParameters,
-    ObjectSelectionDirectiveSet, RefetchQueryIndex, ScalarSelectionDirectiveSet,
+    ObjectSelectionDirectiveSet, RefetchQueryIndex, ScalarSelectionDirectiveSet, SelectionType,
     SelectionTypeContainingSelections,
 };
 use isograph_schema::{
@@ -175,6 +175,7 @@ fn generate_reader_ast_node<TNetworkProtocol: NetworkProtocol>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn linked_field_ast_node<TNetworkProtocol: NetworkProtocol>(
     schema: &Schema<TNetworkProtocol>,
     linked_field: &ValidatedObjectSelection,
@@ -753,7 +754,7 @@ fn refetched_paths_with_path<TNetworkProtocol: NetworkProtocol>(
                             Some(Loadability::ImperativelyLoadedField(_)) => {
                                 paths.insert(PathToRefetchField {
                                     linked_fields: path.clone(),
-                                    field_name: client_field.name.item.into(),
+                                    field_name: SelectionType::Scalar(client_field.name.item),
                                 });
                             }
                             Some(Loadability::LoadablySelectedField(_)) => {
@@ -779,8 +780,61 @@ fn refetched_paths_with_path<TNetworkProtocol: NetworkProtocol>(
             }
             SelectionTypeContainingSelections::Object(linked_field_selection) => {
                 match linked_field_selection.associated_data {
-                    DefinitionLocation::Client(_) => {
-                        // Do not recurse into selections of client pointers
+                    DefinitionLocation::Client((
+                        parent_object_entity_name,
+                        client_pointer_name,
+                    )) => {
+                        let client_pointer =
+                            schema.client_pointer(parent_object_entity_name, client_pointer_name)
+                            .expect("Expected selectable to exist. \
+                                This is indicative of a bug in Isograph.");
+
+                        let new_paths = refetched_paths_with_path(
+                            client_pointer.selection_set_for_parent_query(),
+                            schema,
+                            path,
+                            &initial_variable_context.child_variable_context(
+                                &linked_field_selection.arguments,
+                                &client_pointer.variable_definitions,
+                                &ScalarSelectionDirectiveSet::None(EmptyDirectiveSet {}),
+                            ),
+                        );
+
+                        paths.extend(new_paths.into_iter());
+
+                        let name_and_arguments = NameAndArguments {
+                            // TODO use alias
+                            name: linked_field_selection.name.item.into(),
+                            arguments: transform_arguments_with_child_context(
+                                linked_field_selection
+                                    .arguments
+                                    .iter()
+                                    .map(|x| x.item.into_key_and_value()),
+                                // TODO this clearly does something, but why are we able to pass
+                                // the initial variable context here??
+                                initial_variable_context,
+                            ),
+                        };
+
+                        paths.insert(PathToRefetchField {
+                            linked_fields: path.clone(),
+                            field_name: SelectionType::Object(name_and_arguments.clone()),
+                        });
+
+                        let normalization_key = NormalizationKey::ClientPointer(name_and_arguments);
+
+                        path.push(normalization_key);
+
+                        let new_paths = refetched_paths_with_path(
+                            &linked_field_selection.selection_set,
+                            schema,
+                            path,
+                            initial_variable_context,
+                        );
+
+                        paths.extend(new_paths.into_iter());
+
+                        path.pop();
                     }
                     DefinitionLocation::Server((
                         parent_object_entity_name,

--- a/crates/generate_artifacts/src/reader_ast.rs
+++ b/crates/generate_artifacts/src/reader_ast.rs
@@ -274,7 +274,7 @@ fn linked_field_ast_node<TNetworkProtocol: NetworkProtocol>(
             )
             .0;
 
-            format!("{}", refetch_query_index)
+            format!("{refetch_query_index}")
         }
         DefinitionLocation::Server(_) => "null".to_string(),
     };

--- a/crates/generate_artifacts/src/reader_ast.rs
+++ b/crates/generate_artifacts/src/reader_ast.rs
@@ -62,23 +62,33 @@ fn generate_reader_ast_node<TNetworkProtocol: NetworkProtocol>(
         }
         SelectionTypeContainingSelections::Object(linked_field_selection) => {
             match linked_field_selection.associated_data {
-                DefinitionLocation::Client((parent_object_entity_name, client_pointer_name)) => {
-                    let client_pointer = schema
-                        .client_pointer(parent_object_entity_name, client_pointer_name)
-                        .expect(
-                            "Expected selectable to exist. \
-                            This is indicative of a bug in Isograph.",
-                        );
+                DefinitionLocation::Client(_) => {
+                    path.push(NormalizationKey::ClientPointer(NameAndArguments {
+                        // TODO use alias
+                        name: linked_field_selection.name.item.into(),
+                        // TODO this clearly does something, but why are we able to pass
+                        // the initial variable context here??
+                        arguments: transform_arguments_with_child_context(
+                            linked_field_selection
+                                .arguments
+                                .iter()
+                                .map(|x| x.item.into_key_and_value()),
+                            // TODO why is this not the transformed context?
+                            initial_variable_context,
+                        ),
+                    }));
 
                     let inner_reader_ast = generate_reader_ast_with_path(
                         schema,
-                        client_pointer.refetch_strategy.refetch_selection_set(),
+                        &linked_field_selection.selection_set,
                         indentation_level + 1,
                         reader_imports,
                         root_refetched_paths,
                         path,
                         initial_variable_context,
                     );
+
+                    path.pop();
 
                     linked_field_ast_node(
                         schema,
@@ -87,6 +97,8 @@ fn generate_reader_ast_node<TNetworkProtocol: NetworkProtocol>(
                         inner_reader_ast,
                         initial_variable_context,
                         reader_imports,
+                        root_refetched_paths,
+                        path,
                     )
                 }
                 DefinitionLocation::Server((
@@ -154,6 +166,8 @@ fn generate_reader_ast_node<TNetworkProtocol: NetworkProtocol>(
                         inner_reader_ast,
                         initial_variable_context,
                         reader_imports,
+                        root_refetched_paths,
+                        path,
                     )
                 }
             }
@@ -168,6 +182,8 @@ fn linked_field_ast_node<TNetworkProtocol: NetworkProtocol>(
     inner_reader_ast: ReaderAst,
     initial_variable_context: &VariableContext,
     reader_imports: &mut ReaderImports,
+    root_refetched_paths: &RefetchedPathsMap,
+    path: &[NormalizationKey],
 ) -> String {
     let name = linked_field.name.item;
     let alias = linked_field
@@ -248,6 +264,20 @@ fn linked_field_ast_node<TNetworkProtocol: NetworkProtocol>(
         ObjectSelectionDirectiveSet::Updatable(_)
     );
 
+    let refetch_query = match linked_field.associated_data {
+        DefinitionLocation::Client(_) => {
+            let refetch_query_index = find_imperatively_fetchable_query_index(
+                root_refetched_paths,
+                path,
+                linked_field.name.item.unchecked_conversion(),
+            )
+            .0;
+
+            format!("{}", refetch_query_index)
+        }
+        DefinitionLocation::Server(_) => "null".to_string(),
+    };
+
     format!(
         "{indent_1}{{\n\
         {indent_2}kind: \"Linked\",\n\
@@ -257,7 +287,7 @@ fn linked_field_ast_node<TNetworkProtocol: NetworkProtocol>(
         {indent_2}condition: {condition},\n\
         {indent_2}isUpdatable: {is_updatable},\n\
         {indent_2}selections: {inner_reader_ast},\n\
-        {indent_2}refetchQueryIndex: null,\n\
+        {indent_2}refetchQueryIndex: {refetch_query},\n\
         {indent_1}}},\n",
     )
 }
@@ -723,7 +753,7 @@ fn refetched_paths_with_path<TNetworkProtocol: NetworkProtocol>(
                             Some(Loadability::ImperativelyLoadedField(_)) => {
                                 paths.insert(PathToRefetchField {
                                     linked_fields: path.clone(),
-                                    field_name: client_field.name.item,
+                                    field_name: client_field.name.item.into(),
                                 });
                             }
                             Some(Loadability::LoadablySelectedField(_)) => {

--- a/crates/graphql_network_protocol/src/query_text.rs
+++ b/crates/graphql_network_protocol/src/query_text.rs
@@ -115,6 +115,7 @@ fn write_selections_for_query_text<'a>(
                 );
                 query_text.push_str(&format!("{indent}}},{new_line}"));
             }
+            MergedServerSelection::ClientPointer(_) => {}
             MergedServerSelection::InlineFragment(inline_fragment) => {
                 query_text.push_str(indent);
                 query_text.push_str(&format!(

--- a/crates/isograph_schema/src/create_additional_fields/expose_field_directive.rs
+++ b/crates/isograph_schema/src/create_additional_fields/expose_field_directive.rs
@@ -230,8 +230,7 @@ impl<TNetworkProtocol: NetworkProtocol> Schema<TNetworkProtocol> {
 
             variant: ClientFieldVariant::ImperativelyLoadedField(ImperativelyLoadedFieldVariant {
                 top_level_schema_field_arguments,
-                client_field_scalar_selection_name: client_field_scalar_selection_name
-                    .unchecked_conversion(),
+                client_selection_name: client_field_scalar_selection_name.unchecked_conversion(),
 
                 root_object_entity_name: parent_object_entity_name,
                 subfields_or_inline_fragments: subfields_or_inline_fragments.clone(),

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -1143,14 +1143,14 @@ fn insert_imperative_field_into_refetch_paths<TNetworkProtocol: NetworkProtocol>
     encountered_client_type_map: &mut FieldToCompletedMergeTraversalStateMap,
     merge_traversal_state: &mut ScalarClientFieldTraversalState,
     newly_encountered_scalar_client_selectable_name: ClientScalarSelectableName,
-    newly_encountered_scalar_client_selectable: &ClientScalarSelectable<TNetworkProtocol>,
+    newly_encountered_client_scalar_selectable: &ClientScalarSelectable<TNetworkProtocol>,
     parent_object_entity_name: ServerObjectEntityName,
     parent_object_entity: &ServerObjectEntity<TNetworkProtocol>,
     variant: &ImperativelyLoadedFieldVariant,
 ) {
     let path = PathToRefetchField {
         linked_fields: merge_traversal_state.traversal_path.clone(),
-        field_name: SelectionType::Scalar(newly_encountered_scalar_client_selectable.name.item),
+        field_name: SelectionType::Scalar(newly_encountered_client_scalar_selectable.name.item),
     };
 
     let info = PathToRefetchFieldInfo {
@@ -1158,7 +1158,7 @@ fn insert_imperative_field_into_refetch_paths<TNetworkProtocol: NetworkProtocol>
         imperatively_loaded_field_variant: variant.clone(),
         extra_selections: BTreeMap::new(),
         client_selectable_id: SelectionType::Scalar((
-            newly_encountered_scalar_client_selectable.parent_object_entity_name,
+            newly_encountered_client_scalar_selectable.parent_object_entity_name,
             newly_encountered_scalar_client_selectable_name,
         )),
     };
@@ -1169,7 +1169,7 @@ fn insert_imperative_field_into_refetch_paths<TNetworkProtocol: NetworkProtocol>
             ScalarSelectionDirectiveSet::None(EmptyDirectiveSet {}),
         ),
         RootRefetchedPath {
-            field_name: newly_encountered_scalar_client_selectable.name.item.into(),
+            field_name: newly_encountered_client_scalar_selectable.name.item.into(),
             path_to_refetch_field_info: info,
         },
     );
@@ -1178,7 +1178,7 @@ fn insert_imperative_field_into_refetch_paths<TNetworkProtocol: NetworkProtocol>
     create_merged_selection_map_for_field_and_insert_into_global_map(
         schema,
         parent_object_entity,
-        newly_encountered_scalar_client_selectable
+        newly_encountered_client_scalar_selectable
             .refetch_strategy
             .as_ref()
             .expect(
@@ -1192,7 +1192,7 @@ fn insert_imperative_field_into_refetch_paths<TNetworkProtocol: NetworkProtocol>
             newly_encountered_scalar_client_selectable_name,
         ))),
         &initial_variable_context(&SelectionType::Scalar(
-            newly_encountered_scalar_client_selectable,
+            newly_encountered_client_scalar_selectable,
         )),
     );
 }

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -1163,7 +1163,7 @@ fn insert_imperative_field_into_refetch_paths<TNetworkProtocol: NetworkProtocol>
 ) {
     let path = PathToRefetchField {
         linked_fields: merge_traversal_state.traversal_path.clone(),
-        field_name: newly_encountered_scalar_client_selectable.name.item.into(),
+        field_name: SelectionType::Scalar(newly_encountered_scalar_client_selectable.name.item),
     };
 
     let info = PathToRefetchFieldInfo {
@@ -1223,9 +1223,15 @@ fn insert_client_pointer_into_refetch_paths<TNetworkProtocol: NetworkProtocol>(
     object_selection: &ValidatedObjectSelection,
     variable_context: &VariableContext,
 ) {
+    let name_and_arguments = create_transformed_name_and_arguments(
+        object_selection.name.item.into(),
+        &object_selection.arguments,
+        variable_context,
+    );
+
     let path = PathToRefetchField {
         linked_fields: merge_traversal_state.traversal_path.clone(),
-        field_name: newly_encountered_client_object_selectable.name.item.into(),
+        field_name: SelectionType::Object(name_and_arguments.clone()),
     };
 
     let subfields_or_inline_fragments = vec![
@@ -1277,11 +1283,7 @@ fn insert_client_pointer_into_refetch_paths<TNetworkProtocol: NetworkProtocol>(
             newly_encountered_client_object_selectable_name,
         )));
 
-    let normalization_key = NormalizationKey::ClientPointer(create_transformed_name_and_arguments(
-        object_selection.name.item.into(),
-        &object_selection.arguments,
-        variable_context,
-    ));
+    let normalization_key = NormalizationKey::ClientPointer(name_and_arguments);
 
     merge_traversal_state
         .traversal_path

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -1214,8 +1214,10 @@ fn insert_client_pointer_into_refetch_paths<TNetworkProtocol: NetworkProtocol>(
     let parent_type = schema
         .server_entity_data
         .server_object_entity(parent_object_entity_id)
-        .expect("Expected entity to exist. \
-                     This is indicative of a bug in Isograph.");
+        .expect(
+            "Expected entity to exist. \
+                     This is indicative of a bug in Isograph.",
+        );
 
     let parent_object_entity_name = ClientOrServerObjectSelectable::parent_object_entity_name(
         &newly_encountered_client_object_selectable,
@@ -1233,7 +1235,7 @@ fn insert_client_pointer_into_refetch_paths<TNetworkProtocol: NetworkProtocol>(
     };
 
     let subfields_or_inline_fragments = vec![
-        WrappedSelectionMapSelection::InlineFragment(parent_type.name),
+        WrappedSelectionMapSelection::InlineFragment(parent_type.name.item),
         WrappedSelectionMapSelection::LinkedField {
             server_object_selectable_name: *NODE_FIELD_NAME,
             arguments: vec![ArgumentKeyAndValue {

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -783,17 +783,6 @@ fn merge_validated_selections_into_selection_map<TNetworkProtocol: NetworkProtoc
                             newly_encountered_client_object_selectable_id,
                         );
 
-                        let parent_object_entity_id = *newly_encountered_client_object_selectable
-                            .target_object_entity_name()
-                            .inner();
-                        let parent_object = schema
-                            .server_entity_data
-                            .server_object_entity(parent_object_entity_id)
-                            .expect(
-                                "Expected entity to exist. \
-                                      This is indicative of a bug in Isograph.",
-                            );
-
                         insert_client_pointer_into_refetch_paths(
                             schema,
                             parent_map,
@@ -801,8 +790,6 @@ fn merge_validated_selections_into_selection_map<TNetworkProtocol: NetworkProtoc
                             merge_traversal_state,
                             newly_encountered_client_object_selectable_id,
                             newly_encountered_client_object_selectable,
-                            parent_object_entity_id,
-                            parent_object,
                             object_selection,
                             variable_context,
                         );
@@ -929,7 +916,7 @@ fn merge_server_object_field<TNetworkProtocol: NetworkProtocol>(
                         &object_selection.selection_set,
                         encountered_client_type_map,
                         DefinitionLocation::Server((
-                            parent_object_entity_name,
+                            field_parent_object_entity_name,
                             field_server_object_selectable_name,
                         )),
                         &server_object_selectable.initial_variable_context(),
@@ -1218,11 +1205,22 @@ fn insert_client_pointer_into_refetch_paths<TNetworkProtocol: NetworkProtocol>(
     merge_traversal_state: &mut ScalarClientFieldTraversalState,
     newly_encountered_client_object_selectable_name: ClientObjectSelectableName,
     newly_encountered_client_object_selectable: &ClientObjectSelectable<TNetworkProtocol>,
-    parent_object_entity_name: ServerObjectEntityName,
-    parent_type: &ServerObjectEntity<TNetworkProtocol>,
     object_selection: &ValidatedObjectSelection,
     variable_context: &VariableContext,
 ) {
+    let parent_object_entity_id = *newly_encountered_client_object_selectable
+        .target_object_entity_name
+        .inner();
+    let parent_type = schema
+        .server_entity_data
+        .server_object_entity(parent_object_entity_id)
+        .expect("Expected entity to exist. \
+                     This is indicative of a bug in Isograph.");
+
+    let parent_object_entity_name = ClientOrServerObjectSelectable::parent_object_entity_name(
+        &newly_encountered_client_object_selectable,
+    );
+
     let name_and_arguments = create_transformed_name_and_arguments(
         object_selection.name.item.into(),
         &object_selection.arguments,

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -1319,7 +1319,7 @@ fn insert_client_pointer_into_refetch_paths<TNetworkProtocol: NetworkProtocol>(
         | MergedServerSelection::InlineFragment(_) => {
             panic!(
                 "Expected client pointer. \
-                    This is indicative of a bug in Isograph."
+                This is indicative of a bug in Isograph."
             )
         }
     }

--- a/crates/isograph_schema/src/isograph_schema.rs
+++ b/crates/isograph_schema/src/isograph_schema.rs
@@ -4,10 +4,10 @@ use std::{
 };
 
 use common_lang_types::{
-    ClientObjectSelectableName, ClientScalarSelectableName, ClientSelectableName, JavascriptName,
-    Location, ObjectSelectableName, SelectableName, ServerObjectEntityName,
-    ServerObjectSelectableName, ServerScalarEntityName, ServerScalarIdSelectableName,
-    ServerScalarSelectableName, UnvalidatedTypeName, WithLocation,
+    ClientObjectSelectableName, ClientScalarSelectableName, JavascriptName, Location,
+    ObjectSelectableName, SelectableName, ServerObjectEntityName, ServerObjectSelectableName,
+    ServerScalarEntityName, ServerScalarIdSelectableName, ServerScalarSelectableName,
+    UnvalidatedTypeName, WithLocation,
 };
 use graphql_lang_types::GraphQLNamedTypeAnnotation;
 use intern::string_key::Intern;
@@ -776,7 +776,7 @@ impl<TNetworkProtocol: NetworkProtocol> ServerEntityData<TNetworkProtocol> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PathToRefetchField {
     pub linked_fields: Vec<NormalizationKey>,
-    pub field_name: ClientSelectableName,
+    pub field_name: SelectionType<ClientScalarSelectableName, NameAndArguments>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/crates/isograph_schema/src/isograph_schema.rs
+++ b/crates/isograph_schema/src/isograph_schema.rs
@@ -4,10 +4,10 @@ use std::{
 };
 
 use common_lang_types::{
-    ClientObjectSelectableName, ClientScalarSelectableName, JavascriptName, Location,
-    ObjectSelectableName, SelectableName, ServerObjectEntityName, ServerObjectSelectableName,
-    ServerScalarEntityName, ServerScalarIdSelectableName, ServerScalarSelectableName,
-    UnvalidatedTypeName, WithLocation,
+    ClientObjectSelectableName, ClientScalarSelectableName, ClientSelectableName, JavascriptName,
+    Location, ObjectSelectableName, SelectableName, ServerObjectEntityName,
+    ServerObjectSelectableName, ServerScalarEntityName, ServerScalarIdSelectableName,
+    ServerScalarSelectableName, UnvalidatedTypeName, WithLocation,
 };
 use graphql_lang_types::GraphQLNamedTypeAnnotation;
 use intern::string_key::Intern;
@@ -172,7 +172,7 @@ impl<TNetworkProtocol: NetworkProtocol> Schema<TNetworkProtocol> {
             .get(&root_object_name)
             .expect(
                 "Expected root_object_entity_name to exist \
-                in server_object_entity_avaiable_selectables",
+                in server_object_entity_available_selectables",
             )
             .selectables;
 
@@ -270,7 +270,7 @@ impl<TNetworkProtocol: NetworkProtocol> Schema<TNetworkProtocol> {
             .get(&root_object_name)
             .expect(
                 "Expected root_object_entity_name to exist \
-                in server_object_entity_avaiable_selectables",
+                in server_object_entity_available_selectables",
             )
             .selectables;
 
@@ -776,7 +776,7 @@ impl<TNetworkProtocol: NetworkProtocol> ServerEntityData<TNetworkProtocol> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PathToRefetchField {
     pub linked_fields: Vec<NormalizationKey>,
-    pub field_name: ClientScalarSelectableName,
+    pub field_name: ClientSelectableName,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/crates/isograph_schema/src/process_client_field_declaration.rs
+++ b/crates/isograph_schema/src/process_client_field_declaration.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 use common_lang_types::{
     ClientObjectSelectableName, ClientScalarSelectableName, ClientSelectableName, ConstExportName,
-    IsographDirectiveName, Location, ParentObjectEntityNameAndSelectableName, RelativePathToSourceFile,
-    SelectableName, ServerObjectEntityName, TextSource, UnvalidatedTypeName, VariableName,
-    WithLocation, WithSpan,
+    IsographDirectiveName, Location, ParentObjectEntityNameAndSelectableName,
+    RelativePathToSourceFile, SelectableName, ServerObjectEntityName, TextSource,
+    UnvalidatedTypeName, VariableName, WithLocation, WithSpan,
 };
 use intern::string_key::Intern;
 use isograph_lang_types::{

--- a/crates/isograph_schema/src/process_client_field_declaration.rs
+++ b/crates/isograph_schema/src/process_client_field_declaration.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 
 use common_lang_types::{
-    ClientObjectSelectableName, ClientScalarSelectableName, ConstExportName, IsographDirectiveName,
-    Location, ParentObjectEntityNameAndSelectableName, RelativePathToSourceFile, SelectableName,
-    ServerObjectEntityName, TextSource, UnvalidatedTypeName, VariableName, WithLocation, WithSpan,
+    ClientObjectSelectableName, ClientScalarSelectableName, ClientSelectableName, ConstExportName,
+    IsographDirectiveName, Location, ParentObjectEntityNameAndSelectableName, RelativePathToSourceFile,
+    SelectableName, ServerObjectEntityName, TextSource, UnvalidatedTypeName, VariableName,
+    WithLocation, WithSpan,
 };
 use intern::string_key::Intern;
 use isograph_lang_types::{
@@ -505,7 +506,7 @@ pub enum ProcessClientFieldDeclarationError {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImperativelyLoadedFieldVariant {
-    pub client_field_scalar_selection_name: ClientScalarSelectableName,
+    pub client_selection_name: ClientSelectableName,
 
     // Mutation or Query or whatnot. Awkward! A GraphQL-ism!
     pub root_object_entity_name: ServerObjectEntityName,


### PR DESCRIPTION
Some tests used:
- nested refetch:
```graphql
self {
  age
  __refetch
  self {
    tagline
  }
}
```        
```graphql
pointer Pet.self to Pet {
  debug: alt_tagline
  link
}
```

- nested args:
```graphql
  field Pet.PetStatsCard($petId: ID!) @component {
    id
    nickname
    age
    self {
      stats {
        weight
        intelligence
        cuteness
        hunger
        sociability
        energy
        refetch_pet_stats(id: $petId)
      }
    }
  }
```

Part of #53