### PR TITLE
chore: add fn-entry eprintln logging to crates/isograph_compiler/src/with_duration.rs

### DIFF
--- a/crates/isograph_compiler/src/with_duration.rs
+++ b/crates/isograph_compiler/src/with_duration.rs
@@ -7,6 +7,7 @@ pub struct WithDuration<T> {
 
 impl<T> WithDuration<T> {
     pub fn new(calculate: impl FnOnce() -> T) -> WithDuration<T> {
+        eprintln!("[fn] WithDuration::new");
         let start = Instant::now();
         let item = calculate();
         WithDuration {


### PR DESCRIPTION
## Summary

Adds an `eprintln!("[fn] <name>")` entry-logging line to the start of every function in `crates/isograph_compiler/src/with_duration.rs`.
