### PR TITLE
enable oxlint import/no-cycle

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "ignorePatterns": ["__isograph", "vite-demo"],
-  "plugins": ["typescript"],
+  "plugins": ["typescript", "import"],
   "env": { "node": true, "browser": true },
   "rules": {
     "eslint/no-control-regex": "off",
@@ -9,6 +9,7 @@
     "eslint/no-unassigned-vars": "off",
     "eslint/no-unused-expressions": "off",
     "eslint/no-unused-vars": "off",
+    "import/no-cycle": "error",
     "typescript/no-duplicate-type-constituents": "off",
     "typescript/no-redundant-type-constituents": "off",
     "typescript/no-base-to-string": "off",

--- a/demos/pet-demo/src/components/Pet/MutualBestFriendSetter.tsx
+++ b/demos/pet-demo/src/components/Pet/MutualBestFriendSetter.tsx
@@ -3,7 +3,7 @@ import {
   useClientSideDefer,
   useImperativeReference,
 } from '@isograph/react';
-import { iso } from '../__isograph/iso';
+import { iso } from '@iso';
 import { Button, Card, CardContent } from '@mui/material';
 
 /**

--- a/libs/isograph-react/src/core/FragmentReference.ts
+++ b/libs/isograph-react/src/core/FragmentReference.ts
@@ -1,11 +1,11 @@
-import { ReaderWithRefetchQueries } from '../core/entrypoint';
-import { stableCopy } from './cache';
+import { ReaderWithRefetchQueries } from './entrypoint';
 import {
   type ComponentOrFieldName,
   type StoreLink,
 } from './IsographEnvironment';
 import { PromiseWrapper } from './PromiseWrapper';
 import type { StartUpdate } from './reader';
+import { stableCopy } from './util';
 
 // TODO type this better
 export type VariableValue =

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -1,51 +1,33 @@
-import {
-  Factory,
-  ItemCleanupPair,
-  ParentCache,
-} from '@isograph/react-disposable-state';
-import {
-  IsographEntrypoint,
+import { type Factory, ParentCache } from '@isograph/react-disposable-state';
+import type {
+  NormalizationAstNodes,
   NormalizationInlineFragment,
   NormalizationLinkedField,
   NormalizationScalarField,
-  type NormalizationAst,
-  type NormalizationAstLoader,
-  type NormalizationAstNodes,
-} from '../core/entrypoint';
-import { mergeObjectsUsingReaderAst } from './areEqualWithDeepComparison';
-import { FetchOptions } from './check';
-import {
-  ExtractParameters,
+} from './entrypoint';
+import type {
   FragmentReference,
+  UnknownTReadFromStore,
   Variables,
-  type UnknownTReadFromStore,
-  type VariableValue,
+  VariableValue,
 } from './FragmentReference';
 import {
-  DataId,
-  DataTypeValue,
-  FragmentSubscription,
+  type DataId,
+  type DataTypeValue,
   getLink,
-  getOrLoadReaderWithRefetchQueries,
-  ROOT_ID,
-  StoreLink,
-  StoreRecord,
   type IsographEnvironment,
+  ROOT_ID,
+  type StoreLink,
+  type StoreRecord,
   type TypeName,
 } from './IsographEnvironment';
 import { logMessage } from './logging';
 import {
-  maybeMakeNetworkRequest,
-  retainQueryWithoutMakingNetworkRequest,
-} from './makeNetworkRequest';
-import {
-  addNetworkResponseStoreLayer,
   getMutableStoreRecordProxy,
   type StoreLayerWithData,
 } from './optimisticProxy';
-import { readButDoNotEvaluate, WithEncounteredRecords } from './read';
-import { ReaderLinkedField, ReaderScalarField, type ReaderAst } from './reader';
-import { Argument, ArgumentValue } from './util';
+import type { ReaderLinkedField, ReaderScalarField } from './reader';
+import { type Argument, type ArgumentValue, isArray, stableCopy } from './util';
 
 export const TYPENAME_FIELD_NAME = '__typename';
 
@@ -62,90 +44,6 @@ export function getOrCreateItemInSuspenseCache<
   }
 
   return environment.fragmentCache[index];
-}
-
-/**
- * Creates a copy of the provided value, ensuring any nested objects have their
- * keys sorted such that equivalent values would have identical JSON.stringify
- * results.
- */
-export function stableCopy<T>(value: T): T {
-  if (value == null || typeof value !== 'object') {
-    return value;
-  }
-  if (isArray(value)) {
-    // @ts-ignore
-    return value.map(stableCopy);
-  }
-  const keys = Object.keys(value).sort();
-  const stable: { [index: string]: any } = {};
-  for (let i = 0; i < keys.length; i++) {
-    // @ts-ignore
-    stable[keys[i]] = stableCopy(value[keys[i]]);
-  }
-  return stable as any;
-}
-
-export function getOrCreateCacheForArtifact<
-  TReadFromStore extends UnknownTReadFromStore,
-  TClientFieldValue,
-  TNormalizationAst extends NormalizationAst | NormalizationAstLoader,
-  TRawResponseType extends NetworkResponseObject,
->(
-  environment: IsographEnvironment,
-  entrypoint: IsographEntrypoint<
-    TReadFromStore,
-    TClientFieldValue,
-    TNormalizationAst,
-    TRawResponseType
-  >,
-  variables: ExtractParameters<TReadFromStore>,
-  fetchOptions?: FetchOptions<TClientFieldValue, TRawResponseType>,
-): ParentCache<FragmentReference<TReadFromStore, TClientFieldValue>> {
-  let cacheKey = '';
-  switch (entrypoint.networkRequestInfo.operation.kind) {
-    case 'Operation':
-      cacheKey =
-        entrypoint.networkRequestInfo.operation.text +
-        JSON.stringify(stableCopy(variables));
-      break;
-    case 'PersistedOperation':
-      cacheKey =
-        entrypoint.networkRequestInfo.operation.operationId +
-        JSON.stringify(stableCopy(variables));
-      break;
-  }
-  const factory = () => {
-    const { fieldName, readerArtifactKind, readerWithRefetchQueries } =
-      getOrLoadReaderWithRefetchQueries(
-        environment,
-        entrypoint.readerWithRefetchQueries,
-      );
-    const [networkRequest, disposeNetworkRequest] = maybeMakeNetworkRequest(
-      environment,
-      entrypoint,
-      variables,
-      readerWithRefetchQueries,
-      fetchOptions ?? null,
-    );
-
-    const itemCleanupPair: ItemCleanupPair<
-      FragmentReference<TReadFromStore, TClientFieldValue>
-    > = [
-      {
-        kind: 'FragmentReference',
-        readerWithRefetchQueries,
-        fieldName,
-        readerArtifactKind,
-        root: { __link: ROOT_ID, __typename: entrypoint.concreteType },
-        variables,
-        networkRequest: networkRequest,
-      },
-      disposeNetworkRequest,
-    ];
-    return itemCleanupPair;
-  };
-  return getOrCreateItemInSuspenseCache(environment, cacheKey, factory);
 }
 
 export type NetworkResponseScalarValue = string | number | boolean;
@@ -222,33 +120,6 @@ export function subscribeToAnyChangesToRecord(
   return () => environment.subscriptions.delete(subscription);
 }
 
-export function subscribe<TReadFromStore extends UnknownTReadFromStore>(
-  environment: IsographEnvironment,
-  encounteredDataAndRecords: WithEncounteredRecords<TReadFromStore>,
-  fragmentReference: FragmentReference<TReadFromStore, any>,
-  callback: (
-    newEncounteredDataAndRecords: WithEncounteredRecords<TReadFromStore>,
-  ) => void,
-  readerAst: ReaderAst<TReadFromStore>,
-): () => void {
-  const fragmentSubscription: FragmentSubscription<TReadFromStore> = {
-    kind: 'FragmentSubscription',
-    callback,
-    encounteredDataAndRecords,
-    fragmentReference,
-    readerAst,
-  };
-
-  // subscribe is called in an effect. (We should actually subscribe during the
-  // initial render.) Because it's called in an effect, we might have missed some
-  // changes since the initial render! So, at this point, we re-read and call the
-  // subscription (i.e. re-render) if the fragment data has changed.
-  callSubscriptionIfDataChanged(environment, fragmentSubscription);
-
-  environment.subscriptions.add(fragmentSubscription);
-  return () => environment.subscriptions.delete(fragmentSubscription);
-}
-
 export function onNextChangeToRecord(
   environment: IsographEnvironment,
   recordLink: StoreLink,
@@ -263,161 +134,6 @@ export function onNextChangeToRecord(
       },
     );
   });
