### PR TITLE
optimize intern fn

### DIFF
--- a/crates/pico/src/database.rs
+++ b/crates/pico/src/database.rs
@@ -413,7 +413,15 @@ pub fn intern<Db: Database, T: Clone + Hash + DynEq + 'static>(db: &Db, value: T
 
             current_epoch
         }
-        Entry::Occupied(occupied) => occupied.get().time_updated,
+        Entry::Occupied(mut occupied) => {
+            let revision = occupied.get_mut();
+
+            if revision.time_verified != current_epoch {
+                revision.time_verified = current_epoch;
+            }
+
+            revision.time_updated
+        }
     };
 
     db.get_storage().register_dependency_in_parent_memoized_fn(


### PR DESCRIPTION
We optimise `intern` fn the same way we did for `inter_ref`, but it is simpler as we don't need to handle a case when `derived_node` exists besides its registration.