### PR TITLE
verify deps before run

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ link-workspace-packages = deep
 prefer-workspace-packages = true
 enable-pre-post-scripts = true
 save-workspace-protocol = false
+verify-deps-before-run = install

--- a/package.json
+++ b/package.json
@@ -55,5 +55,5 @@
   "engines": {
     "node": "22.9.0"
   },
-  "packageManager": "pnpm@9.11.0"
+  "packageManager": "pnpm@10.15.0"
 }


### PR DESCRIPTION
This is super cool flag, whenever you run any command, it will first check if node_modules are up to date with lockfile and update if necessary.
It's all super fast and seemless.

You never again have to run `pnpm i`.

This is especially cool if you have a bot to update the dependecies, you can just `git pull` `git checkout` and run whatever you want without worry your deps are out of date. 