### PR TITLE
chore: add explicit return types and declaration settings for safer and faster builds

### DIFF
--- a/libs/isograph-babel-plugin/tsconfig.json
+++ b/libs/isograph-babel-plugin/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
+    "isolatedDeclarations": false // cannot use with allowJs
   },
   "include": ["./**/*.ts", "./**/*.js"]
 }

--- a/libs/isograph-react-disposable-state/src/ParentCache.ts
+++ b/libs/isograph-react-disposable-state/src/ParentCache.ts
@@ -85,7 +85,7 @@ export class ParentCache<T> {
     return [cacheItem, cacheItem.getValue(), disposeTemporaryRetain];
   }
 
-  empty() {
+  empty(): void {
     this.__cacheItem = null;
   }
 

--- a/libs/isograph-react/src/core/PromiseWrapper.ts
+++ b/libs/isograph-react/src/core/PromiseWrapper.ts
@@ -1,6 +1,6 @@
 export type AnyError = any;
 
-export const NOT_SET = Symbol('NOT_SET');
+export const NOT_SET: unique symbol = Symbol('NOT_SET');
 export type NotSet = typeof NOT_SET;
 
 export type Result<T, E> =

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -219,7 +219,7 @@ function normalizeDataIntoRecord(
   return recordHasBeenUpdated;
 }
 
-export function insertEmptySetIfMissing<K, V>(map: Map<K, Set<V>>, key: K) {
+export function insertEmptySetIfMissing<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
   let result = map.get(key);
   if (result === undefined) {
     result = new Set();

--- a/libs/isograph-react/src/core/cache.ts
+++ b/libs/isograph-react/src/core/cache.ts
@@ -219,7 +219,10 @@ function normalizeDataIntoRecord(
   return recordHasBeenUpdated;
 }
 
-export function insertEmptySetIfMissing<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
+export function insertEmptySetIfMissing<K, V>(
+  map: Map<K, Set<V>>,
+  key: K,
+): Set<V> {
   let result = map.get(key);
   if (result === undefined) {
     result = new Set();

--- a/libs/isograph-react/src/core/garbageCollection.ts
+++ b/libs/isograph-react/src/core/garbageCollection.ts
@@ -55,14 +55,16 @@ export function unretainQuery(
 export function retainQuery(
   environment: IsographEnvironment,
   queryToRetain: RetainedQuery,
-) {
+): void {
   environment.retainedQueries.add(queryToRetain);
   // TODO can we remove this query from the buffer somehow?
   // We are relying on === equality, but we really should be comparing
   // id + variables
 }
 
-export function garbageCollectEnvironment(environment: IsographEnvironment) {
+export function garbageCollectEnvironment(
+  environment: IsographEnvironment,
+): void {
   if (environment.store.kind !== 'BaseStoreLayer') {
     return;
   }
@@ -88,7 +90,7 @@ export function garbageCollectEnvironment(environment: IsographEnvironment) {
 export function garbageCollectBaseStoreLayer(
   retainedQueries: RetainedQueryWithNormalizationAst[],
   baseStoreLayer: BaseStoreLayer,
-) {
+): void {
   const retainedIds: RetainedIds = {};
 
   for (const query of retainedQueries) {

--- a/libs/isograph-react/src/core/logging.ts
+++ b/libs/isograph-react/src/core/logging.ts
@@ -119,7 +119,7 @@ export type WrappedLogFunction = {
 export function logMessage(
   environment: IsographEnvironment,
   getMessage: () => LogMessage,
-) {
+): void {
   if (environment.loggers.size > 0) {
     const message = getMessage();
     for (const logger of environment.loggers) {

--- a/libs/isograph-react/src/core/subscribe.ts
+++ b/libs/isograph-react/src/core/subscribe.ts
@@ -63,7 +63,7 @@ function logAnyError(
 export function callSubscriptions(
   environment: IsographEnvironment,
   recordsEncounteredWhenNormalizing: EncounteredIds,
-) {
+): void {
   environment.subscriptions.forEach((subscription) =>
     logAnyError(environment, { situation: 'calling subscriptions' }, () => {
       switch (subscription.kind) {

--- a/libs/isograph-react/src/react/IsographEnvironmentProvider.tsx
+++ b/libs/isograph-react/src/react/IsographEnvironmentProvider.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { createContext, useContext } from 'react';
 import { type IsographEnvironment } from '../core/IsographEnvironment';
 
-export const IsographEnvironmentContext =
+export const IsographEnvironmentContext: React.Context<IsographEnvironment | null> =
   createContext<IsographEnvironment | null>(null);
 
 export type IsographEnvironmentProviderProps = {

--- a/libs/isograph-react/src/react/RenderAfterCommit__DO_NOT_USE.tsx
+++ b/libs/isograph-react/src/react/RenderAfterCommit__DO_NOT_USE.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 
 /**
  * This is a function that will render a component only after it commits.
@@ -10,7 +10,7 @@ export function RenderAfterCommit__DO_NOT_USE({
   children,
 }: {
   children: React.ReactNode;
-}) {
+}): ReactNode {
   const [show, setShow] = useState(false);
   useEffect(() => setShow(true), []);
   return show ? children : null;

--- a/libs/isograph-react/src/react/createIsographEnvironment.ts
+++ b/libs/isograph-react/src/react/createIsographEnvironment.ts
@@ -1,6 +1,7 @@
 import {
   createIsographEnvironmentCore,
   type BaseStoreLayerData,
+  type IsographEnvironment,
   type IsographNetworkFunction,
   type MissingFieldHandler,
 } from '../core/IsographEnvironment';
@@ -12,7 +13,7 @@ export function createIsographEnvironment(
   networkFunction: IsographNetworkFunction,
   missingFieldHandler?: MissingFieldHandler | null,
   logFunction?: LogFunction | null,
-) {
+): IsographEnvironment {
   return createIsographEnvironmentCore(
     baseStoreLayerData,
     networkFunction,

--- a/libs/isograph-react/src/react/maybeUnwrapNetworkRequest.ts
+++ b/libs/isograph-react/src/react/maybeUnwrapNetworkRequest.ts
@@ -4,7 +4,7 @@ import type { NetworkRequestReaderOptions } from '../core/read';
 export function maybeUnwrapNetworkRequest(
   networkRequest: PromiseWrapper<void, any>,
   networkRequestOptions: NetworkRequestReaderOptions,
-) {
+): void {
   const state = getPromiseState(networkRequest);
   if (state.kind === 'Err' && networkRequestOptions.throwOnNetworkError) {
     throw state.error;

--- a/libs/isograph-react/src/react/useReadAndSubscribe.ts
+++ b/libs/isograph-react/src/react/useReadAndSubscribe.ts
@@ -51,7 +51,7 @@ export function useSubscribeToMultiple<
     fragmentReference: FragmentReference<TReadFromStore, any>;
     readerAst: ReaderAst<TReadFromStore>;
   }>,
-) {
+): void {
   const environment = useIsographEnvironment();
   useEffect(
     () => {

--- a/libs/isograph-react/src/react/useRerenderOnChange.ts
+++ b/libs/isograph-react/src/react/useRerenderOnChange.ts
@@ -16,7 +16,7 @@ export function useRerenderOnChange<
     data: WithEncounteredRecords<TReadFromStore>,
   ) => void,
   readerAst: ReaderAst<TReadFromStore>,
-) {
+): void {
   const environment = useIsographEnvironment();
   useEffect(() => {
     return subscribe(

--- a/libs/isograph-react/tsconfig.test.json
+++ b/libs/isograph-react/tsconfig.test.json
@@ -6,7 +6,8 @@
     "paths": {
       "@iso": ["./src/tests/__isograph/iso.ts"],
       "@isograph/react": ["./src/index.ts"]
-    }
+    },
+    "isolatedDeclarations": false
   },
   "include": ["src/tests/**/*.ts", "src/tests/**/*.tsx"]
 }

--- a/libs/isograph-react/tsdown.config.mts
+++ b/libs/isograph-react/tsdown.config.mts
@@ -1,0 +1,9 @@
+import { mergeConfig, type UserConfig } from 'tsdown';
+import baseConfig from '../../tsdown.config.mts';
+
+const config: UserConfig = mergeConfig(baseConfig, {
+  dts: {
+    build: true,
+  },
+});
+export default config;

--- a/libs/isograph-react/tsdown.config.ts
+++ b/libs/isograph-react/tsdown.config.ts
@@ -1,8 +1,0 @@
-import { mergeConfig } from 'tsdown';
-import baseConfig from '../../tsdown.config.ts';
-
-export default mergeConfig(baseConfig, {
-  dts: {
-    build: true,
-  },
-});

--- a/libs/isograph-react/vitest.config.ts
+++ b/libs/isograph-react/vitest.config.ts
@@ -1,9 +1,9 @@
 import path from 'node:path';
 import babel from 'vite-plugin-babel';
 import commonjs from 'vite-plugin-commonjs';
-import { defineProject } from 'vitest/config';
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
 
-export default defineProject({
+const project: UserWorkspaceConfig = defineProject({
   plugins: [
     babel({
       filter: /\.[jt]sx?$/,
@@ -32,3 +32,5 @@ export default defineProject({
     },
   },
 });
+
+export default project;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -18,10 +18,8 @@
     "noUnusedParameters": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
-    "paths": {
-      "@isograph/*": ["./libs/*"]
-    },
     "noEmit": true,
-    "allowUnreachableCode": false
+    "allowUnreachableCode": false,
+    "isolatedDeclarations": true
   }
 }

--- a/tsdown.config.mts
+++ b/tsdown.config.mts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig, type UserConfig } from 'tsdown';
 
-export default defineConfig({
+const config: UserConfig = defineConfig({
   entry: ['src/index.ts'],
   dts: {
     sourcemap: true,
@@ -10,3 +10,4 @@ export default defineConfig({
   unbundle: true,
   format: ['commonjs', 'esm'],
 });
+export default config;

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,7 @@
       "outputs": ["dist/**", "package.json"],
       "inputs": [
         "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/tsdown.config.ts",
+        "$TURBO_ROOT$/tsdown.config.mts",
         "$TURBO_ROOT$/tsconfig.json",
         "$TURBO_ROOT$/tsconfig.build.json"
       ]


### PR DESCRIPTION
Enabling `isolatedDeclarations` means we can emit .d.ts files without running typescript compiler. We will be able to build all libs in parallel then typecheck all libs in parallel. Right now we are doing typecheck in topological order