### PR TITLE
Feat: Update the github actions to correctly read in the secrets vaule when Isogrqaph extension is release step is invoked.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,7 +523,7 @@ jobs:
 
   publish-isograph-extension:
     name: Publish Isograph Extension
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'isographlabs/isograph' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     uses: ./.github/workflows/publish-isograph-extension.yml
     needs: [all-checks-passed]
     secrets:

--- a/.github/workflows/publish-isograph-extension.yml
+++ b/.github/workflows/publish-isograph-extension.yml
@@ -15,10 +15,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Debug - Print secret values
-        run: |
-          echo "open-vsx-token: $(echo -n '${{ secrets.open-vsx-token }}' | base64)"
-          echo "vs-marketplace-token: $(echo -n '${{ secrets.vs-marketplace-token }}' | base64)"
       - run: npm ci
         working-directory: vscode-extension
       - name: Publish to Open VSX Registry


### PR DESCRIPTION
I tested the change by removing the if checks on the release step. The child workflow was able to ingest the secrets values successfully.
<img width="1728" height="1037" alt="image" src="https://github.com/user-attachments/assets/f97c212c-83a6-4260-b7cb-ca7b88f595eb" />
