### PR TITLE
fix LSP on windows

### DIFF
--- a/crates/common_lang_types/src/location.rs
+++ b/crates/common_lang_types/src/location.rs
@@ -1,6 +1,9 @@
-use std::{error::Error, fmt, path::PathBuf};
-
 use intern::string_key::{Intern, Lookup};
+use std::{
+    error::Error,
+    fmt,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     text_with_carats::text_with_carats, CurrentWorkingDirectory, RelativePathToSourceFile, Span,
@@ -225,11 +228,31 @@ impl<T> From<WithEmbeddedLocation<T>> for WithLocation<T> {
     }
 }
 
+pub fn strip_windows_long_path_prefix(path: &Path) -> &Path {
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(stripped) = path.strip_prefix(r"\\?\") {
+            return stripped;
+        }
+    }
+    path
+}
+
+pub fn diff_paths_with_prefix<P, B>(path: P, base: B) -> Option<PathBuf>
+where
+    P: AsRef<Path>,
+    B: AsRef<Path>,
+{
+    let clean_path = strip_windows_long_path_prefix(path.as_ref());
+
+    pathdiff::diff_paths(clean_path, base)
+}
+
 pub fn relative_path_from_absolute_and_working_directory(
     current_working_directory: CurrentWorkingDirectory,
     absolute_path: &PathBuf,
 ) -> RelativePathToSourceFile {
-    pathdiff::diff_paths(
+    diff_paths_with_prefix(
         absolute_path,
         PathBuf::from(current_working_directory.lookup()),
     )


### PR DESCRIPTION
`pathdiff::diff_paths` doesn't support windows path starting with `\\?\`