### PR TITLE
improve types for entrypoints with unknonw normalization ast

### DIFF
--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -81,14 +81,16 @@ export function stableCopy<T>(value: T): T {
 export function getOrCreateCacheForArtifact<
   TReadFromStore extends UnknownTReadFromStore,
   TClientFieldValue,
-  TNormalizationAst extends NormalizationAst | NormalizationAstLoader,
+  TEntrypoint extends
+    | IsographEntrypoint<TReadFromStore, TClientFieldValue, NormalizationAst>
+    | IsographEntrypoint<
+        TReadFromStore,
+        TClientFieldValue,
+        NormalizationAstLoader
+      >,
 >(
   environment: IsographEnvironment,
-  entrypoint: IsographEntrypoint<
-    TReadFromStore,
-    TClientFieldValue,
-    TNormalizationAst
-  >,
+  entrypoint: TEntrypoint,
   variables: ExtractParameters<TReadFromStore>,
   fetchOptions?: FetchOptions<TClientFieldValue>,
 ): ParentCache<FragmentReference<TReadFromStore, TClientFieldValue>> {

--- a/libs/isograph-react/src/core/entrypoint.ts
+++ b/libs/isograph-react/src/core/entrypoint.ts
@@ -148,4 +148,6 @@ export type ExtractReadFromStore<Type> =
   Type extends IsographEntrypoint<infer X, any, any> ? X : never;
 export type ExtractResolverResult<Type> =
   Type extends IsographEntrypoint<any, infer X, any> ? X : never;
+export type ExtractNormalizationAst<Type> =
+  Type extends IsographEntrypoint<any, any, infer X> ? X : never;
 export type ExtractProps<Type> = Type extends React.FC<infer X> ? X : never;


### PR DESCRIPTION
finally figured out how to fix types broken in #271

For some reason the type `IsographEntrypoint<..., A | B>` is not equal to `IsographEntrypoint<..., A> | IsographEntrypoint<..., B>` in typescript.


