### PR TITLE
Refactor - Centralize ID field name constant

### DIFF
--- a/crates/artifact_content/src/generate_artifacts.rs
+++ b/crates/artifact_content/src/generate_artifacts.rs
@@ -17,16 +17,17 @@ use isograph_lang_types::{
 };
 use isograph_schema::{
     ClientFieldVariant, ClientScalarSelectable, ClientSelectableId, FieldMapItem,
-    FieldTraversalResult, ID_ENTITY_NAME, IsographDatabase, LINK_FIELD_NAME, NODE_FIELD_NAME,
-    NameAndArguments, NetworkProtocol, NormalizationKey, RefetchStrategy, ScalarSelectableId,
-    SelectableTrait, ServerEntityName, ServerObjectSelectableVariant, UserWrittenClientTypeInfo,
-    ValidatedSelection, ValidatedVariableDefinition, WrappedSelectionMapSelection,
-    accessible_client_fields, client_object_selectable_named, client_scalar_selectable_named,
-    client_selectable_map, client_selectable_named, description, fetchable_types,
-    inline_fragment_reader_selection_set, output_type_annotation, selectable_named,
-    selection_map_wrapped, server_object_entity_named, server_object_selectable_named,
-    server_scalar_entity_javascript_name, server_scalar_selectable_named, validate_entire_schema,
-    validated_entrypoints, validated_refetch_strategy_for_client_scalar_selectable_named,
+    FieldTraversalResult, ID_ENTITY_NAME, ID_FIELD_NAME, IsographDatabase, LINK_FIELD_NAME,
+    NODE_FIELD_NAME, NameAndArguments, NetworkProtocol, NormalizationKey, RefetchStrategy,
+    ScalarSelectableId, SelectableTrait, ServerEntityName, ServerObjectSelectableVariant,
+    UserWrittenClientTypeInfo, ValidatedSelection, ValidatedVariableDefinition,
+    WrappedSelectionMapSelection, accessible_client_fields, client_object_selectable_named,
+    client_scalar_selectable_named, client_selectable_map, client_selectable_named, description,
+    fetchable_types, inline_fragment_reader_selection_set, output_type_annotation,
+    selectable_named, selection_map_wrapped, server_object_entity_named,
+    server_object_selectable_named, server_scalar_entity_javascript_name,
+    server_scalar_selectable_named, validate_entire_schema, validated_entrypoints,
+    validated_refetch_strategy_for_client_scalar_selectable_named,
 };
 use isograph_schema::{ContainsIsoStats, ObjectSelectableId};
 use lazy_static::lazy_static;
