### PR TITLE
chore: use btree set for reachable vars

### DIFF
--- a/crates/generate_artifacts/src/entrypoint_artifact.rs
+++ b/crates/generate_artifacts/src/entrypoint_artifact.rs
@@ -153,7 +153,7 @@ pub(crate) fn generate_entrypoint_artifacts_with_client_field_traversal_result<
                     This is indicative of a bug in Isograph."
                 ))
         })
-        .collect::<Vec<_>>();
+        .collect::<BTreeSet<_>>();
 
     let query_text = TNetworkProtocol::generate_query_text(
         query_name,

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -71,7 +71,7 @@ pub enum MergedServerSelection {
 }
 
 impl MergedServerSelection {
-    pub fn reachable_variables(&self) -> Vec<VariableName> {
+    pub fn reachable_variables(&self) -> BTreeSet<VariableName> {
         match self {
             MergedServerSelection::ScalarField(field) => get_variables(&field.arguments).collect(),
             MergedServerSelection::ClientPointer(field)

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/query_text.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/query_text.ts
@@ -1,4 +1,4 @@
-export default 'query PetCheckinsCard($id: ID!, $skip: Int, $limit: Int) {\
+export default 'query PetCheckinsCard($skip: Int, $limit: Int, $id: ID!) {\
   node____id___v_id: node(id: $id) {\
     ... on Pet {\
       __typename,\

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/query_text.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/query_text.ts
@@ -1,4 +1,4 @@
-export default 'query PetCheckinsCardList($id: ID!, $skip: Int!, $limit: Int!) {\
+export default 'query PetCheckinsCardList($skip: Int!, $limit: Int!, $id: ID!) {\
   node____id___v_id: node(id: $id) {\
     ... on Pet {\
       __typename,\

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/query_text.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/query_text.ts
@@ -1,4 +1,4 @@
-export default 'query NewsfeedPaginationComponent($id: ID!, $skip: Int!, $limit: Int!) {\
+export default 'query NewsfeedPaginationComponent($skip: Int!, $limit: Int!, $id: ID!) {\
   node____id___v_id: node(id: $id) {\
     ... on Viewer {\
       __typename,\


### PR DESCRIPTION
this ensures deterministic ordering for variables in generated queries