### PR TITLE
fix: LSP on Windows

### DIFF
--- a/crates/isograph_cli/src/main.rs
+++ b/crates/isograph_cli/src/main.rs
@@ -108,7 +108,7 @@ fn current_working_directory() -> CurrentWorkingDirectory {
 
     if cfg!(target_os = "windows") {
         current_dir = std::fs::canonicalize(current_dir)
-            .expect("Expected current working directory to exist");
+            .expect("Expected current working directory to be able to be canonicalized");
     }
 
     current_dir

--- a/crates/isograph_cli/src/main.rs
+++ b/crates/isograph_cli/src/main.rs
@@ -104,8 +104,14 @@ fn configure_logger(log_level: LevelFilter) {
 }
 
 fn current_working_directory() -> CurrentWorkingDirectory {
-    std::env::current_dir()
-        .expect("Expected current working to exist")
+    let mut current_dir = std::env::current_dir().expect("Expected current working to exist");
+
+    if cfg!(target_os = "windows") {
+        current_dir = std::fs::canonicalize(current_dir)
+            .expect("Expected current working directory to exist");
+    }
+
+    current_dir
         .to_str()
         .expect("Expected current working directory to be able to be stringified.")
         .intern()

--- a/crates/isograph_lsp/src/uri_file_path_ext.rs
+++ b/crates/isograph_lsp/src/uri_file_path_ext.rs
@@ -6,8 +6,14 @@ pub trait UriFilePathExt {
 
 impl UriFilePathExt for lsp_types::Uri {
     fn to_file_path(&self) -> Result<PathBuf, ()> {
-        url::Url::parse(self.as_str())
+        let mut file_path = url::Url::parse(self.as_str())
             .map_err(|_| ())?
-            .to_file_path()
+            .to_file_path();
+
+        if cfg!(target_os = "windows") {
+            file_path = std::fs::canonicalize(file_path?).map_err(|_| ());
+        }
+
+        file_path
     }
 }


### PR DESCRIPTION
As it turns out, some functions return paths in lowercase: "e:\isograph\..." (beacuse paths on windows are not case sensitive). Calling `canonicalize` corrects the casing.