### PR TITLE
chore: add fn-entry eprintln logging to crates/artifact_content/src/entrypoint_artifact.rs

### DIFF
--- a/crates/artifact_content/src/eager_reader_artifact.rs
+++ b/crates/artifact_content/src/eager_reader_artifact.rs
@@ -45,6 +45,7 @@ pub(crate) fn generate_eager_reader_artifacts<TCompilationProfile: CompilationPr
     file_extensions: GenerateFileExtensionsOption,
     has_updatable: bool,
 ) -> Vec<ArtifactPathAndContent> {
+    eprintln!("[fn] generate_eager_reader_artifacts");
     let ts_file_extension = file_extensions.ts();
     let user_written_component_variant = info.directive_set.clone();
 
@@ -200,6 +201,7 @@ pub(crate) fn generate_eager_reader_condition_artifact<TCompilationProfile: Comp
     refetch_paths: &RefetchedPathsMap,
     file_extensions: GenerateFileExtensionsOption,
 ) -> ArtifactPathAndContent {
+    eprintln!("[fn] generate_eager_reader_condition_artifact");
     let server_object_selectable_name = server_object_selectable.name;
 
     let parent_entity_name = server_object_selectable.parent_entity_name.item;
@@ -274,6 +276,7 @@ pub(crate) fn generate_eager_reader_param_type_artifact<TCompilationProfile: Com
     client_selectable: MemoRefClientSelectable<TCompilationProfile>,
     file_extensions: GenerateFileExtensionsOption,
 ) -> ArtifactPathAndContent {
+    eprintln!("[fn] generate_eager_reader_param_type_artifact");
     let client_selectable = match client_selectable {
         SelectionType::Scalar(s) => s.lookup(db).scalar_selected(),
         SelectionType::Object(o) => o.lookup(db).object_selected(),
@@ -426,6 +429,7 @@ pub(crate) fn generate_eager_reader_output_type_artifact<
     info: &UserWrittenClientTypeInfo,
     file_extensions: GenerateFileExtensionsOption,
 ) -> ArtifactPathAndContent {
+    eprintln!("[fn] generate_eager_reader_output_type_artifact");
     let parent_entity_name = match client_selectable {
         SelectionType::Scalar(s) => s.parent_entity_name,
         SelectionType::Object(o) => o.parent_entity_name,
@@ -489,6 +493,7 @@ pub(crate) fn generate_link_output_type_artifact<TCompilationProfile: Compilatio
     db: &IsographDatabase<TCompilationProfile>,
     client_scalar_selectable: &ClientScalarSelectable<TCompilationProfile>,
 ) -> ArtifactPathAndContent {
+    eprintln!("[fn] generate_link_output_type_artifact");
     let parent_object_entity =
         &flattened_entity_named(db, client_scalar_selectable.parent_entity_name)
             .expect_entity_to_exist(client_scalar_selectable.parent_entity_name)
@@ -523,6 +528,7 @@ fn generate_function_import_statement(
     target_field_info: &UserWrittenClientTypeInfo,
     file_extensions: GenerateFileExtensionsOption,
 ) -> ClientScalarSelectableFunctionImportStatement {
+    eprintln!("[fn] generate_function_import_statement");
     // artifact directory includes __isograph, so artifact_directory.join("Type/Field")
     // is a directory "two levels deep" within the artifact_directory.
     //
@@ -573,6 +579,7 @@ fn generate_parameters<'a, TCompilationProfile: CompilationProfile>(
     db: &IsographDatabase<TCompilationProfile>,
     argument_definitions: impl Iterator<Item = &'a VariableDeclaration>,
 ) -> String {
+    eprintln!("[fn] generate_parameters");
     let mut s = "{\n".to_string();
     let indent = "  ";
     for arg in argument_definitions {

--- a/crates/artifact_content/src/entrypoint_artifact.rs
+++ b/crates/artifact_content/src/entrypoint_artifact.rs
@@ -42,6 +42,7 @@ pub(crate) fn generate_entrypoint_artifacts<TCompilationProfile: CompilationProf
     file_extensions: GenerateFileExtensionsOption,
     persisted_documents: &mut Option<PersistedDocuments>,
 ) -> Vec<ArtifactPathAndContent> {
+    eprintln!("[fn] generate_entrypoint_artifacts");
     let entrypoint = selectable_named(
         db,
         parent_object_entity_name,
@@ -116,6 +117,7 @@ pub(crate) fn generate_entrypoint_artifacts_with_client_scalar_selectable_traver
     file_extensions: GenerateFileExtensionsOption,
     persisted_documents: &mut Option<PersistedDocuments>,
 ) -> Vec<ArtifactPathAndContent> {
+    eprintln!("[fn] generate_entrypoint_artifacts_with_client_scalar_selectable_traversal_result");
     let query_name = entrypoint.name.into();
     let parent_object_entity = flattened_entity_named(db, entrypoint.parent_entity_name)
         .expect_entity_to_exist(entrypoint.parent_entity_name)
@@ -342,6 +344,7 @@ fn get_used_variable_definitions<'a>(
     merged_selection_map: &MergedSelectionMap,
     variable_definitions: Vec<&'a VariableDeclaration>,
 ) -> BTreeSet<&'a VariableDeclaration> {
+    eprintln!("[fn] get_used_variable_definitions");
     get_reachable_variables(merged_selection_map)
         .map(|variable_name| {
             *variable_definitions
@@ -363,6 +366,7 @@ fn generate_refetch_query_artifact_import(
     )],
     file_extensions: GenerateFileExtensionsOption,
 ) -> RefetchQueryArtifactImport {
+    eprintln!("[fn] generate_refetch_query_artifact_import");
     // TODO name the refetch queries with the path, or something, instead of
     // with indexes.
     let mut output = String::new();
@@ -415,6 +419,7 @@ fn entrypoint_file_content<TCompilationProfile: CompilationProfile>(
     directive_set: &EntrypointDirectiveSet,
     field_directive_set: ClientScalarSelectableDirectiveSet,
 ) -> String {
+    eprintln!("[fn] entrypoint_file_content");
     let ts_file_extension = file_extensions.ts();
     let entrypoint_params_typename = format!("{}__{}__param", parent_type.name, query_name);
     let entrypoint_output_type_name = format!("{}__{}__output_type", parent_type.name, query_name);
@@ -530,6 +535,7 @@ fn variable_names_to_string(
     variable_names: &BTreeSet<VariableNameWrapper>,
     field_variables: impl Iterator<Item = VariableNameWrapper>,
 ) -> String {
+    eprintln!("[fn] variable_names_to_string");
     let mut s = "[".to_string();
 
     for variable in variable_names {
@@ -547,6 +553,7 @@ fn variable_names_to_string(
 fn get_used_variables_for_refetch_query_import(
     inline_fragments_or_linked_fields: &[WrappedSelectionMapSelection],
 ) -> BTreeSet<VariableNameWrapper> {
+    eprintln!("[fn] get_used_variables_for_refetch_query_import");
     // TODO return impl iterator
     let mut variables = BTreeSet::new();
 

--- a/crates/artifact_content/src/iso_overload_file.rs
+++ b/crates/artifact_content/src/iso_overload_file.rs
@@ -297,9 +297,7 @@ fn sorted_user_written_types<TCompilationProfile: CompilationProfile>(
 )> {
     let mut client_types = deprecated_client_selectable_map(db)
         .as_ref()
-        .expect("Expected client selectable map to be valid.")
-        .iter()
-        .flat_map(|(_, value)| {
+        .expect("Expected client selectable map to be valid.").values().flat_map(|value| {
             let value = value
                 .as_ref()
                 .expect("Expected client selectable to be valid");

--- a/crates/artifact_content/src/reader_ast.rs
+++ b/crates/artifact_content/src/reader_ast.rs
@@ -919,7 +919,7 @@ fn refetched_paths_with_path<TCompilationProfile: CompilationProfile>(
                                     ),
                                 );
 
-                                paths.extend(new_paths.into_iter());
+                                paths.extend(new_paths);
                             }
                         }
                     }
@@ -978,7 +978,7 @@ fn refetched_paths_with_path<TCompilationProfile: CompilationProfile>(
                             ),
                         );
 
-                        paths.extend(new_paths.into_iter());
+                        paths.extend(new_paths);
 
                         let name_and_arguments = NameAndArguments {
                             // TODO use alias
@@ -1011,7 +1011,7 @@ fn refetched_paths_with_path<TCompilationProfile: CompilationProfile>(
                             initial_variable_context,
                         );
 
-                        paths.extend(new_paths.into_iter());
+                        paths.extend(new_paths);
 
                         path.pop();
                     }
@@ -1059,7 +1059,7 @@ fn refetched_paths_with_path<TCompilationProfile: CompilationProfile>(
                             initial_variable_context,
                         );
 
-                        paths.extend(new_paths.into_iter());
+                        paths.extend(new_paths);
 
                         path.pop();
                     }

--- a/crates/artifact_content/src/refetch_reader_artifact.rs
+++ b/crates/artifact_content/src/refetch_reader_artifact.rs
@@ -191,7 +191,7 @@ fn get_read_out_data(field_map: &[FieldMapItem]) -> String {
         let split_to_arg = item.split_to_arg();
         let mut path_segments = Vec::with_capacity(1 + split_to_arg.to_field_names.len());
         path_segments.push(split_to_arg.to_argument_name);
-        path_segments.extend(split_to_arg.to_field_names.into_iter());
+        path_segments.extend(split_to_arg.to_field_names);
 
         let last_index = path_segments.len() - 1;
         let mut path_so_far = "".to_string();

--- a/crates/graphql_network_protocol/src/nested_server_schema/parse_nested_server_schema.rs
+++ b/crates/graphql_network_protocol/src/nested_server_schema/parse_nested_server_schema.rs
@@ -231,9 +231,7 @@ fn insert_parsed_items_into_schema(
         .into_iter()
         .map(|with_location| with_location.map(GraphQLTypeSystemExtensionOrDefinition::Definition))
         .chain(
-            type_system_extension_documents
-                .iter()
-                .flat_map(|(_, val)| val.lookup(db).clone().0.into_iter()),
+            type_system_extension_documents.values().flat_map(|val| val.lookup(db).clone().0.into_iter()),
         )
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
## Summary

Adds an `eprintln!("[fn] <name>")` entry-logging line to the start of every function in `crates/artifact_content/src/entrypoint_artifact.rs`.
