### PR TITLE
add WithSerialize type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,7 +1548,7 @@ dependencies = [
 name = "intern"
 version = "0.0.4"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "fnv",
  "hashbrown 0.12.3",
  "indexmap 2.10.0",
@@ -2335,6 +2355,7 @@ dependencies = [
 name = "pico"
 version = "0.4.0"
 dependencies = [
+ "bincode 2.0.1",
  "boxcar",
  "dashmap",
  "intern",
@@ -4071,6 +4092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4184,6 +4211,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vsimd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 
 [workspace.dependencies]
 anyhow = "1.0.83"
+bincode = { version = "2", features = ["serde"] }
 boxcar = "0.2.8"
 clap = { version = "4.5.18", features = ["derive"] }
 colored = "2.0.4"

--- a/crates/pico/Cargo.toml
+++ b/crates/pico/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 intern = { path = "../../relay-crates/intern" }
 pico_macros = { path = "../pico_macros" }
 u64_newtypes = { path = "../u64_newtypes" }
+bincode = { workspace = true }
 boxcar = { workspace = true }
 dashmap = { workspace = true }
 lru = { workspace = true }

--- a/crates/pico/src/lib.rs
+++ b/crates/pico/src/lib.rs
@@ -12,6 +12,7 @@ mod memo_ref;
 mod retained_query;
 mod source;
 mod view;
+mod with_serialize;
 
 pub use database::*;
 pub use derived_node::*;
@@ -22,3 +23,4 @@ pub use memo_ref::*;
 pub use retained_query::*;
 pub use source::*;
 pub use view::*;
+pub use with_serialize::*;

--- a/crates/pico/src/with_serialize.rs
+++ b/crates/pico/src/with_serialize.rs
@@ -1,0 +1,54 @@
+use std::any::TypeId;
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+use std::io::{self, Write};
+use std::ops::Deref;
+
+use serde::Serialize;
+
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WithSerialize<T>(pub T);
+
+impl<T> WithSerialize<T> {
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> Deref for WithSerialize<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+struct HasherWrite<'a, H: Hasher>(&'a mut H);
+
+impl<'a, H: Hasher> Write for HasherWrite<'a, H> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf);
+        Ok(buf.len())
+    }
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<T: Serialize + 'static> Hash for WithSerialize<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        TypeId::of::<T>().hash(state);
+
+        let config = bincode::config::standard()
+            .with_little_endian()
+            .with_fixed_int_encoding();
+
+        let mut hw = HasherWrite(state);
+        bincode::serde::encode_into_std_write(&self.0, &mut hw, config)
+            .expect("cannot serialize inner value");
+    }
+}

--- a/crates/pico/tests/params/with_serialize.rs
+++ b/crates/pico/tests/params/with_serialize.rs
@@ -1,0 +1,64 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use pico::{Database, SourceId, Storage, WithSerialize};
+use pico_macros::{Db, Source, memo};
+use serde::Serialize;
+
+static FIRST_LETTER_COUNTER: AtomicUsize = AtomicUsize::new(0);
+static PARAM_CLONE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Db, Default)]
+struct TestDatabase {
+    storage: Storage<Self>,
+}
+
+#[test]
+fn with_serialize() {
+    let mut db = TestDatabase::default();
+
+    let input_id = db.set(Input {
+        key: "key",
+        value: "asdf".to_string(),
+    });
+
+    accepts_param_with_serialize(&db, input_id, WithSerialize(Param {}));
+    assert_eq!(FIRST_LETTER_COUNTER.load(Ordering::SeqCst), 1);
+    assert_eq!(PARAM_CLONE_COUNTER.load(Ordering::SeqCst), 1);
+
+    db.set(Input {
+        key: "key",
+        value: "qwer".to_string(),
+    });
+
+    accepts_param_with_serialize(&db, input_id, WithSerialize(Param {}));
+    assert_eq!(FIRST_LETTER_COUNTER.load(Ordering::SeqCst), 2);
+    assert_eq!(PARAM_CLONE_COUNTER.load(Ordering::SeqCst), 2);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Source)]
+struct Input {
+    #[key]
+    pub key: &'static str,
+    pub value: String,
+}
+
+#[derive(Serialize)]
+struct Param {}
+
+impl Clone for Param {
+    fn clone(&self) -> Self {
+        PARAM_CLONE_COUNTER.fetch_add(1, Ordering::SeqCst);
+        Self {}
+    }
+}
+
+#[memo]
+fn accepts_param_with_serialize(
+    db: &TestDatabase,
+    input_id: SourceId<Input>,
+    _param: WithSerialize<Param>,
+) -> char {
+    FIRST_LETTER_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let input = db.get(input_id);
+    input.value.chars().next().unwrap()
+}

--- a/crates/pico/tests/tests.rs
+++ b/crates/pico/tests/tests.rs
@@ -11,6 +11,7 @@ mod params {
     mod memo_ref_never_cloned;
     mod other_param_cloned_on_execute;
     mod source_id_never_cloned;
+    mod with_serialize;
 }
 
 mod tracking_field {


### PR DESCRIPTION
a tiny wrapper that allows us to use types that implement `Serialize` but do not implement `Hash` as memoized function parameters