### PR TITLE
fix: toSorted to use `arr: readonly T[]` - issue #542

### DIFF
--- a/docs-website/docs/quickstart.md
+++ b/docs-website/docs/quickstart.md
@@ -280,7 +280,10 @@ function nonNullable<T>(value: T): value is NonNullable<T> {
   return value != null;
 }
 
-function toSorted<T>(arr: T[], comparator: (a: T, b: T) => number): T[] {
+function toSorted<T>(
+  arr: readonly T[],
+  comparator: (a: T, b: T) => number,
+): T[] {
   const sorted = [...arr];
   sorted.sort(comparator);
   return sorted;
@@ -428,7 +431,10 @@ function nonNullable<T>(value: T): value is NonNullable<T> {
   return value != null;
 }
 
-function toSorted<T>(arr: T[], comparator: (a: T, b: T) => number): T[] {
+function toSorted<T>(
+  arr: readonly T[],
+  comparator: (a: T, b: T) => number,
+): T[] {
   const sorted = [...arr];
   sorted.sort(comparator);
   return sorted;


### PR DESCRIPTION
fix a ts complain in the Quickstart tutorial