### PR TITLE
derive db macro example

### DIFF
--- a/crates/graphql_network_protocol/src/graphql_network_protocol.rs
+++ b/crates/graphql_network_protocol/src/graphql_network_protocol.rs
@@ -3,13 +3,13 @@ use graphql_lang_types::{from_graphql_directive, DeserializationError};
 use graphql_schema_parser::SchemaParseError;
 use intern::string_key::Intern;
 use isograph_compiler::get_standard_sources;
+use isograph_lang_types::IsographDatabase;
 use isograph_schema::{
     CreateAdditionalFieldsError, ExposeAsFieldToInsert, MergedSelectionMap, NetworkProtocol,
     ProcessTypeSystemDocumentOutcome, RootOperationName, Schema, StandardSources,
     ValidatedVariableDefinition,
 };
 use lazy_static::lazy_static;
-use pico::Database;
 use thiserror::Error;
 
 use crate::{
@@ -33,7 +33,7 @@ impl NetworkProtocol for GraphQLNetworkProtocol {
     type ParseAndProcessTypeSystemDocumentsError = ParseAndProcessGraphQLTypeSystemDocumentsError;
 
     fn parse_and_process_type_system_documents(
-        db: &Database,
+        db: &IsographDatabase,
     ) -> Result<
         ProcessTypeSystemDocumentOutcome<GraphQLNetworkProtocol>,
         ParseAndProcessGraphQLTypeSystemDocumentsError,

--- a/crates/graphql_network_protocol/src/read_schema.rs
+++ b/crates/graphql_network_protocol/src/read_schema.rs
@@ -3,14 +3,14 @@ use std::collections::BTreeMap;
 use common_lang_types::{RelativePathToSourceFile, WithLocation};
 use graphql_lang_types::{GraphQLTypeSystemDocument, GraphQLTypeSystemExtensionDocument};
 use graphql_schema_parser::{parse_schema, parse_schema_extensions, SchemaParseError};
-use isograph_lang_types::SchemaSource;
-use pico::{Database, MemoRef, SourceId};
+use isograph_lang_types::{IsographDatabase, SchemaSource};
+use pico::{MemoRef, SourceId};
 use pico_macros::memo;
 
 #[allow(clippy::type_complexity)]
 #[memo]
 pub fn parse_graphql_schema(
-    db: &Database,
+    db: &IsographDatabase,
     schema_source_id: SourceId<SchemaSource>,
     schema_extension_sources: &BTreeMap<RelativePathToSourceFile, SourceId<SchemaSource>>,
 ) -> Result<
@@ -41,7 +41,7 @@ pub fn parse_graphql_schema(
 
 #[memo]
 pub fn parse_schema_extensions_file(
-    db: &Database,
+    db: &IsographDatabase,
     schema_extension_source_id: SourceId<SchemaSource>,
 ) -> Result<MemoRef<GraphQLTypeSystemExtensionDocument>, WithLocation<SchemaParseError>> {
     let SchemaSource {

--- a/crates/isograph_compiler/src/compiler_state.rs
+++ b/crates/isograph_compiler/src/compiler_state.rs
@@ -7,6 +7,7 @@ use std::{
 use common_lang_types::{CurrentWorkingDirectory, WithLocation};
 use generate_artifacts::get_artifact_path_and_content;
 use isograph_config::create_config;
+use isograph_lang_types::IsographDatabase;
 use isograph_schema::{validate_use_of_arguments, NetworkProtocol, ValidateUseOfArgumentsError};
 use pico::Database;
 use thiserror::Error;
@@ -26,7 +27,7 @@ const GC_DURATION_SECONDS: u64 = 60;
 
 #[derive(Debug)]
 pub struct CompilerState {
-    pub db: Database,
+    pub db: IsographDatabase,
     pub last_gc_run: Instant,
 }
 
@@ -35,7 +36,7 @@ impl CompilerState {
         config_location: PathBuf,
         current_working_directory: CurrentWorkingDirectory,
     ) -> Result<Self, BatchCompileError<TNetworkProtocol>> {
-        let mut db = Database::new();
+        let mut db = IsographDatabase::default();
         db.set(current_working_directory);
         db.set(create_config(config_location, current_working_directory));
         initialize_sources(&mut db)?;
@@ -85,7 +86,7 @@ impl CompilerState {
 /// These are less "core" to the overall mission, and thus invite the question
 /// of whether they belong in this function, or at all.
 pub fn compile<TNetworkProtocol: NetworkProtocol + 'static>(
-    db: &Database,
+    db: &IsographDatabase,
 ) -> Result<CompilationStats, BatchCompileError<TNetworkProtocol>> {
     // Create schema
     let (unvalidated_isograph_schema, unprocessed_items) =

--- a/crates/isograph_compiler/src/create_schema.rs
+++ b/crates/isograph_compiler/src/create_schema.rs
@@ -12,7 +12,9 @@ use graphql_lang_types::{
 };
 use isograph_config::CompilerConfigOptions;
 use isograph_lang_parser::{IsoLiteralExtractionResult, IsographLiteralParseError};
-use isograph_lang_types::{ConstantValue, SelectionType, TypeAnnotation, VariableDefinition};
+use isograph_lang_types::{
+    ConstantValue, IsographDatabase, SelectionType, TypeAnnotation, VariableDefinition,
+};
 use isograph_schema::{
     validate_entrypoints, CreateAdditionalFieldsError, FieldToInsert, NetworkProtocol,
     ProcessClientFieldDeclarationError, ProcessObjectTypeDefinitionOutcome,
@@ -20,7 +22,6 @@ use isograph_schema::{
     ServerObjectSelectable, ServerObjectSelectableVariant, ServerScalarSelectable,
     UnprocessedClientFieldItem, UnprocessedClientPointerItem, ValidateEntrypointDeclarationError,
 };
-use pico::Database;
 use pico_macros::memo;
 use thiserror::Error;
 
@@ -33,7 +34,7 @@ use crate::{
 #[memo]
 #[allow(clippy::type_complexity)]
 pub fn create_schema<TNetworkProtocol: NetworkProtocol + 'static>(
-    db: &Database,
+    db: &IsographDatabase,
 ) -> Result<
     (
         Schema<TNetworkProtocol>,
@@ -117,7 +118,7 @@ pub fn create_schema<TNetworkProtocol: NetworkProtocol + 'static>(
 }
 
 pub fn process_iso_literals_for_schema<TNetworkProtocol: NetworkProtocol>(
-    db: &Database,
+    db: &IsographDatabase,
     mut unvalidated_isograph_schema: Schema<TNetworkProtocol>,
     mut unprocessed_items: Vec<
         SelectionType<UnprocessedClientFieldItem, UnprocessedClientPointerItem>,
@@ -230,7 +231,7 @@ impl From<Vec<WithLocation<AddSelectionSetsError>>> for ProcessIsoLiteralsForSch
 }
 
 fn parse_iso_literals(
-    db: &Database,
+    db: &IsographDatabase,
 ) -> Result<ParsedIsoLiteralsMap, Vec<WithLocation<IsographLiteralParseError>>> {
     let iso_literal_map = get_iso_literal_map(db);
     let mut contains_iso = ParsedIsoLiteralsMap::default();

--- a/crates/isograph_compiler/src/db_singletons.rs
+++ b/crates/isograph_compiler/src/db_singletons.rs
@@ -1,5 +1,6 @@
 use common_lang_types::CurrentWorkingDirectory;
 use isograph_config::CompilerConfig;
+use isograph_lang_types::IsographDatabase;
 use isograph_schema::StandardSources;
 use pico::Database;
 
@@ -7,22 +8,22 @@ use crate::source_files::IsoLiteralMap;
 
 // TODO find a good place for this file to live
 
-pub fn get_current_working_directory(db: &Database) -> CurrentWorkingDirectory {
+pub fn get_current_working_directory(db: &IsographDatabase) -> CurrentWorkingDirectory {
     *db.get_singleton::<CurrentWorkingDirectory>()
         .expect("Expected CurrentWorkingDirectory to have been set")
 }
 
-pub fn get_isograph_config(db: &Database) -> &CompilerConfig {
+pub fn get_isograph_config(db: &IsographDatabase) -> &CompilerConfig {
     db.get_singleton::<CompilerConfig>()
         .expect("Expected CompilerConfig to have been set")
 }
 
-pub fn get_standard_sources(db: &Database) -> &StandardSources {
+pub fn get_standard_sources(db: &IsographDatabase) -> &StandardSources {
     db.get_singleton::<StandardSources>()
         .expect("Expected StandardSources to have been set")
 }
 
-pub fn get_iso_literal_map(db: &Database) -> &IsoLiteralMap {
+pub fn get_iso_literal_map(db: &IsographDatabase) -> &IsoLiteralMap {
     db.get_singleton::<IsoLiteralMap>()
         .expect("Expected IsoLiteralMap to have been set")
 }

--- a/crates/isograph_compiler/src/isograph_literals.rs
+++ b/crates/isograph_compiler/src/isograph_literals.rs
@@ -5,12 +5,14 @@ use common_lang_types::{
 use isograph_lang_parser::{
     parse_iso_literal, IsoLiteralExtractionResult, IsographLiteralParseError,
 };
-use isograph_lang_types::{EntrypointDeclaration, IsoLiteralsSource, SelectionType};
+use isograph_lang_types::{
+    EntrypointDeclaration, IsoLiteralsSource, IsographDatabase, SelectionType,
+};
 use isograph_schema::{
     NetworkProtocol, ProcessClientFieldDeclarationError, Schema, UnprocessedItem,
 };
 use lazy_static::lazy_static;
-use pico::{Database, SourceId};
+use pico::SourceId;
 use pico_macros::memo;
 use regex::Regex;
 use std::{
@@ -143,7 +145,7 @@ pub fn parse_iso_literals_in_file_content(
 #[allow(clippy::type_complexity)]
 #[memo]
 pub fn parse_iso_literal_in_source(
-    db: &Database,
+    db: &IsographDatabase,
     iso_literals_source_id: SourceId<IsoLiteralsSource>,
 ) -> Result<
     Vec<(IsoLiteralExtractionResult, TextSource)>,

--- a/crates/isograph_lang_types/src/base_types.rs
+++ b/crates/isograph_lang_types/src/base_types.rs
@@ -4,6 +4,13 @@ use std::fmt::Display;
 
 use common_lang_types::{SelectableName, UnvalidatedTypeName};
 use intern::Lookup;
+use pico::Storage;
+use pico_macros::Db;
+
+#[derive(Default, Debug, Db)]
+pub struct IsographDatabase {
+    pub storage: Storage<Self>,
+}
 
 /// Distinguishes between server-defined items and locally-defined items.
 ///

--- a/crates/isograph_schema/src/network_protocol.rs
+++ b/crates/isograph_schema/src/network_protocol.rs
@@ -5,7 +5,7 @@ use common_lang_types::{
     ServerSelectableName, UnvalidatedTypeName, WithLocation, WithSpan,
 };
 use graphql_lang_types::{GraphQLInputValueDefinition, GraphQLTypeAnnotation, RootOperationKind};
-use pico::Database;
+use isograph_lang_types::IsographDatabase;
 
 use crate::{
     ExposeFieldDirective, MergedSelectionMap, RootOperationName, Schema, ServerObjectEntity,
@@ -22,7 +22,7 @@ where
 
     #[allow(clippy::type_complexity)]
     fn parse_and_process_type_system_documents(
-        db: &Database,
+        db: &IsographDatabase,
     ) -> Result<ProcessTypeSystemDocumentOutcome<Self>, Self::ParseAndProcessTypeSystemDocumentsError>;
 
     fn generate_query_text<'a>(

--- a/crates/pico/src/derived_node.rs
+++ b/crates/pico/src/derived_node.rs
@@ -35,21 +35,30 @@ impl From<ParamId> for DerivedNodeId {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-pub struct InnerFn(pub fn(&Database, DerivedNodeId) -> Option<Box<dyn DynEq>>);
-impl InnerFn {
-    pub fn new(inner_fn: fn(&Database, DerivedNodeId) -> Option<Box<dyn DynEq>>) -> Self {
+#[derive(Debug)]
+pub struct InnerFn<Db: Database>(pub fn(&Db, DerivedNodeId) -> Option<Box<dyn DynEq>>);
+
+impl<Db: Database> InnerFn<Db> {
+    pub fn new(inner_fn: fn(&Db, DerivedNodeId) -> Option<Box<dyn DynEq>>) -> Self {
         InnerFn(inner_fn)
     }
 }
 
-pub struct DerivedNode {
+impl<Db: Database> Clone for InnerFn<Db> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<Db: Database> Copy for InnerFn<Db> {}
+
+pub struct DerivedNode<Db: Database> {
     pub dependencies: Vec<Dependency>,
-    pub inner_fn: InnerFn,
+    pub inner_fn: InnerFn<Db>,
     pub value: Box<dyn DynEq>,
 }
 
-impl fmt::Debug for DerivedNode {
+impl<Db: Database> fmt::Debug for DerivedNode<Db> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("DerivedNode")
             .field("dependencies", &self.dependencies)

--- a/crates/pico/src/execute_memoized_function.rs
+++ b/crates/pico/src/execute_memoized_function.rs
@@ -1,13 +1,12 @@
 use dashmap::Entry;
 
 use crate::{
-    database::Database,
     dependency::{NodeKind, TrackedDependencies},
     derived_node::{DerivedNode, DerivedNodeId},
     dyn_eq::DynEq,
     epoch::Epoch,
     intern::Key,
-    InnerFn,
+    Database, InnerFn,
 };
 
 pub enum DidRecalculate {
@@ -55,72 +54,71 @@ pub enum DidRecalculate {
 /// After this function is called, we guarantee that a [`DerivedNode`]
 /// (with a value identical to what we would get if we actually invoked the
 /// function) is present in the [`Database`].
-impl Database {
-    pub(crate) fn execute_memoized_function(
-        &self,
-        derived_node_id: DerivedNodeId,
-        inner_fn: InnerFn,
-    ) -> DidRecalculate {
-        if self.dependency_stack.is_empty() {
-            // This is the outermost call to a memoized function. Keep track of all top_level_calls
-            // for the purposes of later garbage collection. (Note that we also cannot update the LRU
-            // cache right now, as that would require a mutable reference to the Database, which we do
-            // not have.)
-            self.top_level_calls.push(derived_node_id);
-        }
+pub fn execute_memoized_function<Db: Database>(
+    db: &Db,
+    derived_node_id: DerivedNodeId,
+    inner_fn: InnerFn<Db>,
+) -> DidRecalculate {
+    if db.get_storage().dependency_stack.is_empty() {
+        // This is the outermost call to a memoized function. Keep track of all top_level_calls
+        // for the purposes of later garbage collection. (Note that we also cannot update the LRU
+        // cache right now, as that would require a mutable reference to the Database, which we do
+        // not have.)
+        db.get_storage().top_level_calls.push(derived_node_id);
+    }
 
-        let (time_updated, did_recalculate) =
-            if let Some(derived_node) = self.storage.get_derived_node(derived_node_id) {
-                if self.storage.node_verified_in_current_epoch(derived_node_id) {
+    let (time_updated, did_recalculate) =
+        if let Some(derived_node) = db.get_storage().internal.get_derived_node(derived_node_id) {
+            if db
+                .get_storage()
+                .internal
+                .node_verified_in_current_epoch(derived_node_id)
+            {
+                (
+                    db.get_storage().internal.current_epoch,
+                    DidRecalculate::ReusedMemoizedValue,
+                )
+            } else {
+                db.get_storage()
+                    .internal
+                    .verify_derived_node(derived_node_id);
+                if any_dependency_changed(db, derived_node) {
+                    update_derived_node(db, derived_node_id, derived_node.value.as_ref(), inner_fn)
+                } else {
                     (
-                        self.storage.current_epoch,
+                        db.get_storage().internal.current_epoch,
                         DidRecalculate::ReusedMemoizedValue,
                     )
-                } else {
-                    self.storage.verify_derived_node(derived_node_id);
-                    if any_dependency_changed(self, derived_node) {
-                        update_derived_node(
-                            self,
-                            derived_node_id,
-                            derived_node.value.as_ref(),
-                            inner_fn,
-                        )
-                    } else {
-                        (
-                            self.storage.current_epoch,
-                            DidRecalculate::ReusedMemoizedValue,
-                        )
-                    }
                 }
-            } else {
-                create_derived_node(self, derived_node_id, inner_fn)
-            };
-        self.register_dependency_in_parent_memoized_fn(
-            NodeKind::Derived(derived_node_id),
-            time_updated,
-        );
-        did_recalculate
-    }
+            }
+        } else {
+            create_derived_node(db, derived_node_id, inner_fn)
+        };
+    db.get_storage().register_dependency_in_parent_memoized_fn(
+        NodeKind::Derived(derived_node_id),
+        time_updated,
+    );
+    did_recalculate
 }
 
-fn create_derived_node(
-    db: &Database,
+fn create_derived_node<Db: Database>(
+    db: &Db,
     derived_node_id: DerivedNodeId,
-    inner_fn: InnerFn,
+    inner_fn: InnerFn<Db>,
 ) -> (Epoch, DidRecalculate) {
     let (value, tracked_dependencies) =
         invoke_with_dependency_tracking(db, derived_node_id, inner_fn).expect(
             "InnerFn call cannot fail for a new derived node. This is indicative of a bug in Pico.",
         );
-    let index = db.storage.insert_derived_node(DerivedNode {
+    let index = db.get_storage().internal.insert_derived_node(DerivedNode {
         dependencies: tracked_dependencies.dependencies,
         inner_fn,
         value,
     });
-    db.storage.insert_derived_node_revision(
+    db.get_storage().internal.insert_derived_node_revision(
         derived_node_id,
         tracked_dependencies.max_time_updated,
-        db.storage.current_epoch,
+        db.get_storage().internal.current_epoch,
         index,
     );
     (
@@ -129,16 +127,17 @@ fn create_derived_node(
     )
 }
 
-fn update_derived_node(
-    db: &Database,
+fn update_derived_node<Db: Database>(
+    db: &Db,
     derived_node_id: DerivedNodeId,
     prev_value: &dyn DynEq,
-    inner_fn: InnerFn,
+    inner_fn: InnerFn<Db>,
 ) -> (Epoch, DidRecalculate) {
     match invoke_with_dependency_tracking(db, derived_node_id, inner_fn) {
         Some((value, tracked_dependencies)) => {
             let mut occupied = if let Entry::Occupied(occupied) = db
-                .storage
+                .get_storage()
+                .internal
                 .derived_node_id_to_revision
                 .entry(derived_node_id)
             {
@@ -154,7 +153,7 @@ fn update_derived_node(
                 DidRecalculate::ReusedMemoizedValue
             };
 
-            let index = db.storage.insert_derived_node(DerivedNode {
+            let index = db.get_storage().internal.insert_derived_node(DerivedNode {
                 dependencies: tracked_dependencies.dependencies,
                 inner_fn,
                 value,
@@ -168,11 +167,11 @@ fn update_derived_node(
     }
 }
 
-fn any_dependency_changed(db: &Database, derived_node: &DerivedNode) -> bool {
+fn any_dependency_changed<Db: Database>(db: &Db, derived_node: &DerivedNode<Db>) -> bool {
     derived_node
         .dependencies
         .iter()
-        .filter(|dep| dep.time_verified_or_updated != db.storage.current_epoch)
+        .filter(|dep| dep.time_verified_or_updated != db.get_storage().internal.current_epoch)
         .any(|dependency| match dependency.node_to {
             NodeKind::Source(key) => {
                 source_node_changed_since(db, key, dependency.time_verified_or_updated)
@@ -183,8 +182,8 @@ fn any_dependency_changed(db: &Database, derived_node: &DerivedNode) -> bool {
         })
 }
 
-fn source_node_changed_since(db: &Database, key: Key, since: Epoch) -> bool {
-    match db.storage.get_source_node(key) {
+fn source_node_changed_since<Db: Database>(db: &Db, key: Key, since: Epoch) -> bool {
+    match db.get_storage().internal.get_source_node(key) {
         Some(source) => source.time_updated > since,
         None => panic!(
             "Source node not found. This may occur if \
@@ -193,32 +192,41 @@ fn source_node_changed_since(db: &Database, key: Key, since: Epoch) -> bool {
     }
 }
 
-fn derived_node_changed_since(db: &Database, derived_node_id: DerivedNodeId, since: Epoch) -> bool {
-    let inner_fn = if let Some(derived_node) = db.storage.get_derived_node(derived_node_id) {
-        if let Some(rev) = db.storage.get_derived_node_revision(derived_node_id) {
-            if rev.time_updated > since {
+fn derived_node_changed_since<Db: Database>(
+    db: &Db,
+    derived_node_id: DerivedNodeId,
+    since: Epoch,
+) -> bool {
+    let inner_fn =
+        if let Some(derived_node) = db.get_storage().internal.get_derived_node(derived_node_id) {
+            if let Some(rev) = db
+                .get_storage()
+                .internal
+                .get_derived_node_revision(derived_node_id)
+            {
+                if rev.time_updated > since {
+                    return true;
+                }
+            } else {
                 return true;
             }
+            derived_node.inner_fn
         } else {
             return true;
-        }
-        derived_node.inner_fn
-    } else {
-        return true;
-    };
-    let did_recalculate = db.execute_memoized_function(derived_node_id, inner_fn);
+        };
+    let did_recalculate = execute_memoized_function(db, derived_node_id, inner_fn);
     matches!(
         did_recalculate,
         DidRecalculate::Recalculated | DidRecalculate::Error
     )
 }
 
-fn invoke_with_dependency_tracking(
-    db: &Database,
+fn invoke_with_dependency_tracking<Db: Database>(
+    db: &Db,
     derived_node_id: DerivedNodeId,
-    inner_fn: InnerFn,
+    inner_fn: InnerFn<Db>,
 ) -> Option<(Box<dyn DynEq>, TrackedDependencies)> {
-    let guard = db.dependency_stack.enter(derived_node_id);
+    let guard = db.get_storage().dependency_stack.enter(derived_node_id);
     let result = inner_fn.0(db, derived_node_id);
     let dependencies = guard.release();
     Some((result?, dependencies))

--- a/crates/pico/src/garbage_collection.rs
+++ b/crates/pico/src/garbage_collection.rs
@@ -7,10 +7,10 @@ use tracing::debug;
 use crate::{
     dependency::{Dependency, NodeKind},
     index::Index,
-    DatabaseStorage, DerivedNode, DerivedNodeId, DerivedNodeRevision, ParamId,
+    Database, DerivedNode, DerivedNodeId, DerivedNodeRevision, InternalStorage, ParamId,
 };
 
-impl DatabaseStorage {
+impl<Db: Database> InternalStorage<Db> {
     /// Run garbage collection, retaining retained_derived_node_ids (which represent
     /// top level function calls) and everything reachable from them.
     ///

--- a/crates/pico/src/lib.rs
+++ b/crates/pico/src/lib.rs
@@ -14,7 +14,9 @@ mod source;
 
 pub use database::*;
 pub use derived_node::*;
+pub use dyn_eq::*;
 pub use execute_memoized_function::*;
 pub use intern::*;
 pub use memo_ref::*;
+pub use retained_query::*;
 pub use source::*;

--- a/crates/pico/tests/basic.rs
+++ b/crates/pico/tests/basic.rs
@@ -1,13 +1,18 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::{Database, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
 
 static FIRST_LETTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
 #[test]
 fn basic() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let input_id = db.set(Input {
         key: "key",
@@ -34,7 +39,7 @@ struct Input {
 }
 
 #[memo]
-fn first_letter(db: &Database, input_id: SourceId<Input>) -> char {
+fn first_letter(db: &TestDatabase, input_id: SourceId<Input>) -> char {
     FIRST_LETTER_COUNTER.fetch_add(1, Ordering::SeqCst);
     let input = db.get(input_id);
     input.value.chars().next().unwrap()

--- a/crates/pico/tests/cyclic_dependency_panic.rs
+++ b/crates/pico/tests/cyclic_dependency_panic.rs
@@ -1,10 +1,15 @@
-use pico::Database;
-use pico_macros::memo;
+use pico::Storage;
+use pico_macros::{memo, Db};
+
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
 
 #[test]
 #[should_panic]
 fn test_calls_itself() {
-    let db = Database::default();
+    let db = TestDatabase::default();
 
     // calls_itself calls calls_itself, which panics
     calls_itself(&db);
@@ -13,7 +18,7 @@ fn test_calls_itself() {
 #[test]
 #[should_panic]
 fn test_calls_calls_itself() {
-    let db = Database::default();
+    let db = TestDatabase::default();
 
     // calls_calls_itself calls calls_itself, which calls calls_itself, which panics
     calls_calls_itself(&db);
@@ -22,7 +27,7 @@ fn test_calls_calls_itself() {
 #[test]
 #[should_panic]
 fn test_a() {
-    let db = Database::default();
+    let db = TestDatabase::default();
 
     // a calls b, which calls a, which panics
     a(&db);
@@ -31,33 +36,33 @@ fn test_a() {
 #[test]
 #[should_panic]
 fn test_calls_a() {
-    let db = Database::default();
+    let db = TestDatabase::default();
 
     // calls_a calls a, which calls b, which calls a, which panics
     calls_a(&db);
 }
 
 #[memo]
-fn calls_itself(database: &Database) {
+fn calls_itself(database: &TestDatabase) {
     calls_itself(database);
 }
 
 #[memo]
-fn calls_calls_itself(database: &Database) {
+fn calls_calls_itself(database: &TestDatabase) {
     calls_itself(database);
 }
 
 #[memo]
-fn a(database: &Database) {
+fn a(database: &TestDatabase) {
     b(database);
 }
 
 #[memo]
-fn b(database: &Database) {
+fn b(database: &TestDatabase) {
     a(database);
 }
 
 #[memo]
-fn calls_a(database: &Database) {
+fn calls_a(database: &TestDatabase) {
     a(database);
 }

--- a/crates/pico/tests/garbage_collection/basic_gc.rs
+++ b/crates/pico/tests/garbage_collection/basic_gc.rs
@@ -1,15 +1,28 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::Database;
-use pico_macros::memo;
+use pico::{Database, Storage};
+use pico_macros::{memo, Db};
 
 static A_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static B_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
+impl TestDatabase {
+    pub fn new() -> Self {
+        Self {
+            storage: Storage::new_with_capacity(1.try_into().unwrap()),
+        }
+    }
+}
+
 #[test]
 fn basic_gc() {
     // When we garbage collect, we will only keep the most recently called top-level field
-    let mut db = Database::new_with_capacity(1.try_into().unwrap());
+    let mut db = TestDatabase::new();
 
     memoized_a(&db);
     assert_eq!(A_COUNTER.load(Ordering::SeqCst), 1);
@@ -28,13 +41,13 @@ fn basic_gc() {
 }
 
 #[memo]
-fn memoized_a(_db: &Database) -> char {
+fn memoized_a(_db: &TestDatabase) -> char {
     A_COUNTER.fetch_add(1, Ordering::SeqCst);
     'a'
 }
 
 #[memo]
-fn memoized_b(_db: &Database) -> char {
+fn memoized_b(_db: &TestDatabase) -> char {
     B_COUNTER.fetch_add(1, Ordering::SeqCst);
     'b'
 }

--- a/crates/pico/tests/garbage_collection/inner_retained.rs
+++ b/crates/pico/tests/garbage_collection/inner_retained.rs
@@ -1,15 +1,28 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::Database;
-use pico_macros::memo;
+use pico::{Database, Storage};
+use pico_macros::{memo, Db};
 
 static OUTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static INNER_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
+impl TestDatabase {
+    pub fn new() -> Self {
+        Self {
+            storage: Storage::new_with_capacity(1.try_into().unwrap()),
+        }
+    }
+}
+
 #[test]
 fn inner_retained() {
     // When we garbage collect, we will only keep the most recently called top-level field
-    let mut db = Database::new_with_capacity(1.try_into().unwrap());
+    let mut db = TestDatabase::new();
 
     outer(&db);
     assert_eq!(OUTER_COUNTER.load(Ordering::SeqCst), 1);
@@ -28,14 +41,14 @@ fn inner_retained() {
 }
 
 #[memo]
-fn outer(db: &Database) -> &'static str {
+fn outer(db: &TestDatabase) -> &'static str {
     inner(db);
     OUTER_COUNTER.fetch_add(1, Ordering::SeqCst);
     "outer"
 }
 
 #[memo]
-fn inner(_db: &Database) -> &'static str {
+fn inner(_db: &TestDatabase) -> &'static str {
     INNER_COUNTER.fetch_add(1, Ordering::SeqCst);
     "inner"
 }

--- a/crates/pico/tests/garbage_collection/multiple_calls.rs
+++ b/crates/pico/tests/garbage_collection/multiple_calls.rs
@@ -1,15 +1,28 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::Database;
-use pico_macros::memo;
+use pico::{Database, Storage};
+use pico_macros::{memo, Db};
 
 static A_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static B_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
+impl TestDatabase {
+    pub fn new() -> Self {
+        Self {
+            storage: Storage::new_with_capacity(2.try_into().unwrap()),
+        }
+    }
+}
+
 #[test]
 fn multiple_calls() {
     // When we garbage collect, we will only keep the most recently called top-level field
-    let mut db = Database::new_with_capacity(2.try_into().unwrap());
+    let mut db = TestDatabase::new();
 
     memoized_a(&db);
     assert_eq!(A_COUNTER.load(Ordering::SeqCst), 1);
@@ -30,13 +43,13 @@ fn multiple_calls() {
 }
 
 #[memo]
-fn memoized_a(_db: &Database) -> char {
+fn memoized_a(_db: &TestDatabase) -> char {
     A_COUNTER.fetch_add(1, Ordering::SeqCst);
     'a'
 }
 
 #[memo]
-fn memoized_b(_db: &Database) -> char {
+fn memoized_b(_db: &TestDatabase) -> char {
     B_COUNTER.fetch_add(1, Ordering::SeqCst);
     'b'
 }

--- a/crates/pico/tests/garbage_collection/retained_and_in_lru.rs
+++ b/crates/pico/tests/garbage_collection/retained_and_in_lru.rs
@@ -1,15 +1,28 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::Database;
-use pico_macros::memo;
+use pico::{retain, Database, Storage};
+use pico_macros::{memo, Db};
 
 static A_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static B_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
+impl TestDatabase {
+    pub fn new() -> Self {
+        Self {
+            storage: Storage::new_with_capacity(1.try_into().unwrap()),
+        }
+    }
+}
+
 #[test]
 fn basic_retained() {
     // When we garbage collect, we will only keep the most recently called top-level field
-    let mut db = Database::new_with_capacity(1.try_into().unwrap());
+    let mut db = TestDatabase::new();
 
     let memo_ref_a = memoized_a(&db);
     assert_eq!(A_COUNTER.load(Ordering::SeqCst), 1);
@@ -17,7 +30,7 @@ fn basic_retained() {
     memoized_b(&db);
     assert_eq!(B_COUNTER.load(Ordering::SeqCst), 1);
 
-    let retain = db.retain(memo_ref_a);
+    let retain = retain(&db, memo_ref_a);
     retain.never_garbage_collect();
 
     memoized_a(&db);
@@ -33,13 +46,13 @@ fn basic_retained() {
 }
 
 #[memo]
-fn memoized_a(_db: &Database) -> char {
+fn memoized_a(_db: &TestDatabase) -> char {
     A_COUNTER.fetch_add(1, Ordering::SeqCst);
     'a'
 }
 
 #[memo]
-fn memoized_b(_db: &Database) -> char {
+fn memoized_b(_db: &TestDatabase) -> char {
     B_COUNTER.fetch_add(1, Ordering::SeqCst);
     'b'
 }

--- a/crates/pico/tests/intern.rs
+++ b/crates/pico/tests/intern.rs
@@ -1,10 +1,15 @@
-use pico::{Database, MemoRef, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, MemoRef, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
 use thiserror::Error;
+
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
 
 #[test]
 fn intern() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let id = db.set(Input {
         key: "key",
@@ -35,7 +40,7 @@ enum ProcessInputError {
 
 #[memo]
 fn first_letter(
-    db: &Database,
+    db: &TestDatabase,
     input_id: SourceId<Input>,
 ) -> Result<MemoRef<char>, FirstLetterError> {
     db.get(input_id)
@@ -48,7 +53,7 @@ fn first_letter(
 
 #[memo]
 fn process_input(
-    db: &Database,
+    db: &TestDatabase,
     input_id: SourceId<Input>,
 ) -> Result<MemoRef<char>, ProcessInputError> {
     let result = first_letter(db, input_id).to_owned()?;

--- a/crates/pico/tests/overriding_same_source.rs
+++ b/crates/pico/tests/overriding_same_source.rs
@@ -1,13 +1,18 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::{Database, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
 
 static FIRST_LETTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
 #[test]
 fn overriding_same_source() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let input_id = db.set(Input {
         key: "key",
@@ -37,7 +42,7 @@ struct Input {
 }
 
 #[memo]
-fn first_letter(db: &Database, input_id: SourceId<Input>) -> char {
+fn first_letter(db: &TestDatabase, input_id: SourceId<Input>) -> char {
     FIRST_LETTER_COUNTER.fetch_add(1, Ordering::SeqCst);
     let input = db.get(input_id);
     input.value.chars().next().unwrap()

--- a/crates/pico/tests/params/memo_ref_never_cloned.rs
+++ b/crates/pico/tests/params/memo_ref_never_cloned.rs
@@ -1,13 +1,18 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::{Database, MemoRef};
-use pico_macros::memo;
+use pico::{MemoRef, Storage};
+use pico_macros::{memo, Db};
 
 static OUTPUT_CLONE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
 #[test]
 fn memo_ref_never_cloned() {
-    let db = Database::default();
+    let db = TestDatabase::default();
 
     let output = get_output(&db);
 
@@ -29,9 +34,9 @@ impl Clone for Output {
 }
 
 #[memo]
-fn get_output(_db: &Database) -> Output {
+fn get_output(_db: &TestDatabase) -> Output {
     Output {}
 }
 
 #[memo]
-fn consume_output(db: &Database, _output: MemoRef<Output>) {}
+fn consume_output(db: &TestDatabase, _output: MemoRef<Output>) {}

--- a/crates/pico/tests/params/source_id_never_cloned.rs
+++ b/crates/pico/tests/params/source_id_never_cloned.rs
@@ -1,14 +1,19 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::{Database, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
 
 static INPUT_CLONE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static ASSERT_INPUT_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
 #[test]
 fn source_id_never_cloned() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
     let input_id = db.set(Input {
         key: "key",
         value: "asdf".to_string(),
@@ -51,7 +56,7 @@ impl Clone for Input {
 }
 
 #[memo]
-fn assert_input_cloned(db: &Database, input_id: SourceId<Input>) {
+fn assert_input_cloned(db: &TestDatabase, input_id: SourceId<Input>) {
     ASSERT_INPUT_COUNTER.fetch_add(1, Ordering::SeqCst);
     db.get(input_id);
     assert_eq!(INPUT_CLONE_COUNTER.load(Ordering::SeqCst), 0);

--- a/crates/pico/tests/partial_reuse_multi_function.rs
+++ b/crates/pico/tests/partial_reuse_multi_function.rs
@@ -1,18 +1,23 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::{Database, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
 
 static FIRST_LETTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static FIRST_LETTER_AND_EXCLAMATION_POINT_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static FIRST_LETTER_AND_QUESTION_MARK_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
 
 #[test]
 fn multi_chain_reuse() {
     FIRST_LETTER_AND_EXCLAMATION_POINT_COUNTER.store(0, Ordering::SeqCst);
     FIRST_LETTER_AND_QUESTION_MARK_COUNTER.store(0, Ordering::SeqCst);
 
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let input_id = db.set(Input {
         key: "key",
@@ -45,21 +50,21 @@ struct Input {
 }
 
 #[memo]
-fn first_letter(db: &Database, input_id: SourceId<Input>) -> char {
+fn first_letter(db: &TestDatabase, input_id: SourceId<Input>) -> char {
     FIRST_LETTER_COUNTER.fetch_add(1, Ordering::SeqCst);
     let input = db.get(input_id);
     input.value.chars().next().unwrap()
 }
 
 #[memo]
-fn first_letter_and_exclamation_point(db: &Database, input_id: SourceId<Input>) -> String {
+fn first_letter_and_exclamation_point(db: &TestDatabase, input_id: SourceId<Input>) -> String {
     FIRST_LETTER_AND_EXCLAMATION_POINT_COUNTER.fetch_add(1, Ordering::SeqCst);
     let capitalized_first_letter = *first_letter(db, input_id);
     format!("{capitalized_first_letter}!")
 }
 
 #[memo]
-fn first_letter_and_question_mark(db: &Database, input_id: SourceId<Input>) -> String {
+fn first_letter_and_question_mark(db: &TestDatabase, input_id: SourceId<Input>) -> String {
     FIRST_LETTER_AND_QUESTION_MARK_COUNTER.fetch_add(1, Ordering::SeqCst);
     let capitalized_first_letter = *first_letter(db, input_id);
     format!("{capitalized_first_letter}?")

--- a/crates/pico/tests/removing_params.rs
+++ b/crates/pico/tests/removing_params.rs
@@ -1,10 +1,15 @@
-use pico::{Database, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
+
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
 
 #[test]
 #[should_panic]
 fn removing_direct_param_causes_panic() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let input_id = db.set(Input {
         key: "key",
@@ -19,7 +24,7 @@ fn removing_direct_param_causes_panic() {
 #[test]
 #[should_panic]
 fn removing_indirect_param_causes_panic() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let input_id = db.set(Input {
         key: "key",
@@ -43,13 +48,13 @@ struct Input {
 }
 
 #[memo]
-fn first_letter(db: &Database, input_id: SourceId<Input>) -> char {
+fn first_letter(db: &TestDatabase, input_id: SourceId<Input>) -> char {
     let input = db.get(input_id);
     input.value.chars().next().unwrap()
 }
 
 #[memo]
-fn capitalized_first_letter(db: &Database, input_id: SourceId<Input>) -> char {
+fn capitalized_first_letter(db: &TestDatabase, input_id: SourceId<Input>) -> char {
     let first = first_letter(db, input_id);
     first.to_ascii_uppercase()
 }

--- a/crates/pico/tests/return_value_not_cloned.rs
+++ b/crates/pico/tests/return_value_not_cloned.rs
@@ -1,13 +1,18 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::{Database, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
 
 static RETURN_VALUE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
 #[test]
 fn arg_reference() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let input_id = db.set(Input {
         key: "input",
@@ -39,7 +44,7 @@ impl Clone for ReturnValue {
 }
 
 #[memo]
-fn first_letter(db: &Database, input_id: SourceId<Input>) -> ReturnValue {
+fn first_letter(db: &TestDatabase, input_id: SourceId<Input>) -> ReturnValue {
     let input = db.get(input_id);
     ReturnValue(input.value.chars().next().unwrap())
 }

--- a/crates/pico/tests/same_source_key.rs
+++ b/crates/pico/tests/same_source_key.rs
@@ -1,9 +1,14 @@
-use pico::{Database, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
+
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
 
 #[test]
 fn same_source_key() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let input_a = db.set(InputA {
         key: "source",
@@ -33,11 +38,11 @@ struct InputB {
 }
 
 #[memo]
-fn memoized_a(db: &Database, input: SourceId<InputA>) -> char {
+fn memoized_a(db: &TestDatabase, input: SourceId<InputA>) -> char {
     db.get(input).value.chars().next().unwrap()
 }
 
 #[memo]
-fn memoized_b(db: &Database, input: SourceId<InputB>) -> char {
+fn memoized_b(db: &TestDatabase, input: SourceId<InputB>) -> char {
     db.get(input).value.chars().next().unwrap()
 }

--- a/crates/pico/tests/singleton.rs
+++ b/crates/pico/tests/singleton.rs
@@ -1,13 +1,18 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::Database;
-use pico_macros::{memo, Singleton};
+use pico::{Database, Storage};
+use pico_macros::{memo, Db, Singleton};
 
 static FIRST_LETTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
 #[test]
 fn singleton() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     assert_eq!(db.get_singleton::<Input>(), None);
 
@@ -38,7 +43,7 @@ struct Input {
 }
 
 #[memo]
-fn first_letter(db: &Database) -> char {
+fn first_letter(db: &TestDatabase) -> char {
     FIRST_LETTER_COUNTER.fetch_add(1, Ordering::SeqCst);
     let input = db
         .get_singleton::<Input>()

--- a/crates/pico/tests/store_memo_ref.rs
+++ b/crates/pico/tests/store_memo_ref.rs
@@ -1,14 +1,19 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::{Database, MemoRef, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, MemoRef, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
 
 static FIRST_LETTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static FIRST_LETTER_AS_MEMO_REF_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
 #[test]
 fn store_memo_ref() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let id = db.set(Input {
         key: "key",
@@ -37,14 +42,14 @@ struct Input {
 }
 
 #[memo]
-fn first_letter(db: &Database, input_id: SourceId<Input>) -> char {
+fn first_letter(db: &TestDatabase, input_id: SourceId<Input>) -> char {
     FIRST_LETTER_COUNTER.fetch_add(1, Ordering::SeqCst);
     let input = db.get(input_id);
     input.value.chars().next().unwrap()
 }
 
 #[memo]
-fn first_letter_as_memo_ref(db: &Database, input_id: SourceId<Input>) -> MemoRef<char> {
+fn first_letter_as_memo_ref(db: &TestDatabase, input_id: SourceId<Input>) -> MemoRef<char> {
     FIRST_LETTER_AS_MEMO_REF_COUNTER.fetch_add(1, Ordering::SeqCst);
     first_letter(db, input_id)
 }

--- a/crates/pico/tests/unrelated_source_change.rs
+++ b/crates/pico/tests/unrelated_source_change.rs
@@ -1,13 +1,18 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use pico::{Database, SourceId};
-use pico_macros::{memo, Source};
+use pico::{Database, SourceId, Storage};
+use pico_macros::{memo, Db, Source};
 
 static FIRST_LETTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Db, Default)]
+struct TestDatabase {
+    pub storage: Storage<Self>,
+}
+
 #[test]
 fn unrelated_source_changes() {
-    let mut db = Database::default();
+    let mut db = TestDatabase::default();
 
     let input_id = db.set(Input {
         key: "key",
@@ -40,7 +45,7 @@ struct Input {
 }
 
 #[memo]
-fn first_letter(db: &Database, input_id: SourceId<Input>) -> char {
+fn first_letter(db: &TestDatabase, input_id: SourceId<Input>) -> char {
     FIRST_LETTER_COUNTER.fetch_add(1, Ordering::SeqCst);
     let input = db.get(input_id);
     input.value.chars().next().unwrap()

--- a/crates/pico_macros/src/db_macro.rs
+++ b/crates/pico_macros/src/db_macro.rs
@@ -1,0 +1,57 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+pub(crate) fn db_macro(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+    let struct_name = input.ident.clone();
+
+    let output = quote! {
+        impl ::pico::Database for #struct_name {
+            fn get_storage(&self) -> &::pico::Storage<Self> {
+                &self.storage
+            }
+
+            fn get<T: 'static>(&self, id: ::pico::SourceId<T>) -> &T {
+                self.storage.get(id)
+            }
+
+            fn get_singleton<T: ::pico::Singleton + 'static>(&self) -> Option<&T> {
+                self.storage.get_singleton::<T>()
+            }
+
+            fn intern<T: Clone + std::hash::Hash + ::pico::DynEq + 'static>(&self, value: T) -> ::pico::MemoRef<T> {
+                ::pico::intern(self, value)
+            }
+
+            fn intern_ref<T: Clone + std::hash::Hash + ::pico::DynEq + 'static>(&self, value: &T) -> ::pico::MemoRef<T> {
+                ::pico::intern_ref(self, value)
+            }
+
+            fn set<T: ::pico::Source + ::pico::DynEq>(&mut self, source: T) -> ::pico::SourceId<T> {
+                self.storage.set(source)
+            }
+
+            fn remove<T>(&mut self, id: ::pico::SourceId<T>) {
+                self.storage.remove(id)
+            }
+
+            fn remove_singleton<T: ::pico::Singleton + 'static>(&mut self) {
+                self.storage.remove_singleton::<T>()
+            }
+
+            fn run_garbage_collection(&mut self) {
+                self.storage.run_garbage_collection()
+            }
+        }
+
+        impl ::pico::DatabaseDyn for #struct_name {
+            fn get_storage_dyn(&self) -> &dyn ::pico::StorageDyn {
+                use ::pico::Database;
+                self.get_storage()
+            }
+        }
+    };
+
+    output.into()
+}

--- a/crates/pico_macros/src/lib.rs
+++ b/crates/pico_macros/src/lib.rs
@@ -1,3 +1,4 @@
+mod db_macro;
 mod memo_macro;
 mod singleton_macro;
 mod source_macro;
@@ -19,4 +20,9 @@ pub fn source(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Singleton)]
 pub fn singleton(input: TokenStream) -> TokenStream {
     singleton_macro::singleton_macro(input)
+}
+
+#[proc_macro_derive(Db)]
+pub fn db(input: TokenStream) -> TokenStream {
+    db_macro::db_macro(input)
 }

--- a/crates/pico_macros/src/memo_macro.rs
+++ b/crates/pico_macros/src/memo_macro.rs
@@ -122,10 +122,11 @@ pub(crate) fn memo_macro(_args: TokenStream, item: TokenStream) -> TokenStream {
                 #param_ids_blocks
             )*
             let derived_node_id = ::pico::DerivedNodeId::new(#fn_hash.into(), param_ids);
-            let did_recalculate = ::pico::macro_fns::execute_memoized_function(
+            let did_recalculate = ::pico::execute_memoized_function(
                 #db_arg,
                 derived_node_id,
                 ::pico::InnerFn::new(|#db_arg, derived_node_id| {
+                    use ::pico::Database;
                     #(
                         #extract_parameters
                     )*


### PR DESCRIPTION
Here is an example how we can implement `#[derive(Db)]` on some struct and use it as a `Database`. This allows us to add new methods and fields, which can be used inside memoized functions.