### PR TITLE
[LSP] fix overlow error on hover

### DIFF
--- a/crates/isograph_lsp/src/hover.rs
+++ b/crates/isograph_lsp/src/hover.rs
@@ -194,7 +194,7 @@ fn find_iso_literal_extraction_under_cursor<'a>(
             let diff_char = if diff_line > 0 {
                 target_line_char.character
             } else {
-                target_line_char.character - start_line_count
+                target_line_char.character - start_char_count
             };
 
             // This is the character offset in the extract item where we are hovering


### PR DESCRIPTION
This line was cauing `attempt to subtract with overflow` error


This maybe fixes #624