### PR TITLE
wrap record fields in `WithErrors`

### DIFF
--- a/libs/isograph-react/src/core/IsographEnvironment.ts
+++ b/libs/isograph-react/src/core/IsographEnvironment.ts
@@ -120,6 +120,24 @@ export type StoreLink = {
   readonly __typename: TypeName;
 };
 
+export type WithErrorsData<T> = {
+  readonly kind: 'Data';
+  readonly value: T;
+};
+
+export type WithErrors<T> =
+  | WithErrorsData<T>
+  | {
+      readonly kind: 'Errors';
+    };
+
+export function isWithErrors<T>(
+  _value: T | WithErrors<T>,
+  isFallible: boolean,
+): _value is WithErrors<T> {
+  return isFallible === true;
+}
+
 export type DataTypeValueScalar =
   // N.B. undefined is here to support optional id's, but
   // undefined should not *actually* be present in the store.
@@ -144,8 +162,12 @@ export type DataTypeValueLinked =
   | readonly DataTypeValueLinked[];
 
 export type StoreRecord = {
-  [index: ScalarParentRecordKey]: DataTypeValueScalar;
-  [index: LinkedParentRecordKey]: DataTypeValueLinked;
+  [index: ScalarParentRecordKey]:
+    | DataTypeValueScalar
+    | WithErrors<DataTypeValueScalar>;
+  [index: LinkedParentRecordKey]:
+    | DataTypeValueLinked
+    | WithErrors<DataTypeValueLinked>;
 } & {
   // TODO __typename?: T, which is restricted to being a concrete string
   // TODO this shouldn't always be named id

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -17,6 +17,7 @@ import {
   type DataTypeValueLinked,
   getLink,
   type IsographEnvironment,
+  isWithErrors,
   ROOT_ID,
   type StoreLink,
   type StoreRecord,
@@ -237,6 +238,10 @@ function normalizeScalarField(
   const parentRecordKey = getParentRecordKey(astNode, variables);
   const existingValue = targetStoreRecord[parentRecordKey];
 
+  if (isWithErrors(existingValue, astNode.isFallible ?? false)) {
+    throw new Error('TODO: write errors');
+  }
+
   if (networkResponseData == null) {
     targetStoreRecord[parentRecordKey] = null;
     return existingValue === undefined || existingValue != null;
@@ -263,6 +268,10 @@ function normalizeLinkedField(
   const networkResponseData = networkResponseParentRecord[networkResponseKey];
   const parentRecordKey = getParentRecordKey(astNode, variables);
   const existingValue = targetParentRecord[parentRecordKey];
+
+  if (isWithErrors(existingValue, astNode.isFallible ?? false)) {
+    throw new Error('TODO: write errors');
+  }
 
   if (networkResponseData == null) {
     targetParentRecord[parentRecordKey] = null;

--- a/libs/isograph-react/src/core/check.ts
+++ b/libs/isograph-react/src/core/check.ts
@@ -6,7 +6,7 @@ import type {
   StoreLink,
   StoreRecord,
 } from './IsographEnvironment';
-import { getLink } from './IsographEnvironment';
+import { getLink, isWithErrors } from './IsographEnvironment';
 import { logMessage } from './logging';
 import { getStoreRecordProxy } from './optimisticProxy';
 
@@ -101,7 +101,16 @@ function checkFromRecord(
           variables,
         );
 
-        const linkedValue = record[parentRecordKey];
+        let linkedValue = record[parentRecordKey];
+
+        if (
+          isWithErrors(linkedValue, normalizationAstNode.isFallible ?? false)
+        ) {
+          if (linkedValue.kind === 'Errors') {
+            continue;
+          }
+          linkedValue = linkedValue.value;
+        }
 
         if (linkedValue === undefined) {
           return {


### PR DESCRIPTION
<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #931 
- <kbd>&nbsp;2&nbsp;</kbd> #930 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #928
<!-- GitButler Footer Boundary Bottom -->