### PR TITLE
fix client pointer `output_type.ts`

### DIFF
--- a/crates/generate_artifacts/src/eager_reader_artifact.rs
+++ b/crates/generate_artifacts/src/eager_reader_artifact.rs
@@ -2,25 +2,22 @@ use common_lang_types::{
     ArtifactPathAndContent, ParentObjectEntityNameAndSelectableName, WithSpan,
 };
 use intern::Lookup;
-
 use isograph_config::{CompilerConfig, GenerateFileExtensionsOption};
-
 use isograph_lang_types::{ClientFieldDirectiveSet, SelectionType};
 use isograph_schema::{
     ClientScalarOrObjectSelectable, ClientSelectable, NetworkProtocol, Schema,
     ServerObjectSelectable, ValidatedSelection, initial_variable_context,
 };
 use isograph_schema::{RefetchedPathsMap, UserWrittenClientTypeInfo};
-
 use std::{borrow::Cow, collections::BTreeSet, path::PathBuf};
 
-use crate::generate_artifacts::ClientFieldOutputType;
 use crate::{
     generate_artifacts::{
-        ClientFieldFunctionImportStatement, RESOLVER_OUTPUT_TYPE, RESOLVER_OUTPUT_TYPE_FILE_NAME,
-        RESOLVER_PARAM_TYPE, RESOLVER_PARAM_TYPE_FILE_NAME, RESOLVER_PARAMETERS_TYPE_FILE_NAME,
-        RESOLVER_READER_FILE_NAME, generate_client_field_parameter_type,
-        generate_client_field_updatable_data_type, generate_output_type, generate_parameters,
+        ClientFieldFunctionImportStatement, ClientFieldOutputType, RESOLVER_OUTPUT_TYPE,
+        RESOLVER_OUTPUT_TYPE_FILE_NAME, RESOLVER_PARAM_TYPE, RESOLVER_PARAM_TYPE_FILE_NAME,
+        RESOLVER_PARAMETERS_TYPE_FILE_NAME, RESOLVER_READER_FILE_NAME,
+        generate_client_field_parameter_type, generate_client_field_updatable_data_type,
+        generate_output_type, generate_parameters,
     },
     import_statements::{
         param_type_imports_to_import_param_statement, param_type_imports_to_import_statement,

--- a/demos/pet-demo/src/components/__isograph/Query/smartestPet/output_type.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/smartestPet/output_type.ts
@@ -1,4 +1,3 @@
-import type { Link } from '@isograph/react';
 import type React from 'react';
 import { SmartestPet as resolver } from '../../../SmartestPet';
-export type Query__smartestPet__output_type = (Link<"Pet"> | null);
+export type Query__smartestPet__output_type = ReturnType<typeof resolver>;


### PR DESCRIPTION
Let's infer pointer output type here.

 In the future we can use it to map types with typescript, for example if pointer returns array of length two `[Link, Link]`, we map it so the loadable would return an array of length two as well `[{ ... }, { ... }]` 