-}
-
-// Calls to readButDoNotEvaluate can suspend (i.e. throw a promise).
-// Maybe in the future, they will be able to throw errors.
-//
-// That's probably okay to ignore. We don't, however, want to prevent
-// updating other subscriptions if one subscription had missing data.
-function logAnyError(
-  environment: IsographEnvironment,
-  context: any,
-  f: () => void,
-) {
-  try {
-    f();
-  } catch (e) {
-    logMessage(environment, () => ({
-      kind: 'ErrorEncounteredInWithErrorHandling',
-      error: e,
-      context,
-    }));
-  }
-}
-
-export function callSubscriptions(
-  environment: IsographEnvironment,
-  recordsEncounteredWhenNormalizing: EncounteredIds,
-) {
-  environment.subscriptions.forEach((subscription) =>
-    logAnyError(environment, { situation: 'calling subscriptions' }, () => {
-      switch (subscription.kind) {
-        case 'FragmentSubscription': {
-          // TODO if there are multiple components subscribed to the same
-          // fragment, we will call readButNotEvaluate multiple times. We
-          // should fix that.
-          if (
-            hasOverlappingIds(
-              recordsEncounteredWhenNormalizing,
-              subscription.encounteredDataAndRecords.encounteredRecords,
-            )
-          ) {
-            callSubscriptionIfDataChanged(environment, subscription);
-          }
-          return;
-        }
-        case 'AnyRecords': {
-          logAnyError(
-            environment,
-            { situation: 'calling AnyRecords callback' },
-            () => subscription.callback(),
-          );
-          return;
-        }
-        case 'AnyChangesToRecord': {
-          if (
-            recordsEncounteredWhenNormalizing
-              .get(subscription.recordLink.__typename)
-              ?.has(subscription.recordLink.__link) != null
-          ) {
-            logAnyError(
-              environment,
-              { situation: 'calling AnyChangesToRecord callback' },
-              () => subscription.callback(),
-            );
-          }
-          return;
-        }
-        default: {
-          // Ensure we have covered all variants
-          const _: never = subscription;
-          _;
-          throw new Error('Unexpected case');
-        }
-      }
-    }),
-  );
-}
-
-function callSubscriptionIfDataChanged<
-  TReadFromStore extends UnknownTReadFromStore,
->(
-  environment: IsographEnvironment,
-  subscription: FragmentSubscription<TReadFromStore>,
-) {
-  const newEncounteredDataAndRecords = readButDoNotEvaluate(
-    environment,
-    subscription.fragmentReference,
-    // Is this wrong?
-    // Reasons to think no:
-    // - we are only updating the read-out value, and the network
-    //   options only affect whether we throw.
-    // - the component will re-render, and re-throw on its own, anyway.
-    //
-    // Reasons to think not:
-    // - it seems more efficient to suspend here and not update state,
-    //   if we expect that the component will just throw anyway
-    // - consistency
-    // - it's also weird, this is called from makeNetworkRequest, where
-    //   we don't currently pass network request options
-    {
-      suspendIfInFlight: false,
-      throwOnNetworkError: false,
-    },
-  );
-
-  const mergedItem = mergeObjectsUsingReaderAst(
-    subscription.readerAst,
-    subscription.encounteredDataAndRecords.item,
-    newEncounteredDataAndRecords.item,
-  );
-
-  logMessage(environment, () => ({
-    kind: 'DeepEqualityCheck',
-    fragmentReference: subscription.fragmentReference,
-    old: subscription.encounteredDataAndRecords.item,
-    new: newEncounteredDataAndRecords.item,
-    deeplyEqual: mergedItem === subscription.encounteredDataAndRecords.item,
-  }));
-
-  if (mergedItem !== subscription.encounteredDataAndRecords.item) {
-    logAnyError(
-      environment,
-      { situation: 'calling FragmentSubscription callback' },
-      () => {
-        subscription.callback(newEncounteredDataAndRecords);
-      },
-    );
-    subscription.encounteredDataAndRecords = newEncounteredDataAndRecords;
-  }
-}
-
-function hasOverlappingIds(
-  ids1: EncounteredIds,
-  ids2: EncounteredIds,
-): boolean {
-  for (const [typeName, set1] of ids1.entries()) {
-    const set2 = ids2.get(typeName);
-    if (set2 === undefined) {
-      continue;
-    }
-
-    if (isNotDisjointFrom(set1, set2)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// TODO use a polyfill library
-function isNotDisjointFrom<T>(set1: Set<T>, set2: Set<T>): boolean {
-  for (const id of set1) {
-    if (set2.has(id)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 export type EncounteredIds = Map<TypeName, Set<DataId>>;
@@ -529,10 +245,6 @@ function normalizeScalarField(
   } else {
     throw new Error('Unexpected object array when normalizing scalar');
   }
-}
-
-export function isArray(value: unknown): value is readonly unknown[] {
-  return Array.isArray(value);
 }
 
 /**
@@ -925,62 +637,4 @@ function getDataIdOfNetworkResponse(
     storeKey += getStoreKeyChunkForArgument(fieldParameter, variables);
   }
   return storeKey;
-}
-
-export function writeData<
-  TReadFromStore extends UnknownTReadFromStore,
-  TRawResponseType extends NetworkResponseObject,
-  TClientFieldValue,
->(
-  environment: IsographEnvironment,
-  entrypoint: IsographEntrypoint<
-    TReadFromStore,
-    TClientFieldValue,
-    NormalizationAst,
-    TRawResponseType
-  >,
-  data: TRawResponseType,
-  variables: ExtractParameters<TReadFromStore>,
-): ItemCleanupPair<FragmentReference<TReadFromStore, TClientFieldValue>> {
-  const encounteredIds: EncounteredIds = new Map();
-  environment.store = addNetworkResponseStoreLayer(environment.store);
-  normalizeData(
-    environment,
-    environment.store,
-    entrypoint.networkRequestInfo.normalizationAst.selections,
-    data,
-    variables,
-    { __link: ROOT_ID, __typename: entrypoint.concreteType },
-    encounteredIds,
-  );
-  logMessage(environment, () => ({
-    kind: 'AfterNormalization',
-    store: environment.store,
-    encounteredIds,
-  }));
-
-  callSubscriptions(environment, encounteredIds);
-
-  const { fieldName, readerArtifactKind, readerWithRefetchQueries } =
-    getOrLoadReaderWithRefetchQueries(
-      environment,
-      entrypoint.readerWithRefetchQueries,
-    );
-  const [networkRequest, disposeNetworkRequest] =
-    retainQueryWithoutMakingNetworkRequest(environment, entrypoint, variables);
-
-  return [
-    {
-      kind: 'FragmentReference',
-      readerWithRefetchQueries,
-      fieldName,
-      readerArtifactKind,
-      root: { __link: ROOT_ID, __typename: entrypoint.concreteType },
-      variables,
-      networkRequest,
-    },
-    () => {
-      disposeNetworkRequest();
-    },
-  ];
 }

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -1,13 +1,9 @@
-import { useReadAndSubscribe } from '../react/useReadAndSubscribe';
-import { maybeUnwrapNetworkRequest } from '../react/useResult';
 import {
   FragmentReference,
   stableIdForFragmentReference,
 } from './FragmentReference';
-import { IsographEnvironment } from './IsographEnvironment';
-import { logMessage } from './logging';
-import { readPromise } from './PromiseWrapper';
-import { NetworkRequestReaderOptions } from './read';
+import type { IsographEnvironment } from './IsographEnvironment';
+import type { NetworkRequestReaderOptions } from './read';
 import { createStartUpdate } from './startUpdate';
 
 export function getOrCreateCachedComponent(
@@ -24,41 +20,10 @@ export function getOrCreateCachedComponent(
 
   return (environment.componentCache[
     stableIdForFragmentReference(fragmentReference)
-  ] ??= (() => {
-    function Component(additionalRuntimeProps: { [key: string]: any }) {
-      maybeUnwrapNetworkRequest(
-        fragmentReference.networkRequest,
-        networkRequestOptions,
-      );
-      const readerWithRefetchQueries = readPromise(
-        fragmentReference.readerWithRefetchQueries,
-      );
-
-      const data = useReadAndSubscribe(
-        fragmentReference,
-        networkRequestOptions,
-        readerWithRefetchQueries.readerArtifact.readerAst,
-      );
-
-      logMessage(environment, () => ({
-        kind: 'ComponentRerendered',
-        componentName: fragmentReference.fieldName,
-        rootLink: fragmentReference.root,
-      }));
-
-      return readerWithRefetchQueries.readerArtifact.resolver(
-        {
-          data,
-          parameters: fragmentReference.variables,
-          startUpdate: readerWithRefetchQueries.readerArtifact.hasUpdatable
-            ? startUpdate
-            : undefined,
-        },
-        additionalRuntimeProps,
-      );
-    }
-    const idString = `(type: ${fragmentReference.root.__typename}, id: ${fragmentReference.root.__link})`;
-    Component.displayName = `${fragmentReference.fieldName} ${idString} @component`;
-    return Component;
-  })());
+  ] ??= environment.componentFunction(
+    environment,
+    fragmentReference,
+    networkRequestOptions,
+    startUpdate,
+  ));
 }

--- a/libs/isograph-react/src/core/entrypoint.ts
+++ b/libs/isograph-react/src/core/entrypoint.ts
@@ -5,8 +5,8 @@ import type {
   UnknownTReadFromStore,
 } from './FragmentReference';
 import type { ComponentOrFieldName, TypeName } from './IsographEnvironment';
-import { TopLevelReaderArtifact } from './reader';
-import { Arguments } from './util';
+import type { TopLevelReaderArtifact } from './reader';
+import type { Arguments } from './util';
 
 export type ReaderWithRefetchQueries<
   TReadFromStore extends UnknownTReadFromStore,

--- a/libs/isograph-react/src/core/garbageCollection.ts
+++ b/libs/isograph-react/src/core/garbageCollection.ts
@@ -1,11 +1,11 @@
 import { getParentRecordKey } from './cache';
-import { NormalizationAstNodes, type NormalizationAst } from './entrypoint';
-import { Variables } from './FragmentReference';
+import type { NormalizationAstNodes, NormalizationAst } from './entrypoint';
+import type { Variables } from './FragmentReference';
 import {
   assertLink,
-  DataId,
-  IsographEnvironment,
-  StoreRecord,
+  type DataId,
+  type IsographEnvironment,
+  type StoreRecord,
   type StoreLayerData,
   type StoreLink,
   type TypeName,

--- a/libs/isograph-react/src/core/getOrCreateCacheForArtifact.ts
+++ b/libs/isograph-react/src/core/getOrCreateCacheForArtifact.ts
@@ -1,0 +1,86 @@
+import type { ItemCleanupPair } from '@isograph/isograph-disposable-types/dist';
+import type { ParentCache } from '@isograph/isograph-react-disposable-state/dist';
+import {
+  type NetworkResponseObject,
+  getOrCreateItemInSuspenseCache,
+} from './cache';
+import type { FetchOptions } from './check';
+import type {
+  IsographEntrypoint,
+  NormalizationAst,
+  NormalizationAstLoader,
+} from './entrypoint';
+import type {
+  ExtractParameters,
+  FragmentReference,
+  UnknownTReadFromStore,
+} from './FragmentReference';
+import {
+  type IsographEnvironment,
+  getOrLoadReaderWithRefetchQueries,
+  ROOT_ID,
+} from './IsographEnvironment';
+import { maybeMakeNetworkRequest } from './makeNetworkRequest';
+import { stableCopy } from './util';
+
+export function getOrCreateCacheForArtifact<
+  TReadFromStore extends UnknownTReadFromStore,
+  TClientFieldValue,
+  TNormalizationAst extends NormalizationAst | NormalizationAstLoader,
+  TRawResponseType extends NetworkResponseObject,
+>(
+  environment: IsographEnvironment,
+  entrypoint: IsographEntrypoint<
+    TReadFromStore,
+    TClientFieldValue,
+    TNormalizationAst,
+    TRawResponseType
+  >,
+  variables: ExtractParameters<TReadFromStore>,
+  fetchOptions?: FetchOptions<TClientFieldValue, TRawResponseType>,
+): ParentCache<FragmentReference<TReadFromStore, TClientFieldValue>> {
+  let cacheKey = '';
+  switch (entrypoint.networkRequestInfo.operation.kind) {
+    case 'Operation':
+      cacheKey =
+        entrypoint.networkRequestInfo.operation.text +
+        JSON.stringify(stableCopy(variables));
+      break;
+    case 'PersistedOperation':
+      cacheKey =
+        entrypoint.networkRequestInfo.operation.operationId +
+        JSON.stringify(stableCopy(variables));
+      break;
+  }
+  const factory = () => {
+    const { fieldName, readerArtifactKind, readerWithRefetchQueries } =
+      getOrLoadReaderWithRefetchQueries(
+        environment,
+        entrypoint.readerWithRefetchQueries,
+      );
+    const [networkRequest, disposeNetworkRequest] = maybeMakeNetworkRequest(
+      environment,
+      entrypoint,
+      variables,
+      readerWithRefetchQueries,
+      fetchOptions ?? null,
+    );
+
+    const itemCleanupPair: ItemCleanupPair<
+      FragmentReference<TReadFromStore, TClientFieldValue>
+    > = [
+      {
+        kind: 'FragmentReference',
+        readerWithRefetchQueries,
+        fieldName,
+        readerArtifactKind,
+        root: { __link: ROOT_ID, __typename: entrypoint.concreteType },
+        variables,
+        networkRequest: networkRequest,
+      },
+      disposeNetworkRequest,
+    ];
+    return itemCleanupPair;
+  };
+  return getOrCreateItemInSuspenseCache(environment, cacheKey, factory);
+}

--- a/libs/isograph-react/src/core/logging.ts
+++ b/libs/isograph-react/src/core/logging.ts
@@ -1,19 +1,19 @@
-import { CleanupFn } from '@isograph/disposable-types';
-import { NetworkResponseObject, type EncounteredIds } from './cache';
-import { CheckResult } from './check';
-import {
+import type { CleanupFn } from '@isograph/disposable-types';
+import type { NetworkResponseObject, EncounteredIds } from './cache';
+import type { CheckResult } from './check';
+import type {
   IsographEntrypoint,
   RefetchQueryNormalizationArtifact,
-  type NormalizationAstNodes,
+  NormalizationAstNodes,
 } from './entrypoint';
-import { FragmentReference, Variables } from './FragmentReference';
-import {
+import type { FragmentReference, Variables } from './FragmentReference';
+import type {
   IsographEnvironment,
   StoreRecord,
-  type StoreLink,
+  StoreLink,
 } from './IsographEnvironment';
-import { ReadDataResult } from './read';
-import { Arguments } from './util';
+import type { ReadDataResult } from './read';
+import type { Arguments } from './util';
 import type { StoreLayer } from './optimisticProxy';
 
 /**

--- a/libs/isograph-react/src/core/makeNetworkRequest.ts
+++ b/libs/isograph-react/src/core/makeNetworkRequest.ts
@@ -1,23 +1,22 @@
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import {
-  callSubscriptions,
   normalizeData,
   type EncounteredIds,
   type NetworkResponseObject,
 } from './cache';
 import { check, DEFAULT_SHOULD_FETCH_VALUE, FetchOptions } from './check';
 import { getOrCreateCachedComponent } from './componentCache';
-import {
+import type {
   IsographEntrypoint,
+  NormalizationAst,
+  NormalizationAstLoader,
   ReaderWithRefetchQueries,
   RefetchQueryNormalizationArtifact,
-  type NormalizationAst,
-  type NormalizationAstLoader,
 } from './entrypoint';
-import {
+import type {
   ExtractParameters,
-  type FragmentReference,
-  type UnknownTReadFromStore,
+  FragmentReference,
+  UnknownTReadFromStore,
 } from './FragmentReference';
 import {
   garbageCollectEnvironment,
@@ -42,6 +41,7 @@ import {
 } from './PromiseWrapper';
 import { readButDoNotEvaluate } from './read';
 import { getOrCreateCachedStartUpdate } from './startUpdate';
+import { callSubscriptions } from './subscribe';
 
 let networkRequestId = 0;
 

--- a/libs/isograph-react/src/core/optimisticProxy.ts
+++ b/libs/isograph-react/src/core/optimisticProxy.ts
@@ -1,8 +1,5 @@
-import {
-  callSubscriptions,
-  insertEmptySetIfMissing,
-  type EncounteredIds,
-} from './cache';
+import { insertEmptySetIfMissing, type EncounteredIds } from './cache';
+import { callSubscriptions } from './subscribe';
 import type {
   BaseStoreLayerData,
   IsographEnvironment,

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -1,4 +1,4 @@
-import { CleanupFn, type ItemCleanupPair } from '@isograph/disposable-types';
+import type { CleanupFn, ItemCleanupPair } from '@isograph/disposable-types';
 import {
   getParentRecordKey,
   insertEmptySetIfMissing,
@@ -7,16 +7,16 @@ import {
 } from './cache';
 import { FetchOptions } from './check';
 import { getOrCreateCachedComponent } from './componentCache';
-import {
+import type {
   IsographEntrypoint,
+  ReaderWithRefetchQueries,
   RefetchQueryNormalizationArtifactWrapper,
-  type ReaderWithRefetchQueries,
 } from './entrypoint';
-import {
+import type {
   ExtractData,
   FragmentReference,
+  UnknownTReadFromStore,
   Variables,
-  type UnknownTReadFromStore,
 } from './FragmentReference';
 import {
   assertLink,
@@ -38,17 +38,17 @@ import {
   wrapPromise,
   wrapResolvedValue,
 } from './PromiseWrapper';
-import {
+import type {
+  LoadablySelectedField,
   ReaderAst,
-  type LoadablySelectedField,
-  type ReaderClientPointer,
-  type ReaderImperativelyLoadedField,
-  type ReaderLinkedField,
-  type ReaderNonLoadableResolverField,
-  type ReaderScalarField,
+  ReaderClientPointer,
+  ReaderImperativelyLoadedField,
+  ReaderLinkedField,
+  ReaderNonLoadableResolverField,
+  ReaderScalarField,
 } from './reader';
 import { getOrCreateCachedStartUpdate } from './startUpdate';
-import { Arguments } from './util';
+import type { Arguments } from './util';
 
 export type WithEncounteredRecords<T> = {
   readonly encounteredRecords: EncounteredIds;

--- a/libs/isograph-react/src/core/startUpdate.ts
+++ b/libs/isograph-react/src/core/startUpdate.ts
@@ -1,5 +1,4 @@
 import {
-  callSubscriptions,
   getParentRecordKey,
   insertEmptySetIfMissing,
   type EncounteredIds,
@@ -37,6 +36,7 @@ import {
   type ReadDataResultSuccess,
 } from './read';
 import type { ReaderAst } from './reader';
+import { callSubscriptions } from './subscribe';
 
 export function getOrCreateCachedStartUpdate<
   TReadFromStore extends UnknownTReadFromStore,

--- a/libs/isograph-react/src/core/subscribe.ts
+++ b/libs/isograph-react/src/core/subscribe.ts
@@ -1,0 +1,195 @@
+import { mergeObjectsUsingReaderAst } from './areEqualWithDeepComparison';
+import type { EncounteredIds } from './cache';
+import type {
+  FragmentReference,
+  UnknownTReadFromStore,
+} from './FragmentReference';
+import type {
+  FragmentSubscription,
+  IsographEnvironment,
+} from './IsographEnvironment';
+import { logMessage } from './logging';
+import { type WithEncounteredRecords, readButDoNotEvaluate } from './read';
+import type { ReaderAst } from './reader';
+
+export function subscribe<TReadFromStore extends UnknownTReadFromStore>(
+  environment: IsographEnvironment,
+  encounteredDataAndRecords: WithEncounteredRecords<TReadFromStore>,
+  fragmentReference: FragmentReference<TReadFromStore, any>,
+  callback: (
+    newEncounteredDataAndRecords: WithEncounteredRecords<TReadFromStore>,
+  ) => void,
+  readerAst: ReaderAst<TReadFromStore>,
+): () => void {
+  const fragmentSubscription: FragmentSubscription<TReadFromStore> = {
+    kind: 'FragmentSubscription',
+    callback,
+    encounteredDataAndRecords,
+    fragmentReference,
+    readerAst,
+  };
+
+  // subscribe is called in an effect. (We should actually subscribe during the
+  // initial render.) Because it's called in an effect, we might have missed some
+  // changes since the initial render! So, at this point, we re-read and call the
+  // subscription (i.e. re-render) if the fragment data has changed.
+  callSubscriptionIfDataChanged(environment, fragmentSubscription);
+
+  environment.subscriptions.add(fragmentSubscription);
+  return () => environment.subscriptions.delete(fragmentSubscription);
+}
+
+// Calls to readButDoNotEvaluate can suspend (i.e. throw a promise).
+// Maybe in the future, they will be able to throw errors.
+//
+// That's probably okay to ignore. We don't, however, want to prevent
+// updating other subscriptions if one subscription had missing data.
+function logAnyError(
+  environment: IsographEnvironment,
+  context: any,
+  f: () => void,
+) {
+  try {
+    f();
+  } catch (e) {
+    logMessage(environment, () => ({
+      kind: 'ErrorEncounteredInWithErrorHandling',
+      error: e,
+      context,
+    }));
+  }
+}
+
+export function callSubscriptions(
+  environment: IsographEnvironment,
+  recordsEncounteredWhenNormalizing: EncounteredIds,
+) {
+  environment.subscriptions.forEach((subscription) =>
+    logAnyError(environment, { situation: 'calling subscriptions' }, () => {
+      switch (subscription.kind) {
+        case 'FragmentSubscription': {
+          // TODO if there are multiple components subscribed to the same
+          // fragment, we will call readButNotEvaluate multiple times. We
+          // should fix that.
+          if (
+            hasOverlappingIds(
+              recordsEncounteredWhenNormalizing,
+              subscription.encounteredDataAndRecords.encounteredRecords,
+            )
+          ) {
+            callSubscriptionIfDataChanged(environment, subscription);
+          }
+          return;
+        }
+        case 'AnyRecords': {
+          logAnyError(
+            environment,
+            { situation: 'calling AnyRecords callback' },
+            () => subscription.callback(),
+          );
+          return;
+        }
+        case 'AnyChangesToRecord': {
+          if (
+            recordsEncounteredWhenNormalizing
+              .get(subscription.recordLink.__typename)
+              ?.has(subscription.recordLink.__link) != null
+          ) {
+            logAnyError(
+              environment,
+              { situation: 'calling AnyChangesToRecord callback' },
+              () => subscription.callback(),
+            );
+          }
+          return;
+        }
+        default: {
+          // Ensure we have covered all variants
+          const _: never = subscription;
+          _;
+          throw new Error('Unexpected case');
+        }
+      }
+    }),
+  );
+}
+
+function callSubscriptionIfDataChanged<
+  TReadFromStore extends UnknownTReadFromStore,
+>(
+  environment: IsographEnvironment,
+  subscription: FragmentSubscription<TReadFromStore>,
+) {
+  const newEncounteredDataAndRecords = readButDoNotEvaluate(
+    environment,
+    subscription.fragmentReference,
+    // Is this wrong?
+    // Reasons to think no:
+    // - we are only updating the read-out value, and the network
+    //   options only affect whether we throw.
+    // - the component will re-render, and re-throw on its own, anyway.
+    //
+    // Reasons to think not:
+    // - it seems more efficient to suspend here and not update state,
+    //   if we expect that the component will just throw anyway
+    // - consistency
+    // - it's also weird, this is called from makeNetworkRequest, where
+    //   we don't currently pass network request options
+    {
+      suspendIfInFlight: false,
+      throwOnNetworkError: false,
+    },
+  );
+
+  const mergedItem = mergeObjectsUsingReaderAst(
+    subscription.readerAst,
+    subscription.encounteredDataAndRecords.item,
+    newEncounteredDataAndRecords.item,
+  );
+
+  logMessage(environment, () => ({
+    kind: 'DeepEqualityCheck',
+    fragmentReference: subscription.fragmentReference,
+    old: subscription.encounteredDataAndRecords.item,
+    new: newEncounteredDataAndRecords.item,
+    deeplyEqual: mergedItem === subscription.encounteredDataAndRecords.item,
+  }));
+
+  if (mergedItem !== subscription.encounteredDataAndRecords.item) {
+    logAnyError(
+      environment,
+      { situation: 'calling FragmentSubscription callback' },
+      () => {
+        subscription.callback(newEncounteredDataAndRecords);
+      },
+    );
+    subscription.encounteredDataAndRecords = newEncounteredDataAndRecords;
+  }
+}
+
+function hasOverlappingIds(
+  ids1: EncounteredIds,
+  ids2: EncounteredIds,
+): boolean {
+  for (const [typeName, set1] of ids1.entries()) {
+    const set2 = ids2.get(typeName);
+    if (set2 === undefined) {
+      continue;
+    }
+
+    if (isNotDisjointFrom(set1, set2)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// TODO use a polyfill library
+function isNotDisjointFrom<T>(set1: Set<T>, set2: Set<T>): boolean {
+  for (const id of set1) {
+    if (set2.has(id)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/libs/isograph-react/src/core/util.ts
+++ b/libs/isograph-react/src/core/util.ts
@@ -31,3 +31,29 @@ export type ArgumentValue =
       readonly kind: 'Object';
       readonly value: Arguments;
     };
+
+export function isArray(value: unknown): value is readonly unknown[] {
+  return Array.isArray(value);
+}
+
+/**
+ * Creates a copy of the provided value, ensuring any nested objects have their
+ * keys sorted such that equivalent values would have identical JSON.stringify
+ * results.
+ */
+export function stableCopy<T>(value: T): T {
+  if (value == null || typeof value !== 'object') {
+    return value;
+  }
+  if (isArray(value)) {
+    // @ts-ignore
+    return value.map(stableCopy);
+  }
+  const keys = Object.keys(value).sort();
+  const stable: { [index: string]: any } = {};
+  for (let i = 0; i < keys.length; i++) {
+    // @ts-ignore
+    stable[keys[i]] = stableCopy(value[keys[i]]);
+  }
+  return stable as any;
+}

--- a/libs/isograph-react/src/core/writeData.ts
+++ b/libs/isograph-react/src/core/writeData.ts
@@ -1,0 +1,79 @@
+import type { ItemCleanupPair } from '@isograph/isograph-disposable-types/dist';
+import { callSubscriptions } from './subscribe';
+import {
+  type NetworkResponseObject,
+  type EncounteredIds,
+  normalizeData,
+} from './cache';
+import type { IsographEntrypoint, NormalizationAst } from './entrypoint';
+import type {
+  UnknownTReadFromStore,
+  ExtractParameters,
+  FragmentReference,
+} from './FragmentReference';
+import {
+  type IsographEnvironment,
+  ROOT_ID,
+  getOrLoadReaderWithRefetchQueries,
+} from './IsographEnvironment';
+import { logMessage } from './logging';
+import { retainQueryWithoutMakingNetworkRequest } from './makeNetworkRequest';
+import { addNetworkResponseStoreLayer } from './optimisticProxy';
+
+export function writeData<
+  TReadFromStore extends UnknownTReadFromStore,
+  TRawResponseType extends NetworkResponseObject,
+  TClientFieldValue,
+>(
+  environment: IsographEnvironment,
+  entrypoint: IsographEntrypoint<
+    TReadFromStore,
+    TClientFieldValue,
+    NormalizationAst,
+    TRawResponseType
+  >,
+  data: TRawResponseType,
+  variables: ExtractParameters<TReadFromStore>,
+): ItemCleanupPair<FragmentReference<TReadFromStore, TClientFieldValue>> {
+  const encounteredIds: EncounteredIds = new Map();
+  environment.store = addNetworkResponseStoreLayer(environment.store);
+  normalizeData(
+    environment,
+    environment.store,
+    entrypoint.networkRequestInfo.normalizationAst.selections,
+    data,
+    variables,
+    { __link: ROOT_ID, __typename: entrypoint.concreteType },
+    encounteredIds,
+  );
+  logMessage(environment, () => ({
+    kind: 'AfterNormalization',
+    store: environment.store,
+    encounteredIds,
+  }));
+
+  callSubscriptions(environment, encounteredIds);
+
+  const { fieldName, readerArtifactKind, readerWithRefetchQueries } =
+    getOrLoadReaderWithRefetchQueries(
+      environment,
+      entrypoint.readerWithRefetchQueries,
+    );
+  const [networkRequest, disposeNetworkRequest] =
+    retainQueryWithoutMakingNetworkRequest(environment, entrypoint, variables);
+
+  return [
+    {
+      kind: 'FragmentReference',
+      readerWithRefetchQueries,
+      fieldName,
+      readerArtifactKind,
+      root: { __link: ROOT_ID, __typename: entrypoint.concreteType },
+      variables,
+      networkRequest,
+    },
+    () => {
+      disposeNetworkRequest();
+    },
+  ];
+}

--- a/libs/isograph-react/src/index.ts
+++ b/libs/isograph-react/src/index.ts
@@ -18,15 +18,14 @@ export {
   NOT_SET,
 } from './core/PromiseWrapper';
 export {
-  callSubscriptions,
-  subscribe,
   normalizeData,
-  writeData,
   type NetworkResponseObject,
   type NetworkResponseValue,
   type NetworkResponseScalarValue,
   type EncounteredIds,
 } from './core/cache';
+export { callSubscriptions, subscribe } from './core/subscribe';
+export { writeData } from './core/writeData';
 export { makeNetworkRequest } from './core/makeNetworkRequest';
 export {
   ROOT_ID,
@@ -40,7 +39,6 @@ export {
   type Link,
   type StoreRecord,
   type CacheMap,
-  createIsographEnvironment,
   createIsographStore,
   type FieldCache,
   type Subscriptions,
@@ -159,6 +157,7 @@ export {
 export { useLazyReference } from './react/useLazyReference';
 export { useRerenderOnChange } from './react/useRerenderOnChange';
 export { RenderAfterCommit__DO_NOT_USE } from './react/RenderAfterCommit__DO_NOT_USE';
+export { createIsographEnvironment } from './react/createIsographEnvironment';
 
 export { useClientSideDefer } from './loadable-hooks/useClientSideDefer';
 export {

--- a/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
@@ -9,21 +9,21 @@ import {
 } from '@isograph/reference-counted-pointer';
 import { useState } from 'react';
 import { subscribeToAnyChange } from '../core/cache';
-import { FetchOptions } from '../core/check';
-import {
+import type { FetchOptions } from '../core/check';
+import type {
   FragmentReference,
-  type UnknownTReadFromStore,
+  UnknownTReadFromStore,
 } from '../core/FragmentReference';
 import { getPromiseState, readPromise } from '../core/PromiseWrapper';
 import {
   readButDoNotEvaluate,
   type WithEncounteredRecords,
 } from '../core/read';
-import { LoadableField, type ReaderAst } from '../core/reader';
+import type { LoadableField, ReaderAst } from '../core/reader';
 import { getOrCreateCachedStartUpdate } from '../core/startUpdate';
 import { useIsographEnvironment } from '../react/IsographEnvironmentProvider';
+import { maybeUnwrapNetworkRequest } from '../react/maybeUnwrapNetworkRequest';
 import { useSubscribeToMultiple } from '../react/useReadAndSubscribe';
-import { maybeUnwrapNetworkRequest } from '../react/useResult';
 
 export type UsePaginationReturnValue<
   TReadFromStore extends UnknownTReadFromStore,

--- a/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
@@ -9,21 +9,21 @@ import {
 } from '@isograph/reference-counted-pointer';
 import { useState } from 'react';
 import { subscribeToAnyChange } from '../core/cache';
-import { FetchOptions } from '../core/check';
-import {
+import type { FetchOptions } from '../core/check';
+import type {
   FragmentReference,
-  type UnknownTReadFromStore,
+  UnknownTReadFromStore,
 } from '../core/FragmentReference';
 import { getPromiseState, readPromise } from '../core/PromiseWrapper';
 import {
   readButDoNotEvaluate,
   type WithEncounteredRecords,
 } from '../core/read';
-import { LoadableField, type ReaderAst } from '../core/reader';
+import type { LoadableField, ReaderAst } from '../core/reader';
 import { getOrCreateCachedStartUpdate } from '../core/startUpdate';
 import { useIsographEnvironment } from '../react/IsographEnvironmentProvider';
+import { maybeUnwrapNetworkRequest } from '../react/maybeUnwrapNetworkRequest';
 import { useSubscribeToMultiple } from '../react/useReadAndSubscribe';
-import { maybeUnwrapNetworkRequest } from '../react/useResult';
 
 export type UseSkipLimitReturnValue<
   TReadFromStore extends UnknownTReadFromStore,

--- a/libs/isograph-react/src/react/createIsographEnvironment.ts
+++ b/libs/isograph-react/src/react/createIsographEnvironment.ts
@@ -1,0 +1,23 @@
+import {
+  createIsographEnvironmentCore,
+  type BaseStoreLayerData,
+  type IsographNetworkFunction,
+  type MissingFieldHandler,
+} from '../core/IsographEnvironment';
+import type { LogFunction } from '../core/logging';
+import { componentFunction } from './useReadAndSubscribe';
+
+export function createIsographEnvironment(
+  baseStoreLayerData: BaseStoreLayerData,
+  networkFunction: IsographNetworkFunction,
+  missingFieldHandler?: MissingFieldHandler | null,
+  logFunction?: LogFunction | null,
+) {
+  return createIsographEnvironmentCore(
+    baseStoreLayerData,
+    networkFunction,
+    componentFunction,
+    missingFieldHandler,
+    logFunction,
+  );
+}

--- a/libs/isograph-react/src/react/maybeUnwrapNetworkRequest.ts
+++ b/libs/isograph-react/src/react/maybeUnwrapNetworkRequest.ts
@@ -1,0 +1,17 @@
+import { type PromiseWrapper, getPromiseState } from '../core/PromiseWrapper';
+import type { NetworkRequestReaderOptions } from '../core/read';
+
+export function maybeUnwrapNetworkRequest(
+  networkRequest: PromiseWrapper<void, any>,
+  networkRequestOptions: NetworkRequestReaderOptions,
+) {
+  const state = getPromiseState(networkRequest);
+  if (state.kind === 'Err' && networkRequestOptions.throwOnNetworkError) {
+    throw state.error;
+  } else if (
+    state.kind === 'Pending' &&
+    networkRequestOptions.suspendIfInFlight
+  ) {
+    throw state.promise;
+  }
+}

--- a/libs/isograph-react/src/react/useLazyReference.ts
+++ b/libs/isograph-react/src/react/useLazyReference.ts
@@ -1,8 +1,5 @@
 import { useLazyDisposableState } from '@isograph/react-disposable-state';
-import {
-  getOrCreateCacheForArtifact,
-  type NetworkResponseObject,
-} from '../core/cache';
+import { type NetworkResponseObject } from '../core/cache';
 import { FetchOptions, type RequiredFetchOptions } from '../core/check';
 import {
   IsographEntrypoint,
@@ -16,6 +13,7 @@ import {
 } from '../core/FragmentReference';
 import { logMessage } from '../core/logging';
 import { useIsographEnvironment } from './IsographEnvironmentProvider';
+import { getOrCreateCacheForArtifact } from '../core/getOrCreateCacheForArtifact';
 
 export function useLazyReference<
   TReadFromStore extends UnknownTReadFromStore,

--- a/libs/isograph-react/src/react/useRerenderOnChange.ts
+++ b/libs/isograph-react/src/react/useRerenderOnChange.ts
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
-import { subscribe } from '../core/cache';
-import { FragmentReference } from '../core/FragmentReference';
-import { WithEncounteredRecords } from '../core/read';
+import type { FragmentReference } from '../core/FragmentReference';
+import type { WithEncounteredRecords } from '../core/read';
 import type { ReaderAst } from '../core/reader';
+import { subscribe } from '../core/subscribe';
 import { useIsographEnvironment } from './IsographEnvironmentProvider';
 
 // TODO add unit tests for this. Add integration tests that test

--- a/libs/isograph-react/src/react/useResult.ts
+++ b/libs/isograph-react/src/react/useResult.ts
@@ -1,19 +1,16 @@
 import { getOrCreateCachedComponent } from '../core/componentCache';
-import {
+import type {
   FragmentReference,
-  type UnknownTReadFromStore,
+  UnknownTReadFromStore,
 } from '../core/FragmentReference';
+import { readPromise } from '../core/PromiseWrapper';
 import {
-  getPromiseState,
-  PromiseWrapper,
-  readPromise,
-} from '../core/PromiseWrapper';
-import {
+  type NetworkRequestReaderOptions,
   getNetworkRequestOptionsWithDefaults,
-  NetworkRequestReaderOptions,
 } from '../core/read';
 import { getOrCreateCachedStartUpdate } from '../core/startUpdate';
-import { useIsographEnvironment } from '../react/IsographEnvironmentProvider';
+import { useIsographEnvironment } from './IsographEnvironmentProvider';
+import { maybeUnwrapNetworkRequest } from './maybeUnwrapNetworkRequest';
 import { useReadAndSubscribe } from './useReadAndSubscribe';
 
 export function useResult<
@@ -66,20 +63,5 @@ export function useResult<
       // @ts-expect-error
       return readerWithRefetchQueries.readerArtifact.resolver(param);
     }
-  }
-}
-
-export function maybeUnwrapNetworkRequest(
-  networkRequest: PromiseWrapper<void, any>,
-  networkRequestOptions: NetworkRequestReaderOptions,
-) {
-  const state = getPromiseState(networkRequest);
-  if (state.kind === 'Err' && networkRequestOptions.throwOnNetworkError) {
-    throw state.error;
-  } else if (
-    state.kind === 'Pending' &&
-    networkRequestOptions.suspendIfInFlight
-  ) {
-    throw state.promise;
   }
 }

--- a/libs/isograph-react/src/tests/garbageCollection.test.ts
+++ b/libs/isograph-react/src/tests/garbageCollection.test.ts
@@ -1,18 +1,15 @@
+import { iso } from '@iso';
 import { describe, expect, test } from 'vitest';
 import {
   garbageCollectEnvironment,
   retainQuery,
   type RetainedQuery,
 } from '../core/garbageCollection';
-import {
-  createIsographEnvironment,
-  ROOT_ID,
-  type BaseStoreLayerData,
-} from '../core/IsographEnvironment';
+import { ROOT_ID, type BaseStoreLayerData } from '../core/IsographEnvironment';
 import { wrapResolvedValue } from '../core/PromiseWrapper';
-import { iso } from './__isograph/iso';
 import { meNameSuccessorRetainedQuery } from './meNameSuccessor';
 import { nodeFieldRetainedQuery } from './nodeQuery';
+import { createIsographEnvironment } from '../react/createIsographEnvironment';
 
 const getDefaultStore = (): BaseStoreLayerData => ({
   Query: {

--- a/libs/isograph-react/src/tests/meNameSuccessor.ts
+++ b/libs/isograph-react/src/tests/meNameSuccessor.ts
@@ -1,7 +1,7 @@
 import type { RetainedQuery } from '../core/garbageCollection';
 import { ROOT_ID } from '../core/IsographEnvironment';
 import { wrapResolvedValue } from '../core/PromiseWrapper';
-import { iso } from './__isograph/iso';
+import { iso } from '@iso';
 
 export const meNameField = iso(`
   field Query.meNameSuccessor {

--- a/libs/isograph-react/src/tests/nodeQuery.ts
+++ b/libs/isograph-react/src/tests/nodeQuery.ts
@@ -1,7 +1,7 @@
 import { RetainedQuery } from '../core/garbageCollection';
 import { ROOT_ID } from '../core/IsographEnvironment';
 import { wrapResolvedValue } from '../core/PromiseWrapper';
-import { iso } from './__isograph/iso';
+import { iso } from '@iso';
 
 // TODO investigate why this can't be in garbageCollection.test.ts without
 // typescript incorrectly thinking it is referenced in its own initializer

--- a/libs/isograph-react/src/tests/normalizeData.test.ts
+++ b/libs/isograph-react/src/tests/normalizeData.test.ts
@@ -1,16 +1,18 @@
+import { iso } from '@iso';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { getOrCreateCacheForArtifact, normalizeData } from '../core/cache';
+
 import {
-  createIsographEnvironment,
   createIsographStore,
   ROOT_ID,
   type BaseStoreLayerData,
 } from '../core/IsographEnvironment';
+import { normalizeData } from '../core/cache';
+import { getOrCreateCacheForArtifact } from '../core/getOrCreateCacheForArtifact';
 import {
   readButDoNotEvaluate,
   type WithEncounteredRecords,
 } from '../core/read';
-import { iso } from './__isograph/iso';
+import { createIsographEnvironment } from '../react/createIsographEnvironment';
 import type { Query__subquery__param } from './__isograph/Query/subquery/param_type';
 
 let store: ReturnType<typeof createIsographStore>;

--- a/libs/isograph-react/src/tests/optimisticProxy.test.ts
+++ b/libs/isograph-react/src/tests/optimisticProxy.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { callSubscriptions, type EncounteredIds } from '../core/cache';
+
+import { type EncounteredIds } from '../core/cache';
 import {
-  createIsographEnvironment,
   createIsographStore,
   type IsographEnvironment,
   type StoreLayerData,
@@ -15,8 +15,10 @@ import {
   type OptimisticStoreLayer,
   type StoreLayer,
 } from '../core/optimisticProxy';
+import { callSubscriptions } from '../core/subscribe';
+import { createIsographEnvironment } from '../react/createIsographEnvironment';
 
-vi.mock(import('../core/cache'), { spy: true });
+vi.mock(import('../core/subscribe'), { spy: true });
 
 const CHANGES = new Map([['Query', new Set(['__ROOT'])]]);
 const NO_CHANGES = new Map();

--- a/libs/isograph-react/src/tests/startUpdate.test.ts
+++ b/libs/isograph-react/src/tests/startUpdate.test.ts
@@ -1,13 +1,11 @@
+import { iso } from '@iso';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { getOrCreateCacheForArtifact } from '../core/cache';
+
 import type { ExtractUpdatableData } from '../core/FragmentReference';
-import {
-  createIsographEnvironment,
-  ROOT_ID,
-  type BaseStoreLayerData,
-} from '../core/IsographEnvironment';
+import { getOrCreateCacheForArtifact } from '../core/getOrCreateCacheForArtifact';
+import { ROOT_ID, type BaseStoreLayerData } from '../core/IsographEnvironment';
 import { createUpdatableProxy } from '../core/startUpdate';
-import { iso } from './__isograph/iso';
+import { createIsographEnvironment } from '../react/createIsographEnvironment';
 import type { Query__linkedUpdate__param } from './__isograph/Query/linkedUpdate/param_type';
 import type { Query__startUpdate__param } from './__isograph/Query/startUpdate/param_type';
 

--- a/libs/isograph-react/vitest.config.ts
+++ b/libs/isograph-react/vitest.config.ts
@@ -26,4 +26,9 @@ export default defineProject({
       },
     }),
   ],
+  resolve: {
+    alias: {
+      '@iso': './tests/__isograph/iso.ts',
+    },
+  },
 });


### PR DESCRIPTION
lint for import cycles.

- moved `subscribe()` from `cache.ts -> subscribe.ts` 
- moved `writeData` from `cache.ts -> writeData.ts`
- moved `getOrCreateCacheForArtifact` from `cache.ts ->
  getOrCreateCacheForArtifact.ts`
- moved `stableCopy` and `isArray` from `cache.ts -> util.ts`
- moved `maybeUnwrapNetworkRequest` from `useResult ->
  maybeUnwrapNetworkRequest.ts`
- removed a nasty cycle `read -> componentCache -> useReadAndSubscribe
  -> read`, it required splitting `componentCache`, which removed core dependy on react  `core -> react -> core` which is part of #564

- updated a bunch of imports to use `type` 