### PR TITLE
fix: ensure unused variables are not used in query text

### DIFF
--- a/crates/generate_artifacts/src/entrypoint_artifact.rs
+++ b/crates/generate_artifacts/src/entrypoint_artifact.rs
@@ -140,11 +140,26 @@ pub(crate) fn generate_entrypoint_artifacts_with_client_field_traversal_result<
             "Expected entity to exist. \
             This is indicative of a bug in Isograph.",
         );
+
+    let reachable_variables = merged_selection_map
+        .values()
+        .flat_map(|selection| selection.reachable_variables())
+        .map(|variable_name| {
+            *variable_definitions
+                .iter()
+                .find(|definition| definition.name.item == variable_name)
+                .unwrap_or_else(|| panic!(
+                    "Expected to find a variable defined at the root with name {variable_name}.\n\
+                    This is indicative of a bug in Isograph."
+                ))
+        })
+        .collect::<Vec<_>>();
+
     let query_text = TNetworkProtocol::generate_query_text(
         query_name,
         schema,
         merged_selection_map,
-        variable_definitions.iter().copied(),
+        reachable_variables.iter().copied(),
         root_operation_name,
         Format::Pretty,
     );
@@ -230,7 +245,7 @@ pub(crate) fn generate_entrypoint_artifacts_with_client_field_traversal_result<
         query_name,
         schema,
         merged_selection_map,
-        variable_definitions.iter().copied(),
+        reachable_variables.iter().copied(),
         root_operation_name,
         concrete_type.name.item,
         persisted_documents,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/query_text.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/query_text.ts
@@ -1,4 +1,4 @@
-export default 'query PetCheckinsCard($skip: Int, $limit: Int, $id: ID!) {\
+export default 'query PetCheckinsCard($id: ID!, $skip: Int, $limit: Int) {\
   node____id___v_id: node(id: $id) {\
     ... on Pet {\
       __typename,\

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/query_text.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/query_text.ts
@@ -1,4 +1,4 @@
-export default 'query PetCheckinsCardList($skip: Int!, $limit: Int!, $id: ID!) {\
+export default 'query PetCheckinsCardList($id: ID!, $skip: Int!, $limit: Int!) {\
   node____id___v_id: node(id: $id) {\
     ... on Pet {\
       __typename,\

--- a/demos/pet-demo/src/components/__isograph/Query/OnlyOneRootLoadablePet/query_text.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/OnlyOneRootLoadablePet/query_text.ts
@@ -1,3 +1,3 @@
-export default 'query OnlyOneRootLoadablePet($id: ID!) {\
+export default 'query OnlyOneRootLoadablePet {\
   __typename,\
 }';

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/query_text.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/query_text.ts
@@ -1,4 +1,4 @@
-export default 'query NewsfeedPaginationComponent($skip: Int!, $limit: Int!, $id: ID!) {\
+export default 'query NewsfeedPaginationComponent($id: ID!, $skip: Int!, $limit: Int!) {\
   node____id___v_id: node(id: $id) {\
     ... on Viewer {\
       __typename,\


### PR DESCRIPTION
This PR ensures that variables used in loadable fields are not included in the initial query's variable definition set.