@@ -291,15 +292,17 @@ fn get_artifact_path_and_content_impl<TNetworkProtocol: NetworkProtocol>(
                                 true,
                                 config.options.include_file_extensions_in_import_statements,
                                 &[FieldMapItem {
-                                    from: "id".intern().into(),
-                                    to: "id".intern().into(),
+                                    from: ID_FIELD_NAME.unchecked_conversion(),
+                                    to: ID_FIELD_NAME.unchecked_conversion(),
                                 }],
                             ));
 
                             // Everything about this is quite sus
                             let id_arg = ArgumentKeyAndValue {
-                                key: "id".intern().into(),
-                                value: NonConstantValue::Variable("id".intern().into()),
+                                key: ID_FIELD_NAME.unchecked_conversion(),
+                                value: NonConstantValue::Variable(
+                                    ID_FIELD_NAME.unchecked_conversion(),
+                                ),
                             };
 
                             let type_to_refine_to = &server_object_entity_named(
@@ -323,7 +326,9 @@ fn get_artifact_path_and_content_impl<TNetworkProtocol: NetworkProtocol>(
                                 .map(|variable_definition| &variable_definition.item);
 
                             let id_var = ValidatedVariableDefinition {
-                                name: WithLocation::new_generated("id".intern().into()),
+                                name: WithLocation::new_generated(
+                                    ID_FIELD_NAME.unchecked_conversion(),
+                                ),
                                 type_: GraphQLTypeAnnotation::NonNull(
                                     GraphQLNonNullTypeAnnotation::Named(
                                         GraphQLNamedTypeAnnotation(

--- a/crates/artifact_content/src/imperatively_loaded_fields.rs
+++ b/crates/artifact_content/src/imperatively_loaded_fields.rs
@@ -7,10 +7,11 @@ use intern::string_key::Intern;
 use isograph_config::GenerateFileExtensionsOption;
 use isograph_lang_types::{SelectionType, VariableDefinition};
 use isograph_schema::{
-    ClientScalarOrObjectSelectable, ClientScalarSelectable, Format, ImperativelyLoadedFieldVariant,
-    IsographDatabase, MergedSelectionMap, NetworkProtocol, OwnedClientSelectable,
-    PathToRefetchFieldInfo, REFETCH_FIELD_NAME, RootRefetchedPath, ServerEntityName,
-    WrappedSelectionMapSelection, client_selectable_named, fetchable_types, selection_map_wrapped,
+    ClientScalarOrObjectSelectable, ClientScalarSelectable, Format, ID_FIELD_NAME,
+    ImperativelyLoadedFieldVariant, IsographDatabase, MergedSelectionMap, NetworkProtocol,
+    OwnedClientSelectable, PathToRefetchFieldInfo, REFETCH_FIELD_NAME, RootRefetchedPath,
+    ServerEntityName, WrappedSelectionMapSelection, client_selectable_named, fetchable_types,
+    selection_map_wrapped,
 };
 use prelude::Postfix;
 
@@ -210,7 +211,7 @@ fn get_used_variable_definitions<TNetworkProtocol: NetworkProtocol>(
         .iter()
         .flat_map(|variable_name| {
             // HACK
-            if *variable_name == "id" {
+            if *variable_name == *ID_FIELD_NAME {
                 None
             } else {
                 entrypoint

--- a/crates/common_lang_types/src/string_key_types.rs
+++ b/crates/common_lang_types/src/string_key_types.rs
@@ -4,7 +4,7 @@ use string_key_newtype::{
     string_key_one_way_conversion,
 };
 
-use crate::{ClientScalarSelectableName, SelectableName};
+use crate::{ClientScalarSelectableName, SelectableName, ServerScalarSelectableName};
 
 string_key_newtype!(DirectiveName);
 string_key_newtype!(DirectiveArgumentName);
@@ -96,6 +96,7 @@ string_key_newtype!(IsographDirectiveName);
 
 string_key_newtype!(FieldArgumentName);
 string_key_equality!(FieldArgumentName, VariableName);
+string_key_equality!(ServerScalarSelectableName, VariableName);
 
 string_key_newtype!(ArtifactFilePrefix);
 string_key_newtype!(ArtifactFileName);

--- a/crates/graphql_network_protocol/src/process_type_system_definition.rs
+++ b/crates/graphql_network_protocol/src/process_type_system_definition.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, HashMap};
 
 use common_lang_types::{
     Diagnostic, DiagnosticResult, GraphQLInterfaceTypeName, Location, SelectableName,
-    ServerObjectEntityName, ServerScalarSelectableName, Span, UnvalidatedTypeName, WithLocation,
-    WithLocationPostfix, WithSpan, WithSpanPostfix,
+    ServerObjectEntityName, Span, UnvalidatedTypeName, WithLocation, WithLocationPostfix, WithSpan,
+    WithSpanPostfix,
 };
 use graphql_lang_types::{
     GraphQLConstantValue, GraphQLDirective, GraphQLNamedTypeAnnotation,
@@ -14,7 +14,7 @@ use graphql_lang_types::{
 use intern::string_key::Intern;
 use isograph_lang_types::{Description, SelectionTypePostfix};
 use isograph_schema::{
-    ExposeFieldDirective, ExposeFieldToInsert, FieldMapItem, FieldToInsert,
+    ExposeFieldDirective, ExposeFieldToInsert, FieldMapItem, FieldToInsert, ID_FIELD_NAME,
     IsographObjectTypeDefinition, ParseTypeSystemOutcome, ProcessObjectTypeDefinitionOutcome,
     STRING_JAVASCRIPT_TYPE, ServerObjectEntity, ServerScalarEntity, TYPENAME_FIELD_NAME,
 };
@@ -27,7 +27,6 @@ use crate::{
 };
 
 lazy_static! {
-    static ref ID_FIELD_NAME: ServerScalarSelectableName = "id".intern().into();
     // TODO use schema_data.string_type_id or something
     static ref STRING_TYPE_NAME: UnvalidatedTypeName = "String".intern().into();
     static ref NODE_INTERFACE_NAME: GraphQLInterfaceTypeName = "Node".intern().into();
@@ -403,8 +402,8 @@ fn process_object_type_definition(
             expose_field_directive: ExposeFieldDirective {
                 expose_as: (*REFETCH_FIELD_NAME).wrap_some(),
                 field_map: vec![FieldMapItem {
-                    from: (*ID_FIELD_NAME).unchecked_conversion(),
-                    to: (*ID_FIELD_NAME).unchecked_conversion(),
+                    from: ID_FIELD_NAME.unchecked_conversion(),
+                    to: ID_FIELD_NAME.unchecked_conversion(),
                 }],
                 field: format!("node.as{}", object_type_definition.name.item)
                     .intern()

--- a/crates/isograph_schema/src/create_merged_selection_set.rs
+++ b/crates/isograph_schema/src/create_merged_selection_set.rs
@@ -1233,8 +1233,8 @@ fn insert_client_pointer_into_refetch_paths<TNetworkProtocol: NetworkProtocol>(
         parent_object_entity_name: *query_id,
         server_object_selectable_name: *NODE_FIELD_NAME,
         arguments: vec![ArgumentKeyAndValue {
-            key: "id".intern().into(),
-            value: NonConstantValue::Variable("id".intern().into()),
+            key: ID_FIELD_NAME.unchecked_conversion(),
+            value: NonConstantValue::Variable(ID_FIELD_NAME.unchecked_conversion()),
         }],
         concrete_type: None,
     });
@@ -1399,7 +1399,7 @@ fn merge_server_scalar_field(
     let scalar_field_name = scalar_field_selection.name.item;
     let normalization_key = if scalar_field_name == *TYPENAME_FIELD_NAME {
         NormalizationKey::Discriminator
-    } else if scalar_field_name == "id" {
+    } else if scalar_field_name == *ID_FIELD_NAME {
         NormalizationKey::Id
     } else {
         NormalizationKey::ServerField(create_transformed_name_and_arguments(
@@ -1583,7 +1583,7 @@ fn get_aliased_mutation_field_name(
 
 pub fn id_arguments() -> Vec<VariableDefinition<ServerEntityName>> {
     vec![VariableDefinition {
-        name: WithLocation::new_generated((*ID_FIELD_NAME).unchecked_conversion()),
+        name: WithLocation::new_generated(ID_FIELD_NAME.unchecked_conversion()),
         type_: GraphQLTypeAnnotation::NonNull(
             GraphQLNonNullTypeAnnotation::Named(GraphQLNamedTypeAnnotation(
                 (*ID_ENTITY_NAME).scalar_selected().with_generated_span(),

--- a/crates/isograph_schema/src/isograph_schema.rs
+++ b/crates/isograph_schema/src/isograph_schema.rs
@@ -96,7 +96,7 @@ pub struct NameAndArguments {
 
 impl NameAndArguments {
     pub fn normalization_key(&self) -> NormalizationKey {
-        if self.name == "id" {
+        if self.name == *ID_FIELD_NAME {
             NormalizationKey::Id
         } else {
             NormalizationKey::ServerField(self.clone())

--- a/crates/isograph_schema/src/process_client_field_declaration.rs
+++ b/crates/isograph_schema/src/process_client_field_declaration.rs
@@ -4,7 +4,6 @@ use common_lang_types::{
     RelativePathToSourceFile, SelectableName, ServerObjectEntityName, TextSource,
     UnvalidatedTypeName, VariableName, WithSpan, WithSpanPostfix,
 };
-use intern::string_key::Intern;
 use isograph_lang_types::{
     ArgumentKeyAndValue, ClientFieldDeclaration, ClientPointerDeclaration,
     ClientScalarSelectionDirectiveSet, NonConstantValue, SelectionSet, SelectionType,
@@ -406,8 +405,8 @@ fn get_client_variant(client_field_declaration: &ClientFieldDeclaration) -> Clie
 
 pub fn id_top_level_arguments() -> Vec<ArgumentKeyAndValue> {
     vec![ArgumentKeyAndValue {
-        key: "id".intern().into(),
-        value: NonConstantValue::Variable("id".intern().into()),
+        key: ID_FIELD_NAME.unchecked_conversion(),
+        value: NonConstantValue::Variable(ID_FIELD_NAME.unchecked_conversion()),
     }]
 }
 

--- a/crates/isograph_schema/src/refetch_strategy.rs
+++ b/crates/isograph_schema/src/refetch_strategy.rs
@@ -3,14 +3,13 @@ use std::{collections::BTreeSet, fmt::Debug};
 use common_lang_types::{
     ServerObjectEntityName, VariableName, WithLocation, WithSpan, WithSpanPostfix,
 };
-use intern::string_key::Intern;
 use isograph_lang_types::{
     EmptyDirectiveSet, ScalarSelection, ScalarSelectionDirectiveSet, SelectionSet,
     SelectionTypeContainingSelections,
 };
 
 use crate::{
-    MergedSelectionMap, UnprocessedSelection, WrappedSelectionMapSelection,
+    ID_FIELD_NAME, MergedSelectionMap, UnprocessedSelection, WrappedSelectionMapSelection,
     get_reachable_variables, selection_map_wrapped,
 };
 
@@ -126,7 +125,7 @@ impl GenerateRefetchQueryImpl {
 
 pub fn id_selection() -> UnprocessedSelection {
     SelectionTypeContainingSelections::Scalar(ScalarSelection {
-        name: WithLocation::new_generated("id".intern().into()),
+        name: WithLocation::new_generated(ID_FIELD_NAME.unchecked_conversion()),
         reader_alias: None,
         scalar_selection_directive_set: ScalarSelectionDirectiveSet::None(EmptyDirectiveSet {}),
         associated_data: (),

--- a/crates/isograph_schema/src/validate_use_of_arguments.rs
+++ b/crates/isograph_schema/src/validate_use_of_arguments.rs
@@ -5,7 +5,6 @@ use common_lang_types::{
     ParentObjectEntityNameAndSelectableName, VariableName, WithLocation, WithSpan,
 };
 
-use intern::string_key::Intern;
 use isograph_lang_types::{
     DefinitionLocation, NonConstantValue, ScalarSelectionDirectiveSet, SelectionFieldArgument,
     SelectionType,
@@ -14,17 +13,17 @@ use lazy_static::lazy_static;
 use prelude::{ErrClone, Postfix};
 
 use crate::{
-    ClientScalarOrObjectSelectable, IsographDatabase, NetworkProtocol, ValidatedVariableDefinition,
-    client_object_selectable_named, client_scalar_selectable_named, client_selectable_map,
-    selectable_validated_reader_selection_set, server_object_selectable_named,
-    server_scalar_selectable_named, validate_argument_types::value_satisfies_type,
-    visit_selection_set::visit_selection_set,
+    ClientScalarOrObjectSelectable, ID_FIELD_NAME, IsographDatabase, NetworkProtocol,
+    ValidatedVariableDefinition, client_object_selectable_named, client_scalar_selectable_named,
+    client_selectable_map, selectable_validated_reader_selection_set,
+    server_object_selectable_named, server_scalar_selectable_named,
+    validate_argument_types::value_satisfies_type, visit_selection_set::visit_selection_set,
 };
 
 type UsedVariables = BTreeSet<VariableName>;
 
 lazy_static! {
-    static ref ID: FieldArgumentName = "id".intern().into();
+    static ref ID: FieldArgumentName = ID_FIELD_NAME.unchecked_conversion();
 }
 
 /// For all client types, validate that

--- a/crates/tests/tests/directives_deserialization.rs
+++ b/crates/tests/tests/directives_deserialization.rs
@@ -1,7 +1,7 @@
 use common_lang_types::{Diagnostic, SelectableName, StringLiteralValue, TextSource};
 use graphql_lang_types::{GraphQLConstantValue, GraphQLDirective, from_graphql_directive};
 use intern::string_key::Intern;
-use isograph_schema::{ExposeFieldDirective, FieldMapItem};
+use isograph_schema::{ExposeFieldDirective, FieldMapItem, ID_FIELD_NAME};
 use std::error::Error;
 
 use graphql_lang_types::{GraphQLTypeSystemExtension, GraphQLTypeSystemExtensionOrDefinition};
@@ -45,7 +45,7 @@ fn test_test_mutation_extension_expose_as() -> Result<(), Box<dyn Error>> {
     let set_tagline_mutation = ExposeFieldDirective::new(
         Some(SelectableName::from("set_puppy_tagline".intern())),
         vec![FieldMapItem {
-            from: StringLiteralValue::from("id".intern()),
+            from: ID_FIELD_NAME.unchecked_conversion(),
             to: StringLiteralValue::from("input.id".intern()),
         }],
         StringLiteralValue::from("set_pet_tagline.pet".intern()),
@@ -63,7 +63,7 @@ fn test_test_mutation_extension_set_pet_tagline_parsing() -> Result<(), Box<dyn 
     let set_tagline_mutation = ExposeFieldDirective::new(
         None,
         vec![FieldMapItem {
-            from: StringLiteralValue::from("id".intern()),
+            from: ID_FIELD_NAME.unchecked_conversion(),
             to: StringLiteralValue::from("input.id".intern()),
         }],
         StringLiteralValue::from("set_pet_tagline.pet".intern()),
@@ -81,8 +81,8 @@ fn test_mutation_extension_set_pet_bestfriend_parsing() -> Result<(), Box<dyn Er
     let set_pet_best_friend = ExposeFieldDirective::new(
         None,
         vec![FieldMapItem {
-            from: StringLiteralValue::from("id".intern()),
-            to: StringLiteralValue::from("id".intern()),
+            from: ID_FIELD_NAME.unchecked_conversion(),
+            to: ID_FIELD_NAME.unchecked_conversion(),
         }],
         StringLiteralValue::from("set_pet_best_friend.pet".intern()),
     );


### PR DESCRIPTION
This PR replaces all hardcoded "id" strings with *ID_FIELD_NAME constant

#797 