### PR TITLE
use PartialEq in DynEq trait

### DIFF
--- a/crates/pico/src/dyn_eq.rs
+++ b/crates/pico/src/dyn_eq.rs
@@ -8,7 +8,7 @@ pub trait DynEq: Any {
 
 impl<T> DynEq for T
 where
-    T: Any + Eq,
+    T: Any + PartialEq,
 {
     fn as_any(&self) -> &dyn Any {
         self
@@ -29,12 +29,6 @@ where
 impl PartialEq<dyn DynEq> for dyn DynEq {
     fn eq(&self, other: &dyn DynEq) -> bool {
         self.dyn_eq(other)
-    }
-}
-
-impl PartialEq<&Self> for Box<dyn DynEq> {
-    fn eq(&self, other: &&Self) -> bool {
-        <Self as PartialEq>::eq(self, *other)
     }
 }
 


### PR DESCRIPTION
some types from `lsp_types` are only `PartialEq` and this PR allows to use it as params or return types