### PR TITLE
fix: implement reachable vars for inline fragments

### DIFF
--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -83,7 +83,11 @@ impl MergedServerSelection {
                         .flat_map(|x| x.reachable_variables()),
                 )
                 .collect(),
-            MergedServerSelection::InlineFragment(_) => vec![],
+            MergedServerSelection::InlineFragment(inline_fragment) => inline_fragment
+                .selection_map
+                .values()
+                .flat_map(|selection| selection.reachable_variables())
+                .collect(),
         }
     }
 }


### PR DESCRIPTION
Reachable variables was only partially implemented.