### PR TITLE
enable oxlint rule typescript/consistent-type-imports

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -18,6 +18,7 @@
     "typescript/no-floating-promises": "off",
     "typescript/no-implied-eval": "off",
     "typescript/unbound-method": "off",
+    "typescript/consistent-type-imports": "error",
     "typescript/strict-boolean-expressions": [
       "error",
       {

--- a/demos/disposable-state-ajax-demo/src/components/Card.tsx
+++ b/demos/disposable-state-ajax-demo/src/components/Card.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 
 /**
  * The root component for posts. It lazily loads all posts, and renders them.

--- a/demos/disposable-state-ajax-demo/src/components/LazyLoadPostsPage.tsx
+++ b/demos/disposable-state-ajax-demo/src/components/LazyLoadPostsPage.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import NoSSR from 'react-no-ssr';
 import { getOrCreateCacheForUrl } from './api';
 import { Card } from './Card';
-import { Comment, Post, User } from './networkTypes';
+import type { Comment, Post, User } from './networkTypes';
 import { useReadPromise } from './PromiseWrapper';
 
 /**

--- a/demos/disposable-state-ajax-demo/src/components/PreloadedPostsPage.tsx
+++ b/demos/disposable-state-ajax-demo/src/components/PreloadedPostsPage.tsx
@@ -6,8 +6,9 @@ import React, { useEffect } from 'react';
 import NoSSR from 'react-no-ssr';
 import { makeNetworkRequest } from './api';
 import { Card } from './Card';
-import { Comment, Post, User } from './networkTypes';
-import { PromiseWrapper, useReadPromise } from './PromiseWrapper';
+import type { Comment, Post, User } from './networkTypes';
+import type { PromiseWrapper } from './PromiseWrapper';
+import { useReadPromise } from './PromiseWrapper';
 
 /**
  * Preloading demo

--- a/demos/disposable-state-ajax-demo/src/components/api.ts
+++ b/demos/disposable-state-ajax-demo/src/components/api.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   Factory,
   ItemCleanupPair,
-  ParentCache,
 } from '@isograph/react-disposable-state';
-import { PromiseWrapper, wrapPromise } from './PromiseWrapper';
+import { ParentCache } from '@isograph/react-disposable-state';
+import type { PromiseWrapper } from './PromiseWrapper';
+import { wrapPromise } from './PromiseWrapper';
 
 const cache: { [index: string]: ParentCache<any> } = {};
 

--- a/demos/pet-demo/pages/_app.tsx
+++ b/demos/pet-demo/pages/_app.tsx
@@ -1,8 +1,8 @@
+import type { IsographOperation } from '@isograph/react';
 import {
   createIsographEnvironment,
   createIsographStore,
   IsographEnvironmentProvider,
-  IsographOperation,
   type StoreLink,
   type StoreRecord,
 } from '@isograph/react';

--- a/demos/pet-demo/src/components/Pet/PetUpdater.tsx
+++ b/demos/pet-demo/src/components/Pet/PetUpdater.tsx
@@ -1,7 +1,7 @@
 import { iso } from '@iso';
 import { Box, Button, Input, MenuItem, Select } from '@mui/material';
 import React, { useState } from 'react';
-import { PetId } from '../routes';
+import type { PetId } from '../routes';
 
 export const PetUpdater = iso(`
   field Pet.PetUpdater @component

--- a/demos/pet-demo/src/components/PetByName.tsx
+++ b/demos/pet-demo/src/components/PetByName.tsx
@@ -1,7 +1,7 @@
 import { iso } from '@iso';
 import { useLazyReference, useResult } from '@isograph/react';
 import React from 'react';
-import { PetByNameRoute } from './routes';
+import type { PetByNameRoute } from './routes';
 
 export const PetByNameRouteComponent = iso(`
   field Query.PetByName(

--- a/demos/pet-demo/src/components/PetCheckinListRoute.tsx
+++ b/demos/pet-demo/src/components/PetCheckinListRoute.tsx
@@ -7,7 +7,8 @@ import {
 import { Button, Container, Input, Stack } from '@mui/material';
 import React, { useState } from 'react';
 import { ErrorBoundary } from './ErrorBoundary';
-import { FullPageLoading, PetCheckinListRoute, useNavigateTo } from './routes';
+import type { PetCheckinListRoute } from './routes';
+import { FullPageLoading, useNavigateTo } from './routes';
 
 export const PetDetailDeferredRouteComponent = iso(`
   field Query.PetCheckinListRoute(

--- a/demos/pet-demo/src/components/PetDetailDeferredRoute.tsx
+++ b/demos/pet-demo/src/components/PetDetailDeferredRoute.tsx
@@ -7,11 +7,8 @@ import {
 import { Container, Stack } from '@mui/material';
 import React from 'react';
 import { ErrorBoundary } from './ErrorBoundary';
-import {
-  FullPageLoading,
-  PetDetailDeferredRoute,
-  useNavigateTo,
-} from './routes';
+import type { PetDetailDeferredRoute } from './routes';
+import { FullPageLoading, useNavigateTo } from './routes';
 
 export const PetDetailDeferredRouteComponent = iso(`
   field Query.PetDetailDeferredRoute(

--- a/demos/pet-demo/src/components/PetDetailRoute.tsx
+++ b/demos/pet-demo/src/components/PetDetailRoute.tsx
@@ -3,7 +3,8 @@ import { FragmentRenderer, useLazyReference } from '@isograph/react';
 import { Button, Card, CardContent, Container, Stack } from '@mui/material';
 import React from 'react';
 import { ErrorBoundary } from './ErrorBoundary';
-import { FullPageLoading, PetDetailRoute, useNavigateTo } from './routes';
+import type { PetDetailRoute } from './routes';
+import { FullPageLoading, useNavigateTo } from './routes';
 
 export const PetDetailRouteComponent = iso(`
   field Query.PetDetailRoute(

--- a/demos/pet-demo/src/components/RestEndpointDemoRoute.tsx
+++ b/demos/pet-demo/src/components/RestEndpointDemoRoute.tsx
@@ -5,8 +5,8 @@ import {
   useUpdatableDisposableState,
 } from '@isograph/react-disposable-state';
 import { Suspense, useEffect } from 'react';
+import type { FragmentReferenceOfEntrypoint } from '@isograph/react';
 import {
-  FragmentReferenceOfEntrypoint,
   FragmentRenderer,
   useIsographEnvironment,
   writeData,

--- a/libs/isograph-react-disposable-state/src/CacheItem.test.ts
+++ b/libs/isograph-react-disposable-state/src/CacheItem.test.ts
@@ -1,4 +1,4 @@
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import {
   afterEach,
   assert,
@@ -8,11 +8,8 @@ import {
   test,
   vi,
 } from 'vitest';
-import {
-  CacheItem,
-  CacheItemState,
-  createTemporarilyRetainedCacheItem,
-} from './CacheItem';
+import type { CacheItem, CacheItemState } from './CacheItem';
+import { createTemporarilyRetainedCacheItem } from './CacheItem';
 
 function getState<T>(cacheItem: CacheItem<T>): CacheItemState<T> {
   return (cacheItem as any).__state as CacheItemState<T>;

--- a/libs/isograph-react-disposable-state/src/CacheItem.ts
+++ b/libs/isograph-react-disposable-state/src/CacheItem.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CleanupFn,
   Factory,
   ItemCleanupPair,

--- a/libs/isograph-react-disposable-state/src/ParentCache.test.ts
+++ b/libs/isograph-react-disposable-state/src/ParentCache.test.ts
@@ -1,6 +1,6 @@
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import { assert, describe, expect, test, vi } from 'vitest';
-import { CacheItem } from './CacheItem';
+import type { CacheItem } from './CacheItem';
 import { ParentCache } from './ParentCache';
 
 function getValue<T>(cache: ParentCache<T>): CacheItem<T> | null {

--- a/libs/isograph-react-disposable-state/src/ParentCache.ts
+++ b/libs/isograph-react-disposable-state/src/ParentCache.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   CleanupFn,
   Factory,
   ItemCleanupPair,
 } from '@isograph/disposable-types';
-import { CacheItem, createTemporarilyRetainedCacheItem } from './CacheItem';
+import type { CacheItem } from './CacheItem';
+import { createTemporarilyRetainedCacheItem } from './CacheItem';
 
 // TODO convert cache impl to a getter and setter and free functions
 // TODO accept options that get passed to CacheItem

--- a/libs/isograph-react-disposable-state/src/useCachedResponsivePrecommitValue.test.tsx
+++ b/libs/isograph-react-disposable-state/src/useCachedResponsivePrecommitValue.test.tsx
@@ -1,8 +1,8 @@
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import React, { type MutableRefObject } from 'react';
 import { create } from 'react-test-renderer';
 import { assert, describe, expect, test, vi } from 'vitest';
-import { CacheItem, CacheItemState } from './CacheItem';
+import type { CacheItem, CacheItemState } from './CacheItem';
 import { ParentCache } from './ParentCache';
 import { useCachedResponsivePrecommitValue } from './useCachedResponsivePrecommitValue';
 

--- a/libs/isograph-react-disposable-state/src/useCachedResponsivePrecommitValue.ts
+++ b/libs/isograph-react-disposable-state/src/useCachedResponsivePrecommitValue.ts
@@ -1,8 +1,8 @@
 'use strict';
 
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import { useEffect, useRef, useState } from 'react';
-import { ParentCache } from './ParentCache';
+import type { ParentCache } from './ParentCache';
 
 /**
  * useCachedResponsivePrecommitValue<T>

--- a/libs/isograph-react-disposable-state/src/useDisposableState.ts
+++ b/libs/isograph-react-disposable-state/src/useDisposableState.ts
@@ -1,10 +1,10 @@
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import { useEffect, useRef } from 'react';
-import { ParentCache } from './ParentCache';
+import type { ParentCache } from './ParentCache';
 import { useCachedResponsivePrecommitValue } from './useCachedResponsivePrecommitValue';
 import {
   UNASSIGNED_STATE,
-  UnassignedState,
+  type UnassignedState,
   useUpdatableDisposableState,
 } from './useUpdatableDisposableState';
 

--- a/libs/isograph-react-disposable-state/src/useHasCommittedRef.ts
+++ b/libs/isograph-react-disposable-state/src/useHasCommittedRef.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useEffect, useRef } from 'react';
+import { type MutableRefObject, useEffect, useRef } from 'react';
 
 /**
  * Returns true if the component has committed, false otherwise.

--- a/libs/isograph-react-disposable-state/src/useLazyDisposableState.test.tsx
+++ b/libs/isograph-react-disposable-state/src/useLazyDisposableState.test.tsx
@@ -1,4 +1,4 @@
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import React, { useEffect, useState } from 'react';
 import { create } from 'react-test-renderer';
 import { describe, expect, test, vi } from 'vitest';

--- a/libs/isograph-react-disposable-state/src/useLazyDisposableState.ts
+++ b/libs/isograph-react-disposable-state/src/useLazyDisposableState.ts
@@ -2,7 +2,7 @@
 
 import type { ItemCleanupPair } from '@isograph/isograph-disposable-types';
 import { useEffect, useRef } from 'react';
-import { ParentCache } from './ParentCache';
+import type { ParentCache } from './ParentCache';
 import { useCachedResponsivePrecommitValue } from './useCachedResponsivePrecommitValue';
 import { type UnassignedState } from './useUpdatableDisposableState';
 

--- a/libs/isograph-react-disposable-state/src/useUpdatableDisposableState.ts
+++ b/libs/isograph-react-disposable-state/src/useUpdatableDisposableState.ts
@@ -1,4 +1,4 @@
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useHasCommittedRef } from './useHasCommittedRef';
 

--- a/libs/isograph-react/src/core/FragmentReference.ts
+++ b/libs/isograph-react/src/core/FragmentReference.ts
@@ -1,9 +1,9 @@
-import { ReaderWithRefetchQueries } from './entrypoint';
+import type { ReaderWithRefetchQueries } from './entrypoint';
 import {
   type ComponentOrFieldName,
   type StoreLink,
 } from './IsographEnvironment';
-import { PromiseWrapper } from './PromiseWrapper';
+import type { PromiseWrapper } from './PromiseWrapper';
 import type { StartUpdate } from './reader';
 import { stableCopy } from './util';
 

--- a/libs/isograph-react/src/core/IsographEnvironment.ts
+++ b/libs/isograph-react/src/core/IsographEnvironment.ts
@@ -1,4 +1,4 @@
-import { ParentCache } from '@isograph/react-disposable-state';
+import type { ParentCache } from '@isograph/react-disposable-state';
 import type { Brand } from './brand';
 import type {
   IsographEntrypoint,
@@ -17,11 +17,8 @@ import type {
 import type { RetainedQuery } from './garbageCollection';
 import type { LogFunction, WrappedLogFunction } from './logging';
 import { type StoreLayer } from './optimisticProxy';
-import {
-  PromiseWrapper,
-  wrapPromise,
-  wrapResolvedValue,
-} from './PromiseWrapper';
+import type { PromiseWrapper } from './PromiseWrapper';
+import { wrapPromise, wrapResolvedValue } from './PromiseWrapper';
 import type {
   NetworkRequestReaderOptions,
   WithEncounteredRecords,

--- a/libs/isograph-react/src/core/check.ts
+++ b/libs/isograph-react/src/core/check.ts
@@ -1,12 +1,12 @@
 import { getParentRecordKey } from './cache';
-import { NormalizationAstNodes } from './entrypoint';
-import { Variables } from './FragmentReference';
-import {
-  getLink,
+import type { NormalizationAstNodes } from './entrypoint';
+import type { Variables } from './FragmentReference';
+import type {
   IsographEnvironment,
   StoreLink,
   StoreRecord,
 } from './IsographEnvironment';
+import { getLink } from './IsographEnvironment';
 import { logMessage } from './logging';
 import { getStoreRecordProxy } from './optimisticProxy';
 

--- a/libs/isograph-react/src/core/componentCache.ts
+++ b/libs/isograph-react/src/core/componentCache.ts
@@ -1,7 +1,5 @@
-import {
-  FragmentReference,
-  stableIdForFragmentReference,
-} from './FragmentReference';
+import type { FragmentReference } from './FragmentReference';
+import { stableIdForFragmentReference } from './FragmentReference';
 import type { IsographEnvironment } from './IsographEnvironment';
 import type { NetworkRequestReaderOptions } from './read';
 import { createStartUpdate } from './startUpdate';

--- a/libs/isograph-react/src/core/makeNetworkRequest.ts
+++ b/libs/isograph-react/src/core/makeNetworkRequest.ts
@@ -4,7 +4,8 @@ import {
   type EncounteredIds,
   type NetworkResponseObject,
 } from './cache';
-import { check, DEFAULT_SHOULD_FETCH_VALUE, FetchOptions } from './check';
+import type { FetchOptions } from './check';
+import { check, DEFAULT_SHOULD_FETCH_VALUE } from './check';
 import { getOrCreateCachedComponent } from './componentCache';
 import type {
   IsographEntrypoint,
@@ -18,13 +19,14 @@ import type {
   FragmentReference,
   UnknownTReadFromStore,
 } from './FragmentReference';
+import type { RetainedQuery } from './garbageCollection';
 import {
   garbageCollectEnvironment,
-  RetainedQuery,
   retainQuery,
   unretainQuery,
 } from './garbageCollection';
-import { IsographEnvironment, ROOT_ID, StoreLink } from './IsographEnvironment';
+import type { IsographEnvironment, StoreLink } from './IsographEnvironment';
+import { ROOT_ID } from './IsographEnvironment';
 import { logMessage } from './logging';
 import {
   addNetworkResponseStoreLayer,
@@ -33,12 +35,8 @@ import {
   type OptimisticStoreLayer,
   type StoreLayerWithData,
 } from './optimisticProxy';
-import {
-  AnyError,
-  PromiseWrapper,
-  wrapPromise,
-  wrapResolvedValue,
-} from './PromiseWrapper';
+import type { AnyError, PromiseWrapper } from './PromiseWrapper';
+import { wrapPromise, wrapResolvedValue } from './PromiseWrapper';
 import { readButDoNotEvaluate } from './read';
 import { getOrCreateCachedStartUpdate } from './startUpdate';
 import { callSubscriptions } from './subscribe';

--- a/libs/isograph-react/src/core/read.ts
+++ b/libs/isograph-react/src/core/read.ts
@@ -5,7 +5,7 @@ import {
   onNextChangeToRecord,
   type EncounteredIds,
 } from './cache';
-import { FetchOptions } from './check';
+import type { FetchOptions } from './check';
 import { getOrCreateCachedComponent } from './componentCache';
 import type {
   IsographEntrypoint,
@@ -18,11 +18,11 @@ import type {
   UnknownTReadFromStore,
   Variables,
 } from './FragmentReference';
+import type { IsographEnvironment } from './IsographEnvironment';
 import {
   assertLink,
   getOrLoadIsographArtifact,
   getOrLoadReaderWithRefetchQueries,
-  IsographEnvironment,
   type DataTypeValue,
   type StoreLink,
   type StoreRecord,
@@ -30,10 +30,10 @@ import {
 import { logMessage } from './logging';
 import { maybeMakeNetworkRequest } from './makeNetworkRequest';
 import { getStoreRecordProxy } from './optimisticProxy';
+import type { PromiseWrapper } from './PromiseWrapper';
 import {
   getPromiseState,
   NOT_SET,
-  PromiseWrapper,
   readPromise,
   wrapPromise,
   wrapResolvedValue,

--- a/libs/isograph-react/src/core/reader.ts
+++ b/libs/isograph-react/src/core/reader.ts
@@ -1,22 +1,19 @@
-import { Factory } from '@isograph/disposable-types';
-import { FetchOptions } from './check';
-import {
+import type { Factory } from '@isograph/disposable-types';
+import type { FetchOptions } from './check';
+import type {
   IsographEntrypoint,
   IsographEntrypointLoader,
   RefetchQueryNormalizationArtifact,
   RefetchQueryNormalizationArtifactWrapper,
 } from './entrypoint';
-import {
-  ExtractParameters,
-  FragmentReference,
-  type UnknownTReadFromStore,
-} from './FragmentReference';
-import {
+import type { ExtractParameters, FragmentReference } from './FragmentReference';
+import { type UnknownTReadFromStore } from './FragmentReference';
+import type {
   ComponentOrFieldName,
   IsographEnvironment,
-  type StoreLink,
 } from './IsographEnvironment';
-import { Arguments } from './util';
+import { type StoreLink } from './IsographEnvironment';
+import type { Arguments } from './util';
 
 export type TopLevelReaderArtifact<
   TReadFromStore extends UnknownTReadFromStore,

--- a/libs/isograph-react/src/loadable-hooks/useClientSideDefer.ts
+++ b/libs/isograph-react/src/loadable-hooks/useClientSideDefer.ts
@@ -1,12 +1,12 @@
 import { useLazyDisposableState } from '@isograph/react-disposable-state';
 import { getOrCreateItemInSuspenseCache } from '../core/cache';
-import { FetchOptions } from '../core/check';
-import {
+import type { FetchOptions } from '../core/check';
+import type {
   ExtractParameters,
   FragmentReference,
-  type UnknownTReadFromStore,
 } from '../core/FragmentReference';
-import { LoadableField } from '../core/reader';
+import { type UnknownTReadFromStore } from '../core/FragmentReference';
+import type { LoadableField } from '../core/reader';
 import { useIsographEnvironment } from '../react/IsographEnvironmentProvider';
 
 type ArgsWithoutProvidedArgs<

--- a/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useConnectionSpecPagination.ts
@@ -1,12 +1,10 @@
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import {
   UNASSIGNED_STATE,
   useUpdatableDisposableState,
 } from '@isograph/react-disposable-state';
-import {
-  createReferenceCountedPointer,
-  ReferenceCountedPointer,
-} from '@isograph/reference-counted-pointer';
+import type { ReferenceCountedPointer } from '@isograph/reference-counted-pointer';
+import { createReferenceCountedPointer } from '@isograph/reference-counted-pointer';
 import { useState } from 'react';
 import { subscribeToAnyChange } from '../core/cache';
 import type { FetchOptions } from '../core/check';

--- a/libs/isograph-react/src/loadable-hooks/useImperativeLoadableField.ts
+++ b/libs/isograph-react/src/loadable-hooks/useImperativeLoadableField.ts
@@ -2,12 +2,12 @@ import {
   UNASSIGNED_STATE,
   useUpdatableDisposableState,
 } from '@isograph/react-disposable-state';
-import { FetchOptions } from '../core/check';
-import {
+import type { FetchOptions } from '../core/check';
+import type {
   ExtractParameters,
   FragmentReference,
 } from '../core/FragmentReference';
-import { LoadableField } from '../core/reader';
+import type { LoadableField } from '../core/reader';
 
 export type UseImperativeLoadableFieldReturn<
   TReadFromStore extends { data: object; parameters: object },

--- a/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
+++ b/libs/isograph-react/src/loadable-hooks/useSkipLimitPagination.ts
@@ -1,12 +1,10 @@
-import { ItemCleanupPair } from '@isograph/disposable-types';
+import type { ItemCleanupPair } from '@isograph/disposable-types';
 import {
   UNASSIGNED_STATE,
   useUpdatableDisposableState,
 } from '@isograph/react-disposable-state';
-import {
-  createReferenceCountedPointer,
-  ReferenceCountedPointer,
-} from '@isograph/reference-counted-pointer';
+import type { ReferenceCountedPointer } from '@isograph/reference-counted-pointer';
+import { createReferenceCountedPointer } from '@isograph/reference-counted-pointer';
 import { useState } from 'react';
 import { subscribeToAnyChange } from '../core/cache';
 import type { FetchOptions } from '../core/check';

--- a/libs/isograph-react/src/react/IsographEnvironmentProvider.tsx
+++ b/libs/isograph-react/src/react/IsographEnvironmentProvider.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { createContext, ReactNode, useContext } from 'react';
+import type { ReactNode } from 'react';
+import { createContext, useContext } from 'react';
 import { type IsographEnvironment } from '../core/IsographEnvironment';
 
 export const IsographEnvironmentContext =

--- a/libs/isograph-react/src/react/LoadableFieldReader.tsx
+++ b/libs/isograph-react/src/react/LoadableFieldReader.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { type FetchOptions } from '../core/check';
-import {
-  ExtractParameters,
-  type UnknownTReadFromStore,
-} from '../core/FragmentReference';
+import type { ExtractParameters } from '../core/FragmentReference';
+import { type UnknownTReadFromStore } from '../core/FragmentReference';
 import { type NetworkRequestReaderOptions } from '../core/read';
 import { type LoadableField } from '../core/reader';
 import { useClientSideDefer } from '../loadable-hooks/useClientSideDefer';

--- a/libs/isograph-react/src/react/LoadableFieldRenderer.tsx
+++ b/libs/isograph-react/src/react/LoadableFieldRenderer.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { type FetchOptions } from '../core/check';
-import {
-  ExtractParameters,
-  type UnknownTReadFromStore,
-} from '../core/FragmentReference';
+import type { ExtractParameters } from '../core/FragmentReference';
+import { type UnknownTReadFromStore } from '../core/FragmentReference';
 import { type NetworkRequestReaderOptions } from '../core/read';
 import { type LoadableField } from '../core/reader';
 import { useClientSideDefer } from '../loadable-hooks/useClientSideDefer';

--- a/libs/isograph-react/src/react/useImperativeReference.ts
+++ b/libs/isograph-react/src/react/useImperativeReference.ts
@@ -3,17 +3,18 @@ import {
   useUpdatableDisposableState,
 } from '@isograph/react-disposable-state';
 import type { NetworkResponseObject } from '../core/cache';
-import { FetchOptions, type RequiredFetchOptions } from '../core/check';
+import type { FetchOptions } from '../core/check';
+import { type RequiredFetchOptions } from '../core/check';
+import type { IsographEntrypoint } from '../core/entrypoint';
 import {
-  IsographEntrypoint,
   type NormalizationAst,
   type NormalizationAstLoader,
 } from '../core/entrypoint';
-import {
+import type {
   ExtractParameters,
   FragmentReference,
-  type UnknownTReadFromStore,
 } from '../core/FragmentReference';
+import { type UnknownTReadFromStore } from '../core/FragmentReference';
 import {
   getOrLoadReaderWithRefetchQueries,
   ROOT_ID,

--- a/libs/isograph-react/src/react/useLazyReference.ts
+++ b/libs/isograph-react/src/react/useLazyReference.ts
@@ -1,16 +1,17 @@
 import { useLazyDisposableState } from '@isograph/react-disposable-state';
 import { type NetworkResponseObject } from '../core/cache';
-import { FetchOptions, type RequiredFetchOptions } from '../core/check';
+import type { FetchOptions } from '../core/check';
+import { type RequiredFetchOptions } from '../core/check';
+import type { IsographEntrypoint } from '../core/entrypoint';
 import {
-  IsographEntrypoint,
   type NormalizationAst,
   type NormalizationAstLoader,
 } from '../core/entrypoint';
-import {
+import type {
   ExtractParameters,
   FragmentReference,
-  type UnknownTReadFromStore,
 } from '../core/FragmentReference';
+import { type UnknownTReadFromStore } from '../core/FragmentReference';
 import { logMessage } from '../core/logging';
 import { useIsographEnvironment } from './IsographEnvironmentProvider';
 import { getOrCreateCacheForArtifact } from '../core/getOrCreateCacheForArtifact';

--- a/libs/isograph-react/src/tests/nodeQuery.ts
+++ b/libs/isograph-react/src/tests/nodeQuery.ts
@@ -1,4 +1,4 @@
-import { RetainedQuery } from '../core/garbageCollection';
+import type { RetainedQuery } from '../core/garbageCollection';
 import { ROOT_ID } from '../core/IsographEnvironment';
 import { wrapResolvedValue } from '../core/PromiseWrapper';
 import { iso } from '@iso';

--- a/vscode-extension/src/config.ts
+++ b/vscode-extension/src/config.ts
@@ -1,4 +1,5 @@
-import { ConfigurationScope, workspace } from 'vscode';
+import type { ConfigurationScope } from 'vscode';
+import { workspace } from 'vscode';
 
 export type Config = {
   rootDirectory: string | null;

--- a/vscode-extension/src/context.ts
+++ b/vscode-extension/src/context.ts
@@ -1,5 +1,5 @@
-import { ExtensionContext, OutputChannel, Terminal } from 'vscode';
-import { LanguageClient } from 'vscode-languageclient/node';
+import type { ExtensionContext, OutputChannel, Terminal } from 'vscode';
+import type { LanguageClient } from 'vscode-languageclient/node';
 
 export type IsographExtensionContext = {
   client: LanguageClient | null;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,6 +1,7 @@
-import { ExtensionContext, window, workspace } from 'vscode';
+import type { ExtensionContext } from 'vscode';
+import { window, workspace } from 'vscode';
 import { getConfig } from './config';
-import { IsographExtensionContext } from './context';
+import type { IsographExtensionContext } from './context';
 import { createAndStartLanguageClient } from './languageClient';
 import { findIsographBinaryWithWarnings } from './utils/findIsographBinary';
 

--- a/vscode-extension/src/languageClient.ts
+++ b/vscode-extension/src/languageClient.ts
@@ -1,20 +1,15 @@
 import * as path from 'path';
+import type { FormattingOptions, TextEdit } from 'vscode';
+import { Range, window, workspace, WorkspaceEdit } from 'vscode';
+import type { LanguageClientOptions } from 'vscode-languageclient';
 import {
-  FormattingOptions,
-  Range,
-  TextEdit,
-  window,
-  workspace,
-  WorkspaceEdit,
-} from 'vscode';
-import {
-  LanguageClientOptions,
   RevealOutputChannelOn,
   TextDocumentIdentifier,
 } from 'vscode-languageclient';
-import { LanguageClient, ServerOptions } from 'vscode-languageclient/node';
+import type { ServerOptions } from 'vscode-languageclient/node';
+import { LanguageClient } from 'vscode-languageclient/node';
 import { getConfig } from './config';
-import { IsographExtensionContext } from './context';
+import type { IsographExtensionContext } from './context';
 
 export function createAndStartLanguageClient(
   context: IsographExtensionContext,

--- a/vscode-extension/src/utils/findIsographBinary.ts
+++ b/vscode-extension/src/utils/findIsographBinary.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as semver from 'semver';
-import { OutputChannel, window, workspace } from 'vscode';
+import type { OutputChannel } from 'vscode';
+import { window, workspace } from 'vscode';
 import { getConfig } from '../config';
 
 async function exists(file: string): Promise<boolean> {


### PR DESCRIPTION
It turns out, there is a rule for that, which is great, because I don't think typescript can fix these on save