### PR TITLE
replace usages of removed `bacon -p` with `watch`

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -13,14 +13,17 @@ command = [
 	"cargo", "build",
 	"--color", "always",
 ]
+watch = ["crates"]
 need_stdout = false
 
 [jobs.watch-libs]
 command = ["pnpm", "compile-libs"]
+watch = ["libs"]
 need_stdout = true
 
 [jobs.check]
 command = ["cargo", "check", "--color", "always"]
+watch = ["crates"]
 need_stdout = false
 
 [jobs.check-all]
@@ -122,7 +125,8 @@ b = "job:build"
 
 [jobs.build-swc]
 command = [
-	"cargo", "build", "-p", "swc_isograph_plugin", "--release", "--target", "wasm32-wasip1", 
+	"cargo", "build", "-p", "swc_isograph_plugin", "--release", "--target", "wasm32-wasip1",
 	"--color", "always",
 ]
+watch = ["crates"]
 need_stdout = false

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "vitest": "^2.1.2"
   },
   "scripts": {
-    "watch-rs": "bacon -j build -p ./crates/",
-    "watch-swc": "bacon -j build-swc -p ./crates/",
-    "check-rs": "bacon -j check -p ./crates/",
+    "watch-rs": "bacon -j build",
+    "watch-swc": "bacon -j build-swc",
+    "check-rs": "bacon -j check",
     "build": "cargo build",
     "build-swc": "cargo build -p swc_isograph_plugin --release --target wasm32-wasip1 && cd ./libs/isograph-swc-plugin && pnpm prepack",
     "compile-libs": "pnpm turbo compile-libs --log-order=grouped",
@@ -29,7 +29,7 @@
     "build-pet-demo": "cross-env ISO_PRINT_ABSOLUTE_FILEPATH=1 pnpm --filter=pet-demo iso",
     "build-isograph-react-demo": "cross-env ISO_PRINT_ABSOLUTE_FILEPATH=1 pnpm --filter=@isograph/react iso",
     "build-vite-demo": "cross-env ISO_PRINT_ABSOLUTE_FILEPATH=1 pnpm --filter=vite-demo iso",
-    "watch-libs": "bacon -j watch-libs -p ./libs",
+    "watch-libs": "bacon -j watch-libs",
     "format": "pnpm run format-prettier && pnpm run format-rust",
     "format-prettier": "prettier --config ./.prettierrc.json --write .",
     "format-rust": "cargo fmt",


### PR DESCRIPTION
This PR updates the `bacon` scripts to stop using the [removed](https://github.com/Canop/bacon/pull/277) `-p` option.