### PR TITLE
make `fieldName` not contain parent type name 

### DIFF
--- a/crates/artifact_content/src/eager_reader_artifact.rs
+++ b/crates/artifact_content/src/eager_reader_artifact.rs
@@ -96,8 +96,7 @@ pub(crate) fn generate_eager_reader_artifacts<TNetworkProtocol: NetworkProtocol>
     let reader_content = if let ClientScalarSelectionDirectiveSet::None(_) =
         user_written_component_variant
     {
-        let eager_reader_name =
-            format!("{}.{}", parent_object_entity.name, client_selectable.name());
+        let eager_reader_name = client_selectable.name();
         let reader_output_type = format!(
             "{}__{}__output_type",
             parent_object_entity.name,
@@ -126,7 +125,7 @@ pub(crate) fn generate_eager_reader_artifacts<TNetworkProtocol: NetworkProtocol>
             "  ", "  ", "  ", "  ", "  ", "  ", "  ",
         )
     } else {
-        let component_name = format!("{}.{}", parent_object_entity.name, client_selectable.name());
+        let component_name = client_selectable.name();
         let param_type_file_name = *RESOLVER_PARAM_TYPE;
         format!(
             "import type {{ComponentReaderArtifact, ExtractSecondParam, \
@@ -244,10 +243,7 @@ pub(crate) fn generate_eager_reader_condition_artifact<TNetworkProtocol: Network
 
     let reader_output_type = format!("Link<\"{}\"> | null", concrete_type);
 
-    let eager_reader_name = format!(
-        "{}.{}",
-        parent_object_entity.name, server_object_selectable_name
-    );
+    let eager_reader_name = server_object_selectable_name;
 
     let link_field_name = *LINK_FIELD_NAME;
     let reader_content = format!(

--- a/demos/github-demo/src/isograph-components/__isograph/Actor/UserLink/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Actor/UserLink/resolver_reader.ts
@@ -43,7 +43,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Actor.UserLink",
+  fieldName: "UserLink",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Actor/asUser/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Actor/asUser/resolver_reader.ts
@@ -19,7 +19,7 @@ const artifact: EagerReaderArtifact<
   Link<"User"> | null
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Actor.asUser",
+  fieldName: "asUser",
   resolver: ({ data }) => data.__typename === "User" ? data.__link : null,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/IssueComment/formattedCommentCreationDate/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/IssueComment/formattedCommentCreationDate/resolver_reader.ts
@@ -18,7 +18,7 @@ const artifact: EagerReaderArtifact<
   IssueComment__formattedCommentCreationDate__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "IssueComment.formattedCommentCreationDate",
+  fieldName: "formattedCommentCreationDate",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequest/CommentList/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequest/CommentList/resolver_reader.ts
@@ -88,7 +88,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "PullRequest.CommentList",
+  fieldName: "CommentList",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequest/PullRequestLink/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequest/PullRequestLink/resolver_reader.ts
@@ -53,7 +53,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "PullRequest.PullRequestLink",
+  fieldName: "PullRequestLink",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequest/createdAtFormatted/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequest/createdAtFormatted/resolver_reader.ts
@@ -18,7 +18,7 @@ const artifact: EagerReaderArtifact<
   PullRequest__createdAtFormatted__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "PullRequest.createdAtFormatted",
+  fieldName: "createdAtFormatted",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/PullRequestConnection/PullRequestTable/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/PullRequestConnection/PullRequestTable/resolver_reader.ts
@@ -109,7 +109,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "PullRequestConnection.PullRequestTable",
+  fieldName: "PullRequestTable",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Query/Header/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/Header/resolver_reader.ts
@@ -36,7 +36,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.Header",
+  fieldName: "Header",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/HomePage/resolver_reader.ts
@@ -26,7 +26,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.HomePage",
+  fieldName: "HomePage",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Query/HomePageList/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/HomePageList/resolver_reader.ts
@@ -51,7 +51,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.HomePageList",
+  fieldName: "HomePageList",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequest/resolver_reader.ts
@@ -41,7 +41,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.PullRequest",
+  fieldName: "PullRequest",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/PullRequestDetail/resolver_reader.ts
@@ -74,7 +74,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.PullRequestDetail",
+  fieldName: "PullRequestDetail",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryDetail/resolver_reader.ts
@@ -96,7 +96,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.RepositoryDetail",
+  fieldName: "RepositoryDetail",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/RepositoryPage/resolver_reader.ts
@@ -41,7 +41,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.RepositoryPage",
+  fieldName: "RepositoryPage",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserDetail/resolver_reader.ts
@@ -41,7 +41,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.UserDetail",
+  fieldName: "UserDetail",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Query/UserPage/resolver_reader.ts
@@ -31,7 +31,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.UserPage",
+  fieldName: "UserPage",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Repository/IsStarred/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Repository/IsStarred/resolver_reader.ts
@@ -24,7 +24,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Repository.IsStarred",
+  fieldName: "IsStarred",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Repository/RepositoryLink/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Repository/RepositoryLink/resolver_reader.ts
@@ -42,7 +42,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Repository.RepositoryLink",
+  fieldName: "RepositoryLink",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/Repository/RepositoryRow/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/Repository/RepositoryRow/resolver_reader.ts
@@ -89,7 +89,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Repository.RepositoryRow",
+  fieldName: "RepositoryRow",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/User/Avatar/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/Avatar/resolver_reader.ts
@@ -24,7 +24,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "User.Avatar",
+  fieldName: "Avatar",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/RepositoryConnection/resolver_reader.ts
@@ -94,7 +94,7 @@ const artifact: EagerReaderArtifact<
   User__RepositoryConnection__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "User.RepositoryConnection",
+  fieldName: "RepositoryConnection",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/github-demo/src/isograph-components/__isograph/User/RepositoryList/resolver_reader.ts
+++ b/demos/github-demo/src/isograph-components/__isograph/User/RepositoryList/resolver_reader.ts
@@ -40,7 +40,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "User.RepositoryList",
+  fieldName: "RepositoryList",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/AdItem/AdItemDisplay/resolver_reader.ts
@@ -24,7 +24,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "AdItem.AdItemDisplay",
+  fieldName: "AdItemDisplay",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemDisplay/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemDisplay/resolver_reader.ts
@@ -70,7 +70,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "BlogItem.BlogItemDisplay",
+  fieldName: "BlogItemDisplay",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/BlogItem/BlogItemMoreDetail/resolver_reader.ts
@@ -17,7 +17,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "BlogItem.BlogItemMoreDetail",
+  fieldName: "BlogItemMoreDetail",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Checkin/CheckinDisplay/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Checkin/CheckinDisplay/resolver_reader.ts
@@ -32,7 +32,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Checkin.CheckinDisplay",
+  fieldName: "CheckinDisplay",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplay/resolver_reader.ts
@@ -17,7 +17,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Image.ImageDisplay",
+  fieldName: "ImageDisplay",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Image/ImageDisplayWrapper/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Image/ImageDisplayWrapper/resolver_reader.ts
@@ -30,7 +30,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Image.ImageDisplayWrapper",
+  fieldName: "ImageDisplayWrapper",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Mutation/MutualBestFriendSetterOtherSide/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Mutation/MutualBestFriendSetterOtherSide/resolver_reader.ts
@@ -93,7 +93,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Mutation.MutualBestFriendSetterOtherSide",
+  fieldName: "MutualBestFriendSetterOtherSide",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Mutation/MututalBestFriendSetterMutation/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Mutation/MututalBestFriendSetterMutation/resolver_reader.ts
@@ -111,7 +111,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Mutation.MututalBestFriendSetterMutation",
+  fieldName: "MututalBestFriendSetterMutation",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Mutation/SetTagline/resolver_reader.ts
@@ -44,7 +44,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Mutation.SetTagline",
+  fieldName: "SetTagline",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/NewsfeedItem/NewsfeedAdOrBlog/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/NewsfeedItem/NewsfeedAdOrBlog/resolver_reader.ts
@@ -62,7 +62,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "NewsfeedItem.NewsfeedAdOrBlog",
+  fieldName: "NewsfeedAdOrBlog",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/NewsfeedItem/asAdItem/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/NewsfeedItem/asAdItem/resolver_reader.ts
@@ -19,7 +19,7 @@ const artifact: EagerReaderArtifact<
   Link<"AdItem"> | null
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "NewsfeedItem.asAdItem",
+  fieldName: "asAdItem",
   resolver: ({ data }) => data.__typename === "AdItem" ? data.__link : null,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/NewsfeedItem/asBlogItem/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/NewsfeedItem/asBlogItem/resolver_reader.ts
@@ -19,7 +19,7 @@ const artifact: EagerReaderArtifact<
   Link<"BlogItem"> | null
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "NewsfeedItem.asBlogItem",
+  fieldName: "asBlogItem",
   resolver: ({ data }) => data.__typename === "BlogItem" ? data.__link : null,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/Avatar/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/Avatar/resolver_reader.ts
@@ -17,7 +17,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.Avatar",
+  fieldName: "Avatar",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/FavoritePhraseLoader/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/FavoritePhraseLoader/resolver_reader.ts
@@ -17,7 +17,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.FavoritePhraseLoader",
+  fieldName: "FavoritePhraseLoader",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/FirstCheckinMakeSuperButton/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/FirstCheckinMakeSuperButton/resolver_reader.ts
@@ -46,7 +46,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.FirstCheckinMakeSuperButton",
+  fieldName: "FirstCheckinMakeSuperButton",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/MutualBestFriendSetter/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/MutualBestFriendSetter/resolver_reader.ts
@@ -17,7 +17,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.MutualBestFriendSetter",
+  fieldName: "MutualBestFriendSetter",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetBestFriendCard/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetBestFriendCard/resolver_reader.ts
@@ -77,7 +77,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.PetBestFriendCard",
+  fieldName: "PetBestFriendCard",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCard/resolver_reader.ts
@@ -53,7 +53,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.PetCheckinsCard",
+  fieldName: "PetCheckinsCard",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetCheckinsCardList/resolver_reader.ts
@@ -47,7 +47,7 @@ const artifact: EagerReaderArtifact<
   Pet__PetCheckinsCardList__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Pet.PetCheckinsCardList",
+  fieldName: "PetCheckinsCardList",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetDetailDeferredRouteInnerComponent/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetDetailDeferredRouteInnerComponent/resolver_reader.ts
@@ -35,7 +35,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.PetDetailDeferredRouteInnerComponent",
+  fieldName: "PetDetailDeferredRouteInnerComponent",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetPhraseCard/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetPhraseCard/resolver_reader.ts
@@ -24,7 +24,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.PetPhraseCard",
+  fieldName: "PetPhraseCard",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetStatsCard/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetStatsCard/resolver_reader.ts
@@ -92,7 +92,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.PetStatsCard",
+  fieldName: "PetStatsCard",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetSummaryCard/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetSummaryCard/resolver_reader.ts
@@ -48,7 +48,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.PetSummaryCard",
+  fieldName: "PetSummaryCard",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetTaglineCard/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetTaglineCard/resolver_reader.ts
@@ -24,7 +24,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.PetTaglineCard",
+  fieldName: "PetTaglineCard",
   resolver,
   readerAst,
   hasUpdatable: true,

--- a/demos/pet-demo/src/components/__isograph/Pet/PetUpdater/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/PetUpdater/resolver_reader.ts
@@ -67,7 +67,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pet.PetUpdater",
+  fieldName: "PetUpdater",
   resolver,
   readerAst,
   hasUpdatable: true,

--- a/demos/pet-demo/src/components/__isograph/Pet/checkinsPointer/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/checkinsPointer/resolver_reader.ts
@@ -31,7 +31,7 @@ const artifact: EagerReaderArtifact<
   Pet__checkinsPointer__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Pet.checkinsPointer",
+  fieldName: "checkinsPointer",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Pet/fullName/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Pet/fullName/resolver_reader.ts
@@ -25,7 +25,7 @@ const artifact: EagerReaderArtifact<
   Pet__fullName__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Pet.fullName",
+  fieldName: "fullName",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/HomeRoute/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/HomeRoute/resolver_reader.ts
@@ -36,7 +36,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.HomeRoute",
+  fieldName: "HomeRoute",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/Newsfeed/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/Newsfeed/resolver_reader.ts
@@ -56,7 +56,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.Newsfeed",
+  fieldName: "Newsfeed",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/OnlyOneRootLoadablePet/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/OnlyOneRootLoadablePet/resolver_reader.ts
@@ -25,7 +25,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.OnlyOneRootLoadablePet",
+  fieldName: "OnlyOneRootLoadablePet",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/PetByName/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetByName/resolver_reader.ts
@@ -34,7 +34,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.PetByName",
+  fieldName: "PetByName",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetCheckinListRoute/resolver_reader.ts
@@ -62,7 +62,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.PetCheckinListRoute",
+  fieldName: "PetCheckinListRoute",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailDeferredRoute/resolver_reader.ts
@@ -66,7 +66,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.PetDetailDeferredRoute",
+  fieldName: "PetDetailDeferredRoute",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetDetailRoute/resolver_reader.ts
@@ -95,7 +95,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.PetDetailRoute",
+  fieldName: "PetDetailRoute",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/PetFavoritePhrase/resolver_reader.ts
@@ -41,7 +41,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.PetFavoritePhrase",
+  fieldName: "PetFavoritePhrase",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/SmartestPetRoute/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/SmartestPetRoute/resolver_reader.ts
@@ -89,7 +89,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.SmartestPetRoute",
+  fieldName: "SmartestPetRoute",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Query/smartestPet/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Query/smartestPet/resolver_reader.ts
@@ -44,7 +44,7 @@ const artifact: EagerReaderArtifact<
   Query__smartestPet__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Query.smartestPet",
+  fieldName: "smartestPet",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/resolver_reader.ts
+++ b/demos/pet-demo/src/components/__isograph/Viewer/NewsfeedPaginationComponent/resolver_reader.ts
@@ -78,7 +78,7 @@ const artifact: EagerReaderArtifact<
   Viewer__NewsfeedPaginationComponent__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Viewer.NewsfeedPaginationComponent",
+  fieldName: "NewsfeedPaginationComponent",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/vite-demo/src/components/__isograph/Pokemon/Pokemon/resolver_reader.ts
+++ b/demos/vite-demo/src/components/__isograph/Pokemon/Pokemon/resolver_reader.ts
@@ -38,7 +38,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Pokemon.Pokemon",
+  fieldName: "Pokemon",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/demos/vite-demo/src/components/__isograph/Query/HomePage/resolver_reader.ts
+++ b/demos/vite-demo/src/components/__isograph/Query/HomePage/resolver_reader.ts
@@ -53,7 +53,7 @@ const artifact: ComponentReaderArtifact<
   ExtractSecondParam<typeof resolver>
 > = {
   kind: "ComponentReaderArtifact",
-  fieldName: "Query.HomePage",
+  fieldName: "HomePage",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/libs/isograph-react/src/tests/__isograph/Node/asEconomist/resolver_reader.ts
+++ b/libs/isograph-react/src/tests/__isograph/Node/asEconomist/resolver_reader.ts
@@ -19,7 +19,7 @@ const artifact: EagerReaderArtifact<
   Link<"Economist"> | null
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Node.asEconomist",
+  fieldName: "asEconomist",
   resolver: ({ data }) => data.__typename === "Economist" ? data.__link : null,
   readerAst,
   hasUpdatable: false,

--- a/libs/isograph-react/src/tests/__isograph/Query/linkedUpdate/resolver_reader.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/linkedUpdate/resolver_reader.ts
@@ -84,7 +84,7 @@ const artifact: EagerReaderArtifact<
   Query__linkedUpdate__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Query.linkedUpdate",
+  fieldName: "linkedUpdate",
   resolver,
   readerAst,
   hasUpdatable: true,

--- a/libs/isograph-react/src/tests/__isograph/Query/meName/resolver_reader.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/meName/resolver_reader.ts
@@ -29,7 +29,7 @@ const artifact: EagerReaderArtifact<
   Query__meName__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Query.meName",
+  fieldName: "meName",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/libs/isograph-react/src/tests/__isograph/Query/meNameSuccessor/resolver_reader.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/meNameSuccessor/resolver_reader.ts
@@ -58,7 +58,7 @@ const artifact: EagerReaderArtifact<
   Query__meNameSuccessor__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Query.meNameSuccessor",
+  fieldName: "meNameSuccessor",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/libs/isograph-react/src/tests/__isograph/Query/nodeField/resolver_reader.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/nodeField/resolver_reader.ts
@@ -34,7 +34,7 @@ const artifact: EagerReaderArtifact<
   Query__nodeField__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Query.nodeField",
+  fieldName: "nodeField",
   resolver,
   readerAst,
   hasUpdatable: false,

--- a/libs/isograph-react/src/tests/__isograph/Query/startUpdate/resolver_reader.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/startUpdate/resolver_reader.ts
@@ -46,7 +46,7 @@ const artifact: EagerReaderArtifact<
   Query__startUpdate__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Query.startUpdate",
+  fieldName: "startUpdate",
   resolver,
   readerAst,
   hasUpdatable: true,

--- a/libs/isograph-react/src/tests/__isograph/Query/subquery/resolver_reader.ts
+++ b/libs/isograph-react/src/tests/__isograph/Query/subquery/resolver_reader.ts
@@ -45,7 +45,7 @@ const artifact: EagerReaderArtifact<
   Query__subquery__output_type
 > = {
   kind: "EagerReaderArtifact",
-  fieldName: "Query.subquery",
+  fieldName: "subquery",
   resolver,
   readerAst,
   hasUpdatable: false,


### PR DESCRIPTION
The type name was included for the components cache, but now we use root.__typename so there's no need to include type name here 


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #747 
- <kbd>&nbsp;1&nbsp;</kbd> #794 👈 
<!-- GitButler Footer Boundary Bottom -